### PR TITLE
Add Chaos Zero Nightmare and Warning Messages

### DIFF
--- a/src/services/dailyResetService.ts
+++ b/src/services/dailyResetService.ts
@@ -261,15 +261,23 @@ export class DailyResetService {
 
         // Add random media image if configured
         if (config.mediaConfig) {
-            const randomMediaUrl = await getRandomCdnMediaUrl(
-                config.mediaConfig.cdnPath,
-                guild.id,
-                {
-                    extensions: config.mediaConfig.extensions,
-                    trackLast: config.mediaConfig.trackLast
+            try {
+                const randomMediaUrl = await getRandomCdnMediaUrl(
+                    config.mediaConfig.cdnPath,
+                    guild.id,
+                    {
+                        extensions: config.mediaConfig.extensions,
+                        trackLast: config.mediaConfig.trackLast
+                    }
+                );
+                // Only set image if we got a valid URL
+                if (randomMediaUrl && randomMediaUrl.startsWith('http')) {
+                    embed.setImage(randomMediaUrl);
                 }
-            );
-            embed.setImage(randomMediaUrl);
+            } catch (error) {
+                // Log but don't fail the entire message if media fetch fails
+                console.log(`Failed to fetch media for ${config.game} in guild ${guild.name}: ${error}`);
+            }
         }
 
         return embed;
@@ -314,15 +322,23 @@ export class DailyResetService {
 
         // Add random media image if configured
         if (config.mediaConfig) {
-            const randomMediaUrl = await getRandomCdnMediaUrl(
-                config.mediaConfig.cdnPath,
-                guild.id,
-                {
-                    extensions: config.mediaConfig.extensions,
-                    trackLast: config.mediaConfig.trackLast
+            try {
+                const randomMediaUrl = await getRandomCdnMediaUrl(
+                    config.mediaConfig.cdnPath,
+                    guild.id,
+                    {
+                        extensions: config.mediaConfig.extensions,
+                        trackLast: config.mediaConfig.trackLast
+                    }
+                );
+                // Only set image if we got a valid URL
+                if (randomMediaUrl && randomMediaUrl.startsWith('http')) {
+                    embed.setImage(randomMediaUrl);
                 }
-            );
-            embed.setImage(randomMediaUrl);
+            } catch (error) {
+                // Log but don't fail the entire message if media fetch fails
+                console.log(`Failed to fetch warning media for ${config.game} in guild ${guild.name}: ${error}`);
+            }
         }
 
         return embed;

--- a/src/services/dailyResetService.ts
+++ b/src/services/dailyResetService.ts
@@ -35,28 +35,81 @@ export class DailyResetService {
     }
 
     /**
-     * Schedule a daily reset message for a specific game
+     * Calculate the warning time based on reset time and minutes before
+     * Handles midnight wraparound (e.g., 00:30 reset - 60 min = 23:30 previous day)
      */
-    private scheduleResetMessage(config: DailyResetConfig): void {
-        let cronTime: string;
-        let scheduleDescription: string;
+    private calculateWarningTime(resetHour: number, resetMinute: number, minutesBefore: number): { warningHour: number; warningMinute: number } {
+        // Convert reset time to total minutes since midnight
+        let totalMinutes = (resetHour * 60) + resetMinute;
 
-        if (this.isDevelopment) {
-            // Dev mode: Run every N minutes
-            cronTime = `*/${this.devModeInterval} * * * *`;
-            scheduleDescription = `every ${this.devModeInterval} minutes (DEV MODE)`;
-        } else {
-            // Production mode: Run at configured daily time
-            cronTime = `${config.resetTime.minute} ${config.resetTime.hour} * * *`;
-            scheduleDescription = `${cronTime} (${config.timezone})`;
+        // Subtract the warning offset
+        totalMinutes -= minutesBefore;
+
+        // Handle negative wraparound (previous day)
+        if (totalMinutes < 0) {
+            totalMinutes += 1440; // 24 hours * 60 minutes
         }
 
-        const job = schedule.scheduleJob(cronTime, async () => {
-            await this.sendResetMessage(config);
-        });
+        // Convert back to hours and minutes
+        return {
+            warningHour: Math.floor(totalMinutes / 60),
+            warningMinute: totalMinutes % 60
+        };
+    }
 
-        this.scheduledJobs.set(config.game, job);
-        console.log(`Scheduled daily reset message for ${config.game} at ${scheduleDescription}`);
+    /**
+     * Schedule a daily reset message for a specific game
+     * Also schedules warning message if configured
+     */
+    private scheduleResetMessage(config: DailyResetConfig): void {
+        if (this.isDevelopment) {
+            // Dev mode: Schedule with fixed offset between warning and reset
+
+            // Schedule warning if enabled
+            if (config.warningConfig?.enabled) {
+                const warningCron = `*/${this.devModeInterval} * * * *`;
+                const warningJob = schedule.scheduleJob(warningCron, async () => {
+                    await this.sendWarningMessage(config);
+                });
+                this.scheduledJobs.set(`${config.game}-warning`, warningJob);
+                console.log(`[DEV] Scheduled warning for ${config.game} every ${this.devModeInterval} minutes`);
+            }
+
+            // Schedule reset with 2-minute offset from warning
+            const resetOffset = 2; // minutes after warning
+            const resetCron = `${resetOffset}-59/${this.devModeInterval} * * * *`;
+            const resetJob = schedule.scheduleJob(resetCron, async () => {
+                await this.sendResetMessage(config);
+            });
+            this.scheduledJobs.set(`${config.game}-reset`, resetJob);
+            console.log(`[DEV] Scheduled reset for ${config.game} at +${resetOffset} min offset (repeats every ${this.devModeInterval} min)`);
+
+        } else {
+            // Production mode: Schedule at exact times
+
+            // Schedule warning if enabled
+            if (config.warningConfig?.enabled) {
+                const { warningHour, warningMinute } = this.calculateWarningTime(
+                    config.resetTime.hour,
+                    config.resetTime.minute,
+                    config.warningConfig.minutesBefore
+                );
+                const warningCron = `${warningMinute} ${warningHour} * * *`;
+                const warningJob = schedule.scheduleJob(warningCron, async () => {
+                    await this.sendWarningMessage(config);
+                });
+                this.scheduledJobs.set(`${config.game}-warning`, warningJob);
+                console.log(`Scheduled warning for ${config.game} at ${String(warningHour).padStart(2, '0')}:${String(warningMinute).padStart(2, '0')} ${config.timezone} (${config.warningConfig.minutesBefore} min before reset)`);
+            }
+
+            // Schedule reset at configured time
+            const resetCron = `${config.resetTime.minute} ${config.resetTime.hour} * * *`;
+            const resetJob = schedule.scheduleJob(resetCron, async () => {
+                await this.sendResetMessage(config);
+            });
+            this.scheduledJobs.set(`${config.game}-reset`, resetJob);
+            console.log(`Scheduled reset for ${config.game} at ${String(config.resetTime.hour).padStart(2, '0')}:${String(config.resetTime.minute).padStart(2, '0')} ${config.timezone}`);
+        }
     }
 
     /**
@@ -74,6 +127,26 @@ export class DailyResetService {
                     guild.name,
                     error instanceof Error ? error : new Error(String(error)),
                     `Sending ${config.game} daily reset message`
+                );
+            }
+        }
+    }
+
+    /**
+     * Send a warning message to all guilds
+     */
+    private async sendWarningMessage(config: DailyResetConfig): Promise<void> {
+        const guilds = this.bot.guilds.cache.values();
+
+        for (const guild of guilds) {
+            try {
+                await this.sendWarningMessageToGuild(guild, config);
+            } catch (error) {
+                logError(
+                    guild.id,
+                    guild.name,
+                    error instanceof Error ? error : new Error(String(error)),
+                    `Sending ${config.game} warning message`
                 );
             }
         }
@@ -110,6 +183,29 @@ export class DailyResetService {
         const sentMessage = await channel.send({ embeds: [embed] });
 
         // Execute afterSend hook if provided
+        if (config.hooks?.afterSend) {
+            await config.hooks.afterSend(sentMessage, guild.id, this.bot);
+        }
+    }
+
+    /**
+     * Send a warning message to a specific guild
+     */
+    private async sendWarningMessageToGuild(guild: Guild, config: DailyResetConfig): Promise<void> {
+        const channel = findChannelByName(guild, config.channelName);
+
+        if (!channel) {
+            console.log(`Channel '${config.channelName}' not found in server: ${guild.name}.`);
+            return;
+        }
+
+        // Build the warning embed
+        const embed = await this.buildWarningEmbed(guild, config);
+
+        // Send the warning embed message (NO role ping as per requirements)
+        const sentMessage = await channel.send({ embeds: [embed] });
+
+        // Execute afterSend hook if provided (warnings can have hooks too)
         if (config.hooks?.afterSend) {
             await config.hooks.afterSend(sentMessage, guild.id, this.bot);
         }
@@ -162,6 +258,59 @@ export class DailyResetService {
                 });
             });
         }
+
+        // Add random media image if configured
+        if (config.mediaConfig) {
+            const randomMediaUrl = await getRandomCdnMediaUrl(
+                config.mediaConfig.cdnPath,
+                guild.id,
+                {
+                    extensions: config.mediaConfig.extensions,
+                    trackLast: config.mediaConfig.trackLast
+                }
+            );
+            embed.setImage(randomMediaUrl);
+        }
+
+        return embed;
+    }
+
+    /**
+     * Build an embed for a warning message
+     * Uses custom warning config if provided, otherwise uses default warning template
+     */
+    private async buildWarningEmbed(guild: Guild, config: DailyResetConfig): Promise<EmbedBuilder> {
+        // Use custom warning embed config if provided, otherwise create default warning message
+        const warningEmbedConfig = config.warningConfig?.embedConfig;
+        const minutesBefore = config.warningConfig?.minutesBefore || 60;
+
+        const embed = new EmbedBuilder()
+            .setTitle(warningEmbedConfig?.title || `⚠️ ${config.game} Reset Warning!`)
+            .setDescription(warningEmbedConfig?.description || `Server will reset in **${minutesBefore} minutes**!\n\nComplete your daily tasks before the reset!`)
+            .setColor(warningEmbedConfig?.color || 0xFFA500) // Orange color for warnings
+            .setTimestamp()
+            .setFooter({
+                text: warningEmbedConfig?.footer?.text || config.embedConfig.footer.text,
+                iconURL: warningEmbedConfig?.footer?.iconURL || config.embedConfig.footer.iconURL
+            });
+
+        // Add author if configured (use custom or fallback to main config)
+        const authorConfig = warningEmbedConfig?.author || config.embedConfig.author;
+        if (authorConfig) {
+            embed.setAuthor({
+                name: authorConfig.name,
+                iconURL: authorConfig.iconURL
+            });
+        }
+
+        // Add thumbnail if configured (use custom or fallback to main config)
+        const thumbnailUrl = warningEmbedConfig?.thumbnail || config.embedConfig.thumbnail;
+        if (thumbnailUrl) {
+            embed.setThumbnail(thumbnailUrl);
+        }
+
+        // Warning messages do NOT include checklist fields (as per requirements)
+        // They are meant to be brief notifications
 
         // Add random media image if configured
         if (config.mediaConfig) {

--- a/src/services/tests/dailyResetService.test.ts
+++ b/src/services/tests/dailyResetService.test.ts
@@ -5,6 +5,7 @@ import { Client, Guild, TextChannel, Collection } from 'discord.js';
 import * as schedule from 'node-schedule';
 import * as util from '../../utils/util';
 import * as mediaManager from '../../utils/cdn/mediaManager';
+import { dailyResetServiceConfig } from '../../utils/data/gamesResetConfig';
 
 // Mock the dependencies
 vi.mock('node-schedule', () => ({
@@ -132,7 +133,7 @@ describe('DailyResetService', () => {
 
             expect(jobs).toBeInstanceOf(Map);
             expect(jobs.size).toBe(1);
-            expect(jobs.has('Test Game')).toBe(true);
+            expect(jobs.has('Test Game-reset')).toBe(true);
         });
     });
 
@@ -299,7 +300,7 @@ describe('DailyResetService', () => {
 
             // Check that schedule description mentions dev mode
             expect(consoleSpy).toHaveBeenCalledWith(
-                expect.stringContaining('every 5 minutes (DEV MODE)')
+                expect.stringContaining('[DEV] Scheduled reset for Test Game')
             );
 
             process.env.NODE_ENV = originalEnv;
@@ -321,7 +322,7 @@ describe('DailyResetService', () => {
 
             // Check that normal daily schedule was used
             expect(consoleSpy).toHaveBeenCalledWith(
-                expect.stringContaining('0 12 * * * (UTC)')
+                expect.stringContaining('Scheduled reset for Test Game at 12:00 UTC')
             );
 
             process.env.NODE_ENV = originalEnv;
@@ -342,6 +343,385 @@ describe('DailyResetService', () => {
             );
 
             process.env.NODE_ENV = originalEnv;
+        });
+    });
+
+    describe('Chaos Zero Nightmare Configuration', () => {
+        it('should schedule Chaos Zero Nightmare with correct reset time (18:00 UTC)', () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'production';
+
+            const consoleSpy = vi.spyOn(console, 'log');
+
+            // Use the actual config to test
+            const chaosZeroConfig = dailyResetServiceConfig.games.find((g: any) => g.game === 'Chaos Zero Nightmare');
+
+            expect(chaosZeroConfig).toBeDefined();
+            expect(chaosZeroConfig?.resetTime.hour).toBe(18);
+            expect(chaosZeroConfig?.resetTime.minute).toBe(0);
+
+            const service = new DailyResetService(mockBot, dailyResetServiceConfig);
+            service.initializeSchedules();
+
+            // Check that schedule includes Chaos Zero
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Scheduled reset for Chaos Zero Nightmare at 18:00 UTC')
+            );
+
+            process.env.NODE_ENV = originalEnv;
+        });
+
+        it('should use correct channel name for Chaos Zero Nightmare', () => {
+            const chaosZeroConfig = dailyResetServiceConfig.games.find((g: any) => g.game === 'Chaos Zero Nightmare');
+
+            expect(chaosZeroConfig).toBeDefined();
+            expect(chaosZeroConfig?.channelName).toBe('chaos-zero-nightmare');
+        });
+
+        it('should reset 2 hours before Nikke (18:00 vs 20:00)', () => {
+            const chaosZeroConfig = dailyResetServiceConfig.games.find((g: any) => g.game === 'Chaos Zero Nightmare');
+            const nikkeConfig = dailyResetServiceConfig.games.find((g: any) => g.game === 'GODDESS OF VICTORY: NIKKE');
+
+            expect(chaosZeroConfig).toBeDefined();
+            expect(nikkeConfig).toBeDefined();
+
+            const chaosZeroMinutes = (chaosZeroConfig?.resetTime.hour ?? 0) * 60 + (chaosZeroConfig?.resetTime.minute ?? 0);
+            const nikkeMinutes = (nikkeConfig?.resetTime.hour ?? 0) * 60 + (nikkeConfig?.resetTime.minute ?? 0);
+
+            expect(nikkeMinutes - chaosZeroMinutes).toBe(120); // 2 hours = 120 minutes
+        });
+
+        it('should have warning config enabled for Chaos Zero Nightmare', () => {
+            const chaosZeroConfig = dailyResetServiceConfig.games.find((g: any) => g.game === 'Chaos Zero Nightmare');
+
+            expect(chaosZeroConfig).toBeDefined();
+            expect(chaosZeroConfig?.warningConfig).toBeDefined();
+            expect(chaosZeroConfig?.warningConfig?.enabled).toBe(true);
+            expect(chaosZeroConfig?.warningConfig?.minutesBefore).toBe(60);
+        });
+    });
+
+    describe('Warning Message System', () => {
+        it('should create dual schedules (warning + reset) when warning is enabled', () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'production';
+
+            const configWithWarning = {
+                ...testConfig,
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithWarning] });
+            service.initializeSchedules();
+
+            const jobs = service.getScheduledJobs();
+            expect(jobs.size).toBe(2); // warning + reset
+            expect(jobs.has('Test Game-warning')).toBe(true);
+            expect(jobs.has('Test Game-reset')).toBe(true);
+
+            process.env.NODE_ENV = originalEnv;
+        });
+
+        it('should only create reset schedule when warning is disabled', () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'production';
+
+            const configWithoutWarning = {
+                ...testConfig,
+                warningConfig: {
+                    enabled: false,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithoutWarning] });
+            service.initializeSchedules();
+
+            const jobs = service.getScheduledJobs();
+            expect(jobs.size).toBe(1); // only reset
+            expect(jobs.has('Test Game-reset')).toBe(true);
+            expect(jobs.has('Test Game-warning')).toBe(false);
+
+            process.env.NODE_ENV = originalEnv;
+        });
+
+        it('should schedule warning 60 minutes before reset in production', () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'production';
+
+            const consoleSpy = vi.spyOn(console, 'log');
+
+            const configWithWarning = {
+                ...testConfig,
+                resetTime: { hour: 20, minute: 0 },
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithWarning] });
+            service.initializeSchedules();
+
+            // Should log warning at 19:00 (1 hour before 20:00)
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Scheduled warning for Test Game at 19:00 UTC (60 min before reset)')
+            );
+
+            process.env.NODE_ENV = originalEnv;
+        });
+
+        it('should not include role ping in warning messages', async () => {
+            vi.mocked(util.findChannelByName).mockReturnValue(mockChannel);
+
+            const configWithRoleAndWarning = {
+                ...testConfig,
+                roleName: 'Test Role',
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithRoleAndWarning] });
+
+            // Access private method to test warning message
+            const sendWarningMessageToGuild = (service as any).sendWarningMessageToGuild;
+            await sendWarningMessageToGuild.call(service, mockGuild, configWithRoleAndWarning);
+
+            // Channel send should only be called once (for embed), not twice (role ping + embed)
+            expect(mockChannel.send).toHaveBeenCalledTimes(1);
+            expect(mockChannel.send).toHaveBeenCalledWith({ embeds: expect.any(Array) });
+        });
+
+        it('should build warning embed with different content than reset embed', async () => {
+            const configWithWarning = {
+                ...testConfig,
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithWarning] });
+
+            // Build warning embed
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+            const warningEmbed = await buildWarningEmbed.call(service, mockGuild, configWithWarning);
+
+            // Build reset embed
+            const buildEmbed = (service as any).buildEmbed;
+            const resetEmbed = await buildEmbed.call(service, mockGuild, configWithWarning);
+
+            // Warning and reset should have different titles
+            expect(warningEmbed.data.title).not.toBe(resetEmbed.data.title);
+            expect(warningEmbed.data.title).toContain('Warning');
+
+            // Warning should have fewer fields (no checklist)
+            const warningFieldCount = warningEmbed.data.fields?.length || 0;
+            const resetFieldCount = resetEmbed.data.fields?.length || 0;
+            expect(warningFieldCount).toBeLessThan(resetFieldCount);
+        });
+
+        it('should use default warning template when no custom config provided', async () => {
+            const configWithBasicWarning = {
+                ...testConfig,
+                game: 'Test Game',
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithBasicWarning] });
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+            const warningEmbed = await buildWarningEmbed.call(service, mockGuild, configWithBasicWarning);
+
+            expect(warningEmbed.data.title).toBe('⚠️ Test Game Reset Warning!');
+            expect(warningEmbed.data.description).toContain('60 minutes');
+            expect(warningEmbed.data.color).toBe(0xFFA500); // Orange
+        });
+
+        it('should support custom warning embed config', async () => {
+            const configWithCustomWarning = {
+                ...testConfig,
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 30,
+                    embedConfig: {
+                        title: 'Custom Warning Title',
+                        description: 'Custom warning description',
+                        color: 0xFF0000
+                    }
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithCustomWarning] });
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+            const warningEmbed = await buildWarningEmbed.call(service, mockGuild, configWithCustomWarning);
+
+            expect(warningEmbed.data.title).toBe('Custom Warning Title');
+            expect(warningEmbed.data.description).toBe('Custom warning description');
+            expect(warningEmbed.data.color).toBe(0xFF0000);
+        });
+
+        it('should schedule warning with 2-minute offset in dev mode', () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'development';
+
+            const consoleSpy = vi.spyOn(console, 'log');
+
+            const configWithWarning = {
+                ...testConfig,
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithWarning], devModeInterval: 5 });
+            service.initializeSchedules();
+
+            // Should log both warning and reset schedules
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('[DEV] Scheduled warning for Test Game every 5 minutes')
+            );
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('[DEV] Scheduled reset for Test Game at +2 min offset')
+            );
+
+            process.env.NODE_ENV = originalEnv;
+        });
+
+        it('should handle midnight wraparound for warning time calculation', () => {
+            const service = new DailyResetService(mockBot, { games: [testConfig] });
+            const calculateWarningTime = (service as any).calculateWarningTime;
+
+            // Test: 00:30 reset - 60 min warning = 23:30 previous day
+            const result = calculateWarningTime.call(service, 0, 30, 60);
+            expect(result.warningHour).toBe(23);
+            expect(result.warningMinute).toBe(30);
+        });
+
+        it('should execute afterSend hook for warning messages', async () => {
+            vi.mocked(util.findChannelByName).mockReturnValue(mockChannel);
+
+            const afterSendSpy = vi.fn().mockResolvedValue(undefined);
+            const configWithHooksAndWarning = {
+                ...testConfig,
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                },
+                hooks: {
+                    afterSend: afterSendSpy
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithHooksAndWarning] });
+            const sendWarningMessageToGuild = (service as any).sendWarningMessageToGuild;
+
+            await sendWarningMessageToGuild.call(service, mockGuild, configWithHooksAndWarning);
+
+            expect(afterSendSpy).toHaveBeenCalled();
+        });
+
+        it('should handle errors in warning message sending gracefully', async () => {
+            const failingChannel = {
+                ...mockChannel,
+                send: vi.fn(() => Promise.reject(new Error('Send failed')))
+            } as any;
+
+            vi.mocked(util.findChannelByName).mockReturnValue(failingChannel);
+
+            const configWithWarning = {
+                ...testConfig,
+                warningConfig: {
+                    enabled: true,
+                    minutesBefore: 60
+                }
+            };
+
+            const service = new DailyResetService(mockBot, { games: [configWithWarning] });
+            const sendWarningMessage = (service as any).sendWarningMessage;
+
+            // Should not throw because errors are caught and logged internally
+            await expect(sendWarningMessage.call(service, configWithWarning)).resolves.not.toThrow();
+        });
+    });
+
+    describe('Time Calculation', () => {
+        it('should calculate warning time correctly for normal times', () => {
+            const service = new DailyResetService(mockBot, { games: [testConfig] });
+            const calculateWarningTime = (service as any).calculateWarningTime;
+
+            // Test: 20:00 - 60 min = 19:00
+            let result = calculateWarningTime.call(service, 20, 0, 60);
+            expect(result.warningHour).toBe(19);
+            expect(result.warningMinute).toBe(0);
+
+            // Test: 18:00 - 60 min = 17:00
+            result = calculateWarningTime.call(service, 18, 0, 60);
+            expect(result.warningHour).toBe(17);
+            expect(result.warningMinute).toBe(0);
+
+            // Test: 14:30 - 30 min = 14:00
+            result = calculateWarningTime.call(service, 14, 30, 30);
+            expect(result.warningHour).toBe(14);
+            expect(result.warningMinute).toBe(0);
+        });
+
+        it('should handle midnight wraparound correctly', () => {
+            const service = new DailyResetService(mockBot, { games: [testConfig] });
+            const calculateWarningTime = (service as any).calculateWarningTime;
+
+            // Test: 00:00 - 60 min = 23:00 previous day
+            let result = calculateWarningTime.call(service, 0, 0, 60);
+            expect(result.warningHour).toBe(23);
+            expect(result.warningMinute).toBe(0);
+
+            // Test: 00:30 - 60 min = 23:30 previous day
+            result = calculateWarningTime.call(service, 0, 30, 60);
+            expect(result.warningHour).toBe(23);
+            expect(result.warningMinute).toBe(30);
+
+            // Test: 01:00 - 120 min = 23:00 previous day
+            result = calculateWarningTime.call(service, 1, 0, 120);
+            expect(result.warningHour).toBe(23);
+            expect(result.warningMinute).toBe(0);
+        });
+
+        it('should handle various minutesBefore values', () => {
+            const service = new DailyResetService(mockBot, { games: [testConfig] });
+            const calculateWarningTime = (service as any).calculateWarningTime;
+
+            // Test: 15 minutes before
+            let result = calculateWarningTime.call(service, 20, 0, 15);
+            expect(result.warningHour).toBe(19);
+            expect(result.warningMinute).toBe(45);
+
+            // Test: 30 minutes before
+            result = calculateWarningTime.call(service, 20, 0, 30);
+            expect(result.warningHour).toBe(19);
+            expect(result.warningMinute).toBe(30);
+
+            // Test: 120 minutes (2 hours) before
+            result = calculateWarningTime.call(service, 20, 0, 120);
+            expect(result.warningHour).toBe(18);
+            expect(result.warningMinute).toBe(0);
+        });
+
+        it('should handle edge case with minutes wraparound', () => {
+            const service = new DailyResetService(mockBot, { games: [testConfig] });
+            const calculateWarningTime = (service as any).calculateWarningTime;
+
+            // Test: 12:15 - 30 min = 11:45
+            const result = calculateWarningTime.call(service, 12, 15, 30);
+            expect(result.warningHour).toBe(11);
+            expect(result.warningMinute).toBe(45);
         });
     });
 });

