### PR TITLE
feat: add scarrow mention detection with automatic image responses

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1486,6 +1486,9 @@ function handleMessages() {
         // Check for sensitive terms in the message
         await checkSensitiveTerms(message);
 
+        // Check for scarrow mentions
+        await checkScarrowMention(message);
+
         // Ignore rapi-bot channel for rate limiting
         const isRapiBotChannel = message.channel.type === ChannelType.GuildText && (message.channel as TextChannel).name === 'rapi-bot';
 
@@ -1746,6 +1749,49 @@ async function handleError(message: Message, error: unknown): Promise<void> {
             guildName,
             error instanceof Error ? error : new Error(String(error)),
             'checkSensitiveTerms'
+        );
+    }
+}
+
+/**
+ * Checks if a message mentions scarrow or the specific user ID and responds with an image
+ * @param message - Discord message to check
+ * @returns Promise<void>
+ */
+async function checkScarrowMention(message: Message): Promise<void> {
+    try {
+        // Early exit conditions
+        if (!message.guild?.id || !message.member || message.author.bot) {
+            return;
+        }
+
+        const SCARROW_USER_ID = '526213488096313354';
+        const messageContent = message.content.toLowerCase();
+        
+        // Check if message mentions scarrow by name or by user ID
+        const mentionsScarrowByName = messageContent.includes('scarrow');
+        const mentionsScarrowById = message.mentions.users.has(SCARROW_USER_ID);
+        
+        if (mentionsScarrowByName || mentionsScarrowById) {
+            const randomCdnMediaUrl = await getRandomCdnMediaUrl(
+                "commands/scarrow/",
+                message.guild.id,
+                {
+                    extensions: [...DEFAULT_IMAGE_EXTENSIONS],
+                }
+            );
+            
+            await message.reply({
+                files: [randomCdnMediaUrl]
+            });
+        }
+    } catch (error) {
+        // Log error but don't throw to avoid breaking message processing
+        logError(
+            message.guild?.id || 'UNKNOWN',
+            message.guild?.name || 'UNKNOWN',
+            error instanceof Error ? error : new Error(String(error)),
+            'checkScarrowMention'
         );
     }
 }

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1784,10 +1784,19 @@ async function checkScarrowMention(message: Message): Promise<void> {
             // Try to find the salute emoji in the guild, leave blank if not found
             const saluteEmoji = message.guild.emojis.cache.find(emoji => emoji.name === 'salute') || '';
             
-            await message.reply({
+            const replyMessage = await message.reply({
                 content: `Thank You Commander <@${SCARROW_USER_ID}> ${saluteEmoji}`,
                 files: [randomCdnMediaUrl]
             });
+            
+            // React with salute emoji if available
+            if (saluteEmoji) {
+                try {
+                    await replyMessage.react(saluteEmoji);
+                } catch (error) {
+                    console.warn(`Failed to react with salute emoji: ${error}`);
+                }
+            }
         }
     } catch (error) {
         // Log error but don't throw to avoid breaking message processing

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1781,7 +1781,11 @@ async function checkScarrowMention(message: Message): Promise<void> {
                 }
             );
             
+            // Try to find the salute emoji in the guild, leave blank if not found
+            const saluteEmoji = message.guild.emojis.cache.find(emoji => emoji.name === 'salute') || '';
+            
             await message.reply({
+                content: `Thank You Commander <@${SCARROW_USER_ID}> ${saluteEmoji}`,
                 files: [randomCdnMediaUrl]
             });
         }


### PR DESCRIPTION
## Summary
- Added automatic detection for "scarrow" mentions (both text and user ID @526213488096313354)
- Bot now responds with random images from `commands/scarrow/` CDN folder when triggered
- Integrated seamlessly into existing message handling system with proper error handling

## Implementation Details
- **Dual Detection**: Detects both case-insensitive "scarrow" text and direct user mentions
- **CDN Integration**: Uses existing `getRandomCdnMediaUrl()` function for consistent image delivery
- **Error Handling**: Includes comprehensive error logging without breaking message flow
- **Code Consistency**: Follows established patterns from existing chat commands

## Test plan
- [x] TypeScript compilation passes without errors
- [x] Function integrates properly with existing message handler
- [x] Error handling prevents message processing interruption
- [x] Follows established code patterns and conventions

🤖 Generated with [Claude Code](https://claude.ai/code)