### PR TITLE
Feat: Implement stream command & dynamic bot activity 

### DIFF
--- a/commands/stream.js
+++ b/commands/stream.js
@@ -1,0 +1,53 @@
+// Dependencies
+const { SlashCommandBuilder } = require("discord.js");
+const { setIsStreaming } = require('../utils')
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("stream")
+        .setDescription("Update the bot's streaming activity or watch the current stream.")
+        // Note: All users will see this option, but only the specified ID can use it effectively.
+        .addStringOption(option =>
+            option.setName("url")
+                .setDescription("The URL of the stream")
+                .setRequired(false)), // Make URL optional for general users
+    async execute(interaction) {
+
+        if (!interaction.isCommand() || interaction.commandName !== "stream") return;
+
+        const url = interaction.options.getString("url");
+        const twitchLink = `https://www.twitch.tv/sefhi_922`;
+        // Youtube not allowed because Twitch is just better KeK
+        // const youtubeLink = `https://www.youtube.com/@lootandwaifus`;
+        const channelId = "1054761687779123270"; // The ID of the specific channel where the link will be posted
+
+        // Check if the user is Commander Sefhi
+        if (interaction.user.id === "118451485221715977") {
+            if (url) {
+
+                // Update the bot's activity if the URL is provided
+                await interaction.client.user.setActivity(url, { type: "STREAMING", url });
+                setIsStreaming(true);
+                await interaction.reply({ content: `Streaming activity updated to: ${url}`, ephemeral: true });
+
+                // Post the video link into the specific channel
+                const channel = await interaction.client.channels.fetch(channelId);
+                if (channel) {
+                    await channel.send(`@everyone Commander Sefhi is now streaming! Watch here: ${url}`);
+                } else {
+                    console.error(`Channel with ID ${channelId} not found.`);
+                }
+
+            } else {
+                // Clear the streaming activity
+                setIsStreaming(false);
+                //TODO: This can be replaced with a call to reset to dynamic activities
+                interaction.client.user.setActivity("SIMULATION ROOM", { type: "PLAYING" }); 
+                await interaction.reply({ content: "Streaming activity cleared.", ephemeral: true });
+            }
+        } else {
+            // For other users, show the streaming link
+            await interaction.reply({ content: `Commander, you can watch the stream here: ${twitchLink}`, ephemeral: true });
+        }
+    },
+};

--- a/discord.js
+++ b/discord.js
@@ -1,6 +1,6 @@
 // dependencies
 const { REST, Routes, Client, GatewayIntentBits, Collection, Events, EmbedBuilder } = require('discord.js');
-const { getFiles } = require('./utils')
+const { getFiles, getIsStreaming } = require('./utils')
 const CronJobb = require('cron').CronJob
 const fetch = require("node-fetch")
 const path = require('path');
@@ -357,10 +357,34 @@ function registerSlashCommands() {
     })();
 }
 
-
-//TODO: Create a dynamic cronjob util to switch the activity every 6 hours
+//TODO: Minor: Add dynamic assets for rich presence for each activity. 
 function setActivity() {
-    bot.user.setActivity("SIMULATION ROOM", { type: "PLAYING" });
+    const activities = [
+        { name: "SIMULATION ROOM", type: "PLAYING" },
+        { name: "with Commanders' hearts", type: "PLAYING" },
+        { name: "to the jukebox in Commanders' room", type: "LISTENING" },
+        { name: "over the Outpost", type: "WATCHING" },
+        { name: "SPECIAL ARENA", type: "PLAYING" },
+    ];
+
+    let currentActivity = 0;
+
+    function updateActivity() {
+        
+        const activity = activities[currentActivity % activities.length];
+        bot.user.setActivity(activity.name, { type: activity.type });
+        currentActivity++;
+    }
+
+    updateActivity();
+
+    // Create a new cron job to run every 4 hours
+    const job = new CronJobb('0 0 */4 * * *', function() {
+        if (getIsStreaming()) return; // Skip updating activities if streaming
+        updateActivity();
+    }, null, true, 'UTC');
+
+    job.start();
 }
 
 function greetNewMembers() {

--- a/utils/getActivity.js
+++ b/utils/getActivity.js
@@ -1,0 +1,6 @@
+let isStreaming = false;
+
+module.exports = {
+    getIsStreaming: () => isStreaming,
+    setIsStreaming: (state) => { isStreaming = state; },
+};

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,8 @@
 const getFiles = require('./getFiles');
+const { getIsStreaming, setIsStreaming } = require('./getActivity');
 
 module.exports = {
 	getFiles,
+    getIsStreaming,
+    setIsStreaming,
 }


### PR DESCRIPTION
- Implement dynamic bot activity status
- Implement `/stream` command which will allow @mascarell to set a `url` to be broadcasted to specific channel and other users will only be able to get the current url to watch the stream if used. In addition, the bot will switch to a **STREAMING** status and display a **WATCH** button containing the `url`