--- a/src/utils/data/gamesResetConfig.ts
+++ b/src/utils/data/gamesResetConfig.ts
@@ -9,6 +9,7 @@ const RAPI_BOT_THUMBNAIL_URL = `${cdnDomainUrl}/assets/rapi-bot-thumbnail.jpg`;
 const NIKKE_LOGO_URL = `${cdnDomainUrl}/assets/logos/nikke-logo.png`;
 const BLUE_ARCHIVE_LOGO_URL = `${cdnDomainUrl}/assets/logos/blue-archive-logo.png`;
 const TRICKCAL_LOGO_URL = `${cdnDomainUrl}/assets/logos/trickcal-logo.png`;
+const CHAOS_ZERO_NIGHTMARE_LOGO_URL = `${cdnDomainUrl}/assets/logos/chaos-zero-nightmare-logo.png`;
 
 // Default extensions
 const DEFAULT_IMAGE_EXTENSIONS = ['.gif', '.png', '.jpg', '.webp'] as const;
@@ -94,6 +95,10 @@ const nikkeResetConfig: DailyResetConfig = {
         cdnPath: 'dailies/nikke/',
         extensions: [...DEFAULT_IMAGE_EXTENSIONS],
         trackLast: 10
+    },
+    warningConfig: {
+        enabled: true,
+        minutesBefore: 60
     },
     hooks: {
         afterSend: async (message: Message, guildId: string, bot: Client) => {
@@ -215,6 +220,10 @@ const blueArchiveResetConfig: DailyResetConfig = {
         cdnPath: 'dailies/blue-archive/',
         extensions: [...DEFAULT_IMAGE_EXTENSIONS],
         trackLast: 10
+    },
+    warningConfig: {
+        enabled: true,
+        minutesBefore: 60
     }
 };
 
@@ -245,6 +254,53 @@ const trickcalResetConfig: DailyResetConfig = {
         cdnPath: 'dailies/trickcal/',
         extensions: [...DEFAULT_IMAGE_EXTENSIONS],
         trackLast: 10
+    },
+    warningConfig: {
+        enabled: true,
+        minutesBefore: 60
+    }
+};
+
+/**
+ * Configuration for Chaos Zero Nightmare daily reset message
+ * Resets 2 hours before Nikke (18:00 UTC vs 20:00 UTC)
+ */
+const chaosZeroNightmareResetConfig: DailyResetConfig = {
+    game: 'Chaos Zero Nightmare',
+    channelName: 'chaos-zero-nightmare',
+    resetTime: { hour: 18, minute: 0 },
+    timezone: 'UTC',
+    embedConfig: {
+        title: '⚠️ ATTENTION PROTOS!',
+        description: `Dear Protos, it's time for your daily breakdown session.\n\nHere are today's **Essential Activities** to survive another day in Chaos Zero:`,
+        color: 0x9B30FF,
+        footer: {
+            text: 'Stay vigilant, Protos. The nightmare never sleeps.',
+            iconURL: RAPI_BOT_THUMBNAIL_URL
+        },
+        thumbnail: CHAOS_ZERO_NIGHTMARE_LOGO_URL,
+        author: {
+            name: 'Rapi BOT',
+            iconURL: RAPI_BOT_THUMBNAIL_URL
+        }
+    },
+    checklist: [
+        { name: '**Morning Routine**', value: 'Grab **Coffee** and collect **Aether** at **Garden Café**. Complete the **Daily Order**' },
+        { name: '**Policy Office**', value: 'Check out **Pending Policies** to be implemented in the office' },
+        { name: '**Starshine Diner**', value: 'Head to **Starshine Diner** to have a meal before entering **Chaos**' },
+        { name: '**Simulation Training**', value: 'Burn all **Aether** on Simulations for materials and experience' },
+        { name: '**Daily Missions**', value: 'Complete all missions for **Crystals** and **Coordinates**' },
+        { name: '**Partner Communication**', value: 'Use **Communication Passes** for **Affinity** gains and bonus **Crystals**' },
+        { name: '**Shop & Rewards**', value: 'Visit **Nono\'s Shop** and claim **Login Rewards** from Mail' }
+    ],
+    mediaConfig: {
+        cdnPath: 'dailies/chaos-zero-nightmare/',
+        extensions: [...DEFAULT_IMAGE_EXTENSIONS],
+        trackLast: 10
+    },
+    warningConfig: {
+        enabled: true,
+        minutesBefore: 60
     }
 };
 
