### PR TITLE
feat: replace GFL2 with Trickal Chibi Go daily reset

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,61 @@ CLIENTID=your_discord_client_id
 
 For more detailed setup and configuration, refer to the official Discord documentation for bot setup and permissions.
 
+## Managing Daily Reset Messages
+
+The bot uses a modular daily reset service to send automated messages for multiple games. To add or remove games:
+
+### Adding a New Game
+
+1. **Edit `src/utils/data/gamesResetConfig.ts`**:
+   - Add a logo URL constant at the top (e.g., `const GAME_LOGO_URL = ...`)
+   - Create a new config object following the `DailyResetConfig` interface:
+     ```typescript
+     const newGameResetConfig: DailyResetConfig = {
+       game: 'Game Name',
+       channelName: 'discord-channel-name',
+       roleName: 'RoleName', // Optional - omit if no role ping needed
+       resetTime: { hour: 19, minute: 0 }, // UTC time
+       timezone: 'UTC',
+       embedConfig: {
+         title: 'ATTENTION PLAYERS!',
+         description: 'Your message here',
+         color: 0x00FF00, // Hex color code
+         footer: { text: 'Footer text', iconURL: RAPI_BOT_THUMBNAIL_URL },
+         thumbnail: GAME_LOGO_URL,
+         author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL }
+       },
+       checklist: [
+         { name: '**Task Name**', value: 'Task description' }
+       ],
+       mediaConfig: {
+         cdnPath: 'dailies/game-name/', // Path to images on CDN
+         extensions: [...DEFAULT_IMAGE_EXTENSIONS],
+         trackLast: 10
+       }
+     };
+     ```
+   - Add your config to the `dailyResetServiceConfig.games` array
+
+2. **Upload media assets**:
+   - Add images/GIFs to your CDN at the path specified in `mediaConfig.cdnPath`
+   - Add a game logo to `assets/logos/` on your CDN
+
+3. **Restart the bot** for changes to take effect
+
+### Removing a Game
+
+1. **Edit `src/utils/data/gamesResetConfig.ts`**:
+   - Remove the game's config object
+   - Remove its logo URL constant
+   - Remove it from the `dailyResetServiceConfig.games` array
+
+2. **Restart the bot** for changes to take effect
+
+### Dev Mode Testing
+
+When `NODE_ENV=development`, daily reset messages trigger every 5 minutes instead of at their scheduled times, making it easy to test changes without waiting.
+
 ---
 
 For more details, see the code or use `/help` in Discord.

--- a/src/utils/data/gamesResetConfig.ts
+++ b/src/utils/data/gamesResetConfig.ts
@@ -6,9 +6,9 @@ import { logError } from '../util';
 
 // Asset URLs (shared across configurations)
 const RAPI_BOT_THUMBNAIL_URL = `${cdnDomainUrl}/assets/rapi-bot-thumbnail.jpg`;
-const GFL2_LOGO_URL = `${cdnDomainUrl}/assets/logos/gfl2-logo.png`;
 const NIKKE_LOGO_URL = `${cdnDomainUrl}/assets/logos/nikke-logo.png`;
 const BLUE_ARCHIVE_LOGO_URL = `${cdnDomainUrl}/assets/logos/blue-archive-logo.png`;
+const TRICKAL_LOGO_URL = `${cdnDomainUrl}/assets/logos/trickal-logo.png`;
 
 // Default extensions
 const DEFAULT_IMAGE_EXTENSIONS = ['.gif', '.png', '.jpg', '.webp'] as const;
@@ -219,38 +219,30 @@ const blueArchiveResetConfig: DailyResetConfig = {
 };
 
 /**
- * Configuration for Girls' Frontline 2 daily reset message
+ * Configuration for Trickal Chibi Go daily reset message
  */
