### PR TITLE
Feat: Add daily command

### DIFF
--- a/commands/daily.js
+++ b/commands/daily.js
@@ -4,10 +4,22 @@ const moment = require("moment-timezone");
 
 const gamesData = [
     {
+        game: "AFK Journey",
+        server: "Global",
+        timezone: "Europe/Madrid",
+        dailyReset: "02:00",
+    },
+    {
         game: "GODDESS OF VICTORY: NIKKE",
         server: "Global",
         timezone: "Etc/GMT-9",
         dailyReset: "05:00",
+    },
+    {
+        game: "SOLO LEVELING",
+        server: "Global",
+        timezone: "Europe/Madrid",
+        dailyReset: "02:00",
     },
     // TODO: Add more games as needed. REF: https://raw.githubusercontent.com/cicerakes/Game-Time-Master/master/game-data.js
 ];

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -1,0 +1,74 @@
+// Dependencies
+const { SlashCommandBuilder } = require("discord.js");
+const moment = require("moment-timezone");
+
+// Game data array
+const gamesData = [
+    {
+        game: "GODDESS OF VICTORY: NIKKE",
+        server: "Global",
+        timezone: "Etc/GMT-9",
+        dailyReset: "05:00",
+        icon: "goddess-of-victory-nikke",
+    },
+    // Add more games as needed
+];
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("daily")
+        .setDescription("Get upcoming reset timer for a game")
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName("time")
+                .setDescription(
+                    "Checks the time until the next daily reset for the specified game."
+                )
+                .addStringOption((option) =>
+                    option
+                        .setName("game")
+                        .setDescription("The name of the game")
+                        .setRequired(false)
+                )
+        ),
+    async execute(interaction) {
+        let gameName = interaction.options.getString("game") || "Nikke";
+        let gameData;
+
+        // Special case for Nikke
+        if (gameName.toLowerCase() === "nikke") {
+            gameData = gamesData.find(
+                (game) =>
+                    game.game.toUpperCase() === "GODDESS OF VICTORY: NIKKE"
+            );
+        } else {
+            // Partial matching for other games
+            gameData = gamesData.find((game) =>
+                game.game.toUpperCase().includes(gameName.toUpperCase())
+            );
+        }
+
+        if (!gameData) {
+            await interaction.reply({
+                content: `Game not found. Please provide a valid game name.`,
+                ephemeral: true,
+            });
+            return;
+        }
+
+        const now = moment().tz(gameData.timezone);
+        let resetTime = moment.tz(
+            `${moment().format("YYYY-MM-DD")} ${gameData.dailyReset}`,
+            gameData.timezone
+        );
+        if (now > resetTime) resetTime.add(1, "days"); // Use next day's reset time if today's has passed
+
+        // Convert reset time to Unix timestamp and format it for Discord
+        const resetTimestamp = `<t:${resetTime.unix()}:R>`;
+
+        await interaction.reply({
+            content: `The next reset for **${gameData.game}** (${gameData.server} Server) is ${resetTimestamp}.`,
+            ephemeral: true,
+        });
+    },
+};

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -2,7 +2,6 @@
 const { SlashCommandBuilder } = require("discord.js");
 const moment = require("moment-timezone");
 