@@ -255,6 +311,7 @@ export const dailyResetServiceConfig: DailyResetServiceConfig = {
     games: [
         nikkeResetConfig,
         blueArchiveResetConfig,
-        trickcalResetConfig
+        trickcalResetConfig,
+        chaosZeroNightmareResetConfig
     ]
 };

--- a/src/utils/interfaces/DailyResetConfig.interface.ts
+++ b/src/utils/interfaces/DailyResetConfig.interface.ts
@@ -52,6 +52,28 @@ export interface MediaConfig {
 export type DynamicFieldGenerator = (currentDate: Date) => EmbedField[];
 
 /**
+ * Configuration for warning messages sent before daily reset
+ */
+export interface WarningConfig {
+    /**
+     * Whether warning messages are enabled for this game
+     */
+    enabled: boolean;
+
+    /**
+     * How many minutes before the reset to send the warning
+     * @default 60 (1 hour)
+     */
+    minutesBefore: number;
+
+    /**
+     * Optional custom embed configuration for warning messages
+     * If not provided, a default warning embed will be used
+     */
+    embedConfig?: Partial<EmbedConfig>;
+}
+
+/**
  * Optional hook functions for custom behavior
  */
 export interface ResetMessageHooks {
@@ -121,6 +143,12 @@ export interface DailyResetConfig {
      * Optional hooks for custom behavior
      */
     hooks?: ResetMessageHooks;
+
+    /**
+     * Optional warning message configuration
+     * When enabled, sends a warning message before the daily reset
+     */
+    warningConfig?: WarningConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds Chaos Zero Nightmare daily reset messages and implements a warning system for all games.

## Changes
- **Chaos Zero Nightmare**: New daily reset at 18:00 UTC (2 hours before Nikke) with purple theme and lore-friendly messaging
- **Warning Messages**: All games now send warnings 1 hour before reset (no role pings)
- **Dev Mode**: 2-minute offset between warning and reset for easy testing
- **Tests**: 34 unit tests, all passing

## Testing
- ✅ All tests passing
- ✅ TypeScript builds successfully
- ✅ Dev mode tested with 5-minute intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)