### PR TITLE
Feat: Add Swimsuit Rapi Gif

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1113,12 +1113,40 @@ function sendRandomMessages() {
 
             try {
                 const message = getRandomRapiMessage();
-                const sentMessage = await channel.send(message);
-                const emoji = channel.guild.emojis.cache.find(emoji => emoji.name === 'rapidd');
-                if (emoji) {
-                    await sentMessage.react(emoji);
+                const swimsuitMessage = `Commander! Anis said that this swimsuit is better than my normal outfit for fighting Raptures, what do you think?`;
+                
+                // Check if the swimsuit message was chosen
+                if (message === swimsuitMessage) {
+                    // Get a random image for the swimsuit message
+                    const randomCdnMediaUrl = await getRandomCdnMediaUrl(
+                        "commands/swimsuit/",
+                        guild.id,
+                        {
+                            extensions: [...DEFAULT_IMAGE_EXTENSIONS],
+                            trackLast: 5
+                        }
+                    );
+                    
+                    const sentMessage = await channel.send({
+                        content: message,
+                        files: [randomCdnMediaUrl]
+                    });
+                    
+                    const emoji = channel.guild.emojis.cache.find(emoji => emoji.name === 'rapidd');
+                    if (emoji) {
+                        await sentMessage.react(emoji);
+                    } else {
+                        console.warn(`Emoji 'rapidd' not found in guild ${guild.name}`);
+                    }
                 } else {
-                    console.warn(`Emoji 'rapidd' not found in guild ${guild.name}`);
+                    // Send normal message without image
+                    const sentMessage = await channel.send(message);
+                    const emoji = channel.guild.emojis.cache.find(emoji => emoji.name === 'rapidd');
+                    if (emoji) {
+                        await sentMessage.react(emoji);
+                    } else {
+                        console.warn(`Emoji 'rapidd' not found in guild ${guild.name}`);
+                    }
                 }
             } catch (error) {
                 logError(guild.id, guild.name, error instanceof Error ? error : new Error(String(error)), 'Sending random message');

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1112,41 +1112,28 @@ function sendRandomMessages() {
             }
 
             try {
-                const message = getRandomRapiMessage();
-                const swimsuitMessage = `Commander! Anis said that this swimsuit is better than my normal outfit for fighting Raptures, what do you think?`;
+                const rapiMessage = getRandomRapiMessage();
+                const messageOptions: any = { content: rapiMessage.text };
                 
-                // Check if the swimsuit message was chosen
-                if (message === swimsuitMessage) {
-                    // Get a random image for the swimsuit message
+                // Add image if configured for this message
+                if (rapiMessage.imageConfig) {
                     const randomCdnMediaUrl = await getRandomCdnMediaUrl(
-                        "commands/swimsuit/",
+                        rapiMessage.imageConfig.cdnPath,
                         guild.id,
                         {
-                            extensions: [...DEFAULT_IMAGE_EXTENSIONS],
-                            trackLast: 5
+                            extensions: rapiMessage.imageConfig.extensions || [...DEFAULT_IMAGE_EXTENSIONS],
+                            trackLast: rapiMessage.imageConfig.trackLast || 5
                         }
                     );
-                    
-                    const sentMessage = await channel.send({
-                        content: message,
-                        files: [randomCdnMediaUrl]
-                    });
-                    
-                    const emoji = channel.guild.emojis.cache.find(emoji => emoji.name === 'rapidd');
-                    if (emoji) {
-                        await sentMessage.react(emoji);
-                    } else {
-                        console.warn(`Emoji 'rapidd' not found in guild ${guild.name}`);
-                    }
+                    messageOptions.files = [randomCdnMediaUrl];
+                }
+                
+                const sentMessage = await channel.send(messageOptions);
+                const emoji = channel.guild.emojis.cache.find(emoji => emoji.name === 'rapidd');
+                if (emoji) {
+                    await sentMessage.react(emoji);
                 } else {
-                    // Send normal message without image
-                    const sentMessage = await channel.send(message);
-                    const emoji = channel.guild.emojis.cache.find(emoji => emoji.name === 'rapidd');
-                    if (emoji) {
-                        await sentMessage.react(emoji);
-                    } else {
-                        console.warn(`Emoji 'rapidd' not found in guild ${guild.name}`);
-                    }
+                    console.warn(`Emoji 'rapidd' not found in guild ${guild.name}`);
                 }
             } catch (error) {
                 logError(guild.id, guild.name, error instanceof Error ? error : new Error(String(error)), 'Sending random message');

--- a/src/utils/constants/messages.ts
+++ b/src/utils/constants/messages.ts
@@ -1,37 +1,63 @@
-export const rapiMessages = [
-    `You're too quiet, Commander, is everything alright?`,
-    `Commander, Anis was just joking with the Christmas present…`,
-    `Commander! When is the next mission?`,
-    `Please take care next time you go to the surface Commander.`,
-    `Don't push yourself too hard Commander!`,
-    `No matter what you think of us, we'll always be by your side.`,
-    `Commander, I'll protect you.`,
-    `Lap of discipline`,
-    `Is it time to break Syuen ribs again, Commander?`,
-    `I found a wet sock with a weird smell under your bed Commander, care to explain?`,
-    `Marian please stop wearing your underwear inside out...`,
-    `Commander, why do you bark every time you see Makima?`,
-    `Scarlet or Modernia? What kind of question is that Commander? The answer is obvious...`,
-    `I can't go out with you today Commander, there's a lot of paperwork to do.`,
-    `Commander... did you really marry Sakura?`,
-    `Those cookies were the snacks of Biscuit. Did you really ate them Commander?`,
-    `Commander, why do you have a picture of Andersen on your wallet?`,
-    `Commander, did you spend the night at Coin Rush again?`,
-    `Commander, people are saying you kissed Blanc and Noir... is that true?`,
-    `Neon said she saw you leaving room 805 at the hotel, what was that about Commander, did you have a meeting?`,
-    `I guess Rosanna was right about idiots living longer.`,
-    `Commander! Anis said that this swimsuit is better than my normal outfit for fighting Raptures, what do you think?`,
-    `Waterpower? I don't know what that is Commander, but it sounds kinda weak.`,
-    `Commander! Is it Volt or Bolt?`,
-    `Commander, Admi was asking about Ruru, do you know where she is?`,
-    `The Golden Ship? Commander you are already old enough to believe in that stuff, please get back to work.`,
-    `Mast? Who's that? Doesn't ring a bell.`,
-    `Commander, did you really tackle Crow? How did you do it?`,
-    `Age is just a number? Commander, I'm calling ACPU`,
-    `What do you mean my voice sounds similar to someone else? Who are you thinking about Commander? sigh...`,
-    `Commander, what did you want to ask about Biscuit?`,
-    `Commander, 61% is more than enough, stop complaining.`,
-    `Commander, Ade said that I need to try a maid outfit, what do you think?`,
+// Define message types for better organization
+export interface RapiMessage {
+    text: string;
+    imageConfig?: {
+        cdnPath: string;
+        trackLast?: number;
+        extensions?: string[];
+    };
+}
+
+// Helper function to create messages with image configs
+export function createRapiMessage(text: string, imageConfig?: RapiMessage['imageConfig']): RapiMessage {
+    return { text, imageConfig };
+}
+
+// Helper function to create image configs
+export function createImageConfig(cdnPath: string, trackLast: number = 5, extensions: string[] = ['.gif', '.png', '.jpg', '.webp']) {
+    return { cdnPath, trackLast, extensions };
+}
+
+export const rapiMessages: RapiMessage[] = [
+    createRapiMessage(`You're too quiet, Commander, is everything alright?`),
+    createRapiMessage(`Commander, Anis was just joking with the Christmas present…`),
+    createRapiMessage(`Commander! When is the next mission?`),
+    createRapiMessage(`Please take care next time you go to the surface Commander.`),
+    createRapiMessage(`Don't push yourself too hard Commander!`),
+    createRapiMessage(`No matter what you think of us, we'll always be by your side.`),
+    createRapiMessage(`Commander, I'll protect you.`),
+    createRapiMessage(`Lap of discipline`),
+    createRapiMessage(`Is it time to break Syuen ribs again, Commander?`),
+    createRapiMessage(`I found a wet sock with a weird smell under your bed Commander, care to explain?`),
+    createRapiMessage(`Marian please stop wearing your underwear inside out...`),
+    createRapiMessage(`Commander, why do you bark every time you see Makima?`),
+    createRapiMessage(`Scarlet or Modernia? What kind of question is that Commander? The answer is obvious...`),
+    createRapiMessage(`I can't go out with you today Commander, there's a lot of paperwork to do.`),
+    createRapiMessage(`Commander... did you really marry Sakura?`),
+    createRapiMessage(`Those cookies were the snacks of Biscuit. Did you really ate them Commander?`),
+    createRapiMessage(`Commander, why do you have a picture of Andersen on your wallet?`),
+    createRapiMessage(`Commander, did you spend the night at Coin Rush again?`),
+    createRapiMessage(`Commander, people are saying you kissed Blanc and Noir... is that true?`),
+    createRapiMessage(`Neon said she saw you leaving room 805 at the hotel, what was that about Commander, did you have a meeting?`),
+    createRapiMessage(`I guess Rosanna was right about idiots living longer.`),
+    createRapiMessage(
+        `Commander! Anis said that this swimsuit is better than my normal outfit for fighting Raptures, what do you think?`,
+        createImageConfig("commands/swimsuit/", 5)
+    ),
+    createRapiMessage(`Waterpower? I don't know what that is Commander, but it sounds kinda weak.`),
+    createRapiMessage(`Commander! Is it Volt or Bolt?`),
+    createRapiMessage(`Commander, Admi was asking about Ruru, do you know where she is?`),
+    createRapiMessage(`The Golden Ship? Commander you are already old enough to believe in that stuff, please get back to work.`),
+    createRapiMessage(`Mast? Who's that? Doesn't ring a bell.`),
+    createRapiMessage(`Commander, did you really tackle Crow? How did you do it?`),
+    createRapiMessage(`Age is just a number? Commander, I'm calling ACPU`),
+    createRapiMessage(`What do you mean my voice sounds similar to someone else? Who are you thinking about Commander? sigh...`),
+    createRapiMessage(`Commander, what did you want to ask about Biscuit?`),
+    createRapiMessage(`Commander, 61% is more than enough, stop complaining.`),
+    createRapiMessage(
+        `Commander, Ade said that I need to try a maid outfit, what do you think?`,
+        createImageConfig("commands/maidOutfit/", 3)
+    ),
 ];
 
 export const readNikkeMessages = [

--- a/src/utils/constants/messages.ts
+++ b/src/utils/constants/messages.ts
@@ -55,8 +55,12 @@ export const rapiMessages: RapiMessage[] = [
     createRapiMessage(`Commander, what did you want to ask about Biscuit?`),
     createRapiMessage(`Commander, 61% is more than enough, stop complaining.`),
     createRapiMessage(
-        `Commander, Ade said that I need to try a maid outfit, what do you think?`,
-        createImageConfig("commands/maidOutfit/", 3)
+        `Commander, it's so hot today... maybe I should wear something more... comfortable? *winks* What do you think, Commander?`,
+        createImageConfig("commands/swimsuit/", 5)
+    ),
+    createRapiMessage(
+        `Commander, Neon keeps saying this swimsuit makes me look... distracting. What do you think? *smirks*`,
+        createImageConfig("commands/swimsuit/", 5)
     ),
 ];
 


### PR DESCRIPTION
This pull request refactors the handling of Rapi messages to support richer content, such as images, and introduces a more structured approach to defining and managing these messages. The changes include updates to the message-sending function and a redesign of the `rapiMessages` structure to allow for optional image configurations.

### Enhancements to message-sending functionality:
* Updated the `sendRandomMessages` function in `src/discord.ts` to support sending messages with optional image attachments. This includes constructing `messageOptions` with content and files based on the message's image configuration.

### Structural improvements to message definitions:
* Replaced the flat array of strings in `rapiMessages` with an array of `RapiMessage` objects in `src/utils/constants/messages.ts`. Each object now supports optional `imageConfig` properties for specifying CDN paths, file extensions, and tracking parameters.
* Added helper functions `createRapiMessage` and `createImageConfig` to simplify the creation of messages and their associated image configurations. These functions improve readability and maintainability of the message definitions.