-const gfl2ResetConfig: DailyResetConfig = {
-    game: "Girls' Frontline 2: Exilium",
-    channelName: 'girls-frontline-2',
-    resetTime: { hour: 9, minute: 0 },
+const trickalResetConfig: DailyResetConfig = {
+    game: 'Trickal: Chibi Go',
+    channelName: 'trickal-chibi-go',
+    resetTime: { hour: 19, minute: 0 },
     timezone: 'UTC',
     embedConfig: {
-        title: 'ATTENTION DARKWINTER COMMANDERS!',
-        description: `Server has been reset! Here's some of Today's **Daily Quests** Checklist:\n`,
-        color: 0xE67E22,
+        title: 'ATTENTION ENLIGHTENED ONES!',
+        description: 'Server has been reset!\n\nDaily checklist will be updated soon once approved by our glorious leader **El Shafto**!',
+        color: 0x00FF00,
         footer: {
-            text: 'Commander, ready for the next mission?',
+            text: 'Stay tuned for updates!',
             iconURL: RAPI_BOT_THUMBNAIL_URL
         },
-        thumbnail: GFL2_LOGO_URL,
+        thumbnail: TRICKAL_LOGO_URL,
         author: {
             name: 'Rapi BOT',
             iconURL: RAPI_BOT_THUMBNAIL_URL
         }
     },
-    checklist: [
-        { name: '**Gunsmoke Frontline**', value: 'Do Your **Daily Patrol** and **Gunsmoke Hits**!' },
-        { name: '**Daily Free Gift Pack**', value: 'Check **Shop** and under **Standard Package Tab** For **Daily Free Gift Pack**' },
-        { name: '**Daily Sign-in**', value: 'Complete Daily Sign-in' },
-        { name: '**Dormitory**', value: 'Enter The Dormitory And **Check on Your WAIFU**' },
-        { name: '**Supply Mission**', value: 'Clear 1 Supply Mission' },
-        { name: '**Combat Simulation**', value: 'Clear 1 Combat Simulation (Don\'t Forgot about Combat Exercise!)' },
-        { name: '**Intelligence Puzzles**', value: 'Consume 120 Intelligence Puzzles (Sweep your desired supply mission if you have the stamina to do so)' }
-    ],
+    checklist: [],
     mediaConfig: {
-        cdnPath: 'dailies/girls-frontline-2/',
+        cdnPath: 'dailies/trickal/',
         extensions: [...DEFAULT_IMAGE_EXTENSIONS],
         trackLast: 10
     }
@@ -263,6 +255,6 @@ export const dailyResetServiceConfig: DailyResetServiceConfig = {
     games: [
         nikkeResetConfig,
         blueArchiveResetConfig,
-        gfl2ResetConfig
+        trickalResetConfig
     ]
 };


### PR DESCRIPTION
## Summary
- Removed Girls' Frontline 2 daily reset configuration completely
- Added Trickal: Chibi Go daily reset configuration with bright green styling
- Added comprehensive README documentation for managing daily reset messages

## Changes

### Game Configuration
- **Removed**: Girls' Frontline 2 (`girls-frontline-2` channel, 9:00 UTC reset)
- **Added**: Trickal: Chibi Go (`trickal-chibi-go` channel, 19:00 UTC reset)
  - Title: "ATTENTION ENLIGHTENED ONES!"
  - Bright green embed color (0x00FF00)
  - No role ping
  - Placeholder message: "Daily checklist will be updated soon once approved by our glorious leader **El Shafto**!"
  - Media path: `dailies/trickal/`

### Documentation
- Added "Managing Daily Reset Messages" section to README
- Included step-by-step instructions for adding/removing games
- Documented dev mode testing feature

## Test Plan
- [x] All 15 unit tests passing
- [x] TypeScript compilation successful
- [ ] Verify bot sends message to `trickal-chibi-go` channel at 19:00 UTC
- [ ] Verify correct embed styling (bright green, correct title)
- [ ] Verify no role ping is sent
- [ ] Verify random image loads from CDN path `dailies/trickal/`

## Technical Details
- Reset time: 19:00 UTC (1 hour before Nikke's reset)
- No checklist items (empty array)
- Uses standard image extensions: .gif, .png, .jpg, .webp
- Tracks last 10 images to avoid repetition

🤖 Generated with [Claude Code](https://claude.com/claude-code)