### PR TITLE
fix: handle file size limit errors for media commands

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -159,10 +159,19 @@ const chatCommands: { [key: string]: Command } = {
                     trackLast: 20
                 }
             );
-            
-            await msg.reply({
-                files: [randomCdnMediaUrl]
-            });
+
+            try {
+                await msg.reply({
+                    files: [randomCdnMediaUrl]
+                });
+            } catch (error: any) {
+                // Handle file size limit errors (Discord's 10MB limit for non-boosted servers)
+                if (error.code === 40005 || error.status === 413) {
+                    await msg.reply("Commander, the selected media file is too large for this server (>10MB). You may need to boost the server to allow larger file uploads, or try the command again for a different file.");
+                } else {
+                    throw error; // Re-throw other errors to be handled by the main error handler
+                }
+            }
         },
     },
     booty: {
@@ -176,10 +185,19 @@ const chatCommands: { [key: string]: Command } = {
                     trackLast: 20
                 }
             );
-            
-            await msg.reply({
-                files: [randomCdnMediaUrl]
-            });
+
+            try {
+                await msg.reply({
+                    files: [randomCdnMediaUrl]
+                });
+            } catch (error: any) {
+                // Handle file size limit errors (Discord's 10MB limit for non-boosted servers)
+                if (error.code === 40005 || error.status === 413) {
+                    await msg.reply("Commander, the selected media file is too large for this server (>10MB). You may need to boost the server to allow larger file uploads, or try the command again for a different file.");
+                } else {
+                    throw error; // Re-throw other errors to be handled by the main error handler
+                }
+            }
         },
     },
     skillissue: {
@@ -192,11 +210,20 @@ const chatCommands: { [key: string]: Command } = {
                     extensions: [...DEFAULT_IMAGE_EXTENSIONS, ...DEFAULT_VIDEO_EXTENSIONS],
                 }
             );
-            
-            await msg.reply({
-                content: `It sounds like you have some skill issues Commander.`,
-                files: [randomCdnMediaUrl]
-            });
+
+            try {
+                await msg.reply({
+                    content: `It sounds like you have some skill issues Commander.`,
+                    files: [randomCdnMediaUrl]
+                });
+            } catch (error: any) {
+                // Handle file size limit errors (Discord's 10MB limit for non-boosted servers)
+                if (error.code === 40005 || error.status === 413) {
+                    await msg.reply("Commander, the selected media file is too large for this server (>10MB). You may need to boost the server to allow larger file uploads, or try the command again for a different file.");
+                } else {
+                    throw error; // Re-throw other errors to be handled by the main error handler
+                }
+            }
         },
     },
     skillissueiphone: {
@@ -757,11 +784,20 @@ const chatCommands: { [key: string]: Command } = {
                     extensions: [...DEFAULT_IMAGE_EXTENSIONS],
                 }
             );
-            
-            await msg.reply({
-                content: `${msg.author}, ${getRandomQuietRapiPhrase()}`,
-                files: [randomCdnMediaUrl]
-            });
+
+            try {
+                await msg.reply({
+                    content: `${msg.author}, ${getRandomQuietRapiPhrase()}`,
+                    files: [randomCdnMediaUrl]
+                });
+            } catch (error: any) {
+                // Handle file size limit errors (Discord's 10MB limit for non-boosted servers)
+                if (error.code === 40005 || error.status === 413) {
+                    await msg.reply("Commander, the selected media file is too large for this server (>10MB). You may need to boost the server to allow larger file uploads, or try the command again for a different file.");
+                } else {
+                    throw error; // Re-throw other errors to be handled by the main error handler
+                }
+            }
         },
     },
     entertainmentttt: {
@@ -775,10 +811,19 @@ const chatCommands: { [key: string]: Command } = {
                     extensions: [...DEFAULT_VIDEO_EXTENSIONS],
                 }
             );
-            
-            await msg.reply({
-                files: [randomCdnMediaUrl]
-            });
+
+            try {
+                await msg.reply({
+                    files: [randomCdnMediaUrl]
+                });
+            } catch (error: any) {
+                // Handle file size limit errors (Discord's 10MB limit for non-boosted servers)
+                if (error.code === 40005 || error.status === 413) {
+                    await msg.reply("Commander, the selected media file is too large for this server (>10MB). You may need to boost the server to allow larger file uploads, or try the command again for a different file.");
+                } else {
+                    throw error; // Re-throw other errors to be handled by the main error handler
+                }
+            }
         },
     },
     casualUnion: {


### PR DESCRIPTION
## Summary
- Fixed server-specific failures where media commands (booba, booty, skillissue, quietRapi, entertainmentttt) fail when randomly selected files exceed Discord's 10MB upload limit
- Added graceful error handling with user-friendly messages

## Changes Made
- Added try-catch blocks to 5 media commands
- Detect Discord error code 40005 (Request entity too large)
- Provide clear error message explaining:
  - File is too large (>10MB)
  - Server may need boost for larger uploads
  - User can retry for different file

## Root Cause
Commands were failing on some servers with `DiscordAPIError[40005]: Request entity too large` because:
- CDN randomly selects media files
- Some files exceed 10MB Discord limit for non-boosted servers
- No error handling → generic error message

## Test Plan
- [x] TypeScript compiles successfully
- [x] Error handling catches code 40005
- [x] User-friendly message displayed
- [ ] Test on non-boosted server with large files
- [ ] Verify retry works with different file

🤖 Generated with [Claude Code](https://claude.com/claude-code)