-// Game data array
 const gamesData = [
     {
         game: "GODDESS OF VICTORY: NIKKE",
@@ -11,7 +10,7 @@ const gamesData = [
         dailyReset: "05:00",
         icon: "goddess-of-victory-nikke",
     },
-    // Add more games as needed
+    // TODO: Add more games as needed. REF: https://raw.githubusercontent.com/cicerakes/Game-Time-Master/master/game-data.js
 ];
 
 module.exports = {
@@ -22,7 +21,7 @@ module.exports = {
             subcommand
                 .setName("time")
                 .setDescription(
-                    "Checks the time until the next daily reset for the specified game."
+                    "Checks the time until the next daily reset (global server) for the specified game."
                 )
                 .addStringOption((option) =>
                     option
@@ -32,10 +31,9 @@ module.exports = {
                 )
         ),
     async execute(interaction) {
-        let gameName = interaction.options.getString("game") || "Nikke";
+        let gameName = interaction.options.getString("game") || "nikke";
         let gameData;
 
-        // Special case for Nikke
         if (gameName.toLowerCase() === "nikke") {
             gameData = gamesData.find(
                 (game) =>

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -4,11 +4,29 @@ const moment = require("moment-timezone");
 
 const gamesData = [
     {
-        game: "AFK JOURNEY",
+        game: "AFK Journey",
         server: "Global",
         timezone: "Europe/Madrid",
         dailyReset: "02:00",
     },
+    {
+		game: "Arknights",
+		server: "EN",
+		timezone: "Etc/GMT+7",
+		dailyReset: "04:00",
+	},
+    {
+		game: "Azur Lane",
+		server: "EN",
+		timezone: "Etc/GMT+7",
+		dailyReset: "00:00",
+	},
+    {
+		game: "Blue Archive",
+		server: "Global",
+		timezone: "Etc/UTC",
+		dailyReset: "19:00",
+	},
     {
         game: "GODDESS OF VICTORY: NIKKE",
         server: "Global",
@@ -16,7 +34,25 @@ const gamesData = [
         dailyReset: "05:00",
     },
     {
-        game: "SOLO LEVELING",
+		game: "Honkai: Star Rail",
+		server: "America",
+		timezone: "Etc/GMT+5",
+		dailyReset: "04:00",
+	},
+    {
+		game: "Honkai Impact 3rd",
+		server: "Americas",
+		timezone: "Etc/GMT+5",
+		dailyReset: "04:00",
+	},
+    {
+		game: "Reverse: 1999",
+		server: "Global",
+		timezone: "Etc/GMT+5",
+		dailyReset: "05:00",
+	},
+    {
+        game: "Solo Leveling",
         server: "Global",
         timezone: "Europe/Madrid",
         dailyReset: "02:00",

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -4,7 +4,7 @@ const moment = require("moment-timezone");
 
 const gamesData = [
     {
-        game: "AFK Journey",
+        game: "AFK JOURNEY",
         server: "Global",
         timezone: "Europe/Madrid",
         dailyReset: "02:00",

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -21,30 +21,23 @@ module.exports = {
             subcommand
                 .setName("time")
                 .setDescription(
-                    "Checks the time until the next daily reset (global server) for the specified game."
+                    "Checks the time until the next daily reset for the specified game."
                 )
                 .addStringOption((option) =>
                     option
                         .setName("game")
                         .setDescription("The name of the game")
                         .setRequired(false)
+                        .setAutocomplete(true)
                 )
         ),
     async execute(interaction) {
-        let gameName = interaction.options.getString("game") || "nikke";
-        let gameData;
-
-        if (gameName.toLowerCase() === "nikke") {
-            gameData = gamesData.find(
-                (game) =>
-                    game.game.toUpperCase() === "GODDESS OF VICTORY: NIKKE"
-            );
-        } else {
-            // Partial matching for other games
-            gameData = gamesData.find((game) =>
-                game.game.toUpperCase().includes(gameName.toUpperCase())
-            );
-        }
+        const gameName =
+            interaction.options.getString("game", false)?.toLowerCase() ||
+            "nikke";
+        const gameData = gamesData.find((game) =>
+            game.game.toLowerCase().includes(gameName)
+        );
 
         if (!gameData) {
             await interaction.reply({
@@ -54,19 +47,28 @@ module.exports = {
             return;
         }
 
-        const now = moment().tz(gameData.timezone);
+        const now = moment.tz(gameData.timezone);
         let resetTime = moment.tz(
             `${moment().format("YYYY-MM-DD")} ${gameData.dailyReset}`,
             gameData.timezone
         );
-        if (now > resetTime) resetTime.add(1, "days"); // Use next day's reset time if today's has passed
+        if (now > resetTime) {
+            resetTime.add(1, "days");
+        }
 
-        // Convert reset time to Unix timestamp and format it for Discord
         const resetTimestamp = `<t:${resetTime.unix()}:R>`;
 
         await interaction.reply({
             content: `The next reset for **${gameData.game}** (${gameData.server} Server) is ${resetTimestamp}.`,
             ephemeral: true,
         });
+    },
+    async autocomplete(interaction) {
+        const focusedValue = interaction.options.getFocused().toLowerCase();
+        const filtered = gamesData
+            .filter((game) => game.game.toLowerCase().includes(focusedValue))
+            .map((game) => ({ name: game.game, value: game.game }));
+
+        await interaction.respond(filtered.slice(0, 25)); // Limit to 25 results as per Discord's limit
     },
 };

--- a/commands/daily.js
+++ b/commands/daily.js
@@ -82,7 +82,7 @@ module.exports = {
         }
 
         await interaction.reply({
-            content: `The next reset for **${gameData.game}** (${gameData.server} Server) is ${resetTimestamp}.`,
+            content: `Commander, the next reset for **${gameData.game}** (${gameData.server} Server) is ${resetTimestamp}.`,
             ephemeral: true,
         });
     },

--- a/discord.js
+++ b/discord.js
@@ -735,6 +735,18 @@ function handleSlashCommands(){
     });
 }
 
+function enableAutoComplete(){
+    bot.on(Events.InteractionCreate, async interaction => {
+        if (!interaction.isAutocomplete()) return;
+    
+        // Assuming you have a way to access your commands
+        const command = bot.commands.get(interaction.commandName);
+        if (command && typeof command.autocomplete === 'function') {
+            await command.autocomplete(interaction);
+        }
+    });
+}
+
 
 
 function initDiscordBot() {
@@ -748,6 +760,7 @@ function initDiscordBot() {
         greetNewMembers();
         sendRandomMessages();
         sendDailyInterceptionMessage();
+        enableAutoComplete();
         handleMessages();
         handleAdvice();
         handleSlashCommands();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "discord.js": "^14.14.1",
         "dotenv": "^16.0.3",
         "express": "*",
+        "moment": "^2.30.1",
+        "moment-timezone": "^0.5.45",
         "node-fetch": "^2.6.9",
         "node-telegram-bot-api": "*",
         "pm2": "*"
@@ -2679,19 +2681,19 @@
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -6555,16 +6557,16 @@
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "discord.js": "^14.14.1",
     "dotenv": "^16.0.3",
     "express": "*",
+    "moment": "^2.30.1",
+    "moment-timezone": "^0.5.45",
     "node-fetch": "^2.6.9",
     "node-telegram-bot-api": "*",
     "pm2": "*"


### PR DESCRIPTION
- Add `/daily time` command with the optional param for game with autocomplete enabled. The default will always be NIKKE Global server time if no game is provided. If it's within 4 hours of the game's reset time it will use a short time format otherwise it will use a long date/time format. 
- Add `moment` & `moment-timezone` packages