### PR TITLE
fix: use ChatInputCommandInteraction for slash commands

### DIFF
--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -1,5 +1,5 @@
 // Dependencies
-import { SlashCommandBuilder, CommandInteraction, AutocompleteInteraction } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, AutocompleteInteraction } from 'discord.js';
 import moment from 'moment-timezone';
 import gamesData from '../utils/data/gamesData';
 
@@ -19,7 +19,7 @@ module.exports = {
                         .setAutocomplete(true)
                 )
         ),
-    async execute(interaction: CommandInteraction) {
+    async execute(interaction: ChatInputCommandInteraction) {
         const gameName = (interaction.options.get('game')?.value as string || 'nikke').toLowerCase();
         const gameData = gamesData.find((game) => game.game.toLowerCase().includes(gameName));
 

--- a/src/commands/rapiball.ts
+++ b/src/commands/rapiball.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, CommandInteraction } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 import { enforceChannelRestriction } from '../utils/channelRestrictions';
 
 const rapiBallResponses = [
@@ -86,7 +86,7 @@ module.exports = {
             option.setName('question')
                 .setDescription('Your question for Rapi')
                 .setRequired(true)),
-    async execute(interaction: CommandInteraction) {
+    async execute(interaction: ChatInputCommandInteraction) {
         // Check channel restriction
         const isRestricted = await enforceChannelRestriction(interaction, 'rapi-bot');
         if (isRestricted) return;

--- a/src/commands/stream.ts
+++ b/src/commands/stream.ts
@@ -1,6 +1,6 @@
 import {
     SlashCommandBuilder,
-    CommandInteraction,
+    ChatInputCommandInteraction,
     TextChannel,
 } from 'discord.js';
 import { checkStreamStatus } from '../utils/twitch';
@@ -14,7 +14,7 @@ module.exports = {
                 .setDescription('The URL of the stream (optional)')
                 .setRequired(true)
         ),
-    async execute(interaction: CommandInteraction) {
+    async execute(interaction: ChatInputCommandInteraction) {
         if (interaction.commandName !== 'stream') return;
         const url = interaction.options.get('url')?.value as string;
         const twitchLink = `https://www.twitch.tv/sefhi_922`;

--- a/src/tests/radio.test.ts
+++ b/src/tests/radio.test.ts
@@ -176,7 +176,7 @@ describe('Radio Playback', () => {
                 adapterCreator: vi.fn() as any,
             });
 
-            vi.mocked(entersState).mockResolvedValue(connection);
+            vi.mocked(entersState).mockResolvedValue(connection as any);
 
             await Promise.race([
                 entersState(connection, VoiceConnectionStatus.Signalling, 5_000),


### PR DESCRIPTION
## Summary
- Replace `CommandInteraction` with `ChatInputCommandInteraction` in slash command execute functions
- Fixes TypeScript errors where `options.get()` method doesn't exist on `CommandInteraction`
- Fix test type assertion for `entersState` mock

## Files Changed
- `src/commands/daily.ts` - Update import and execute function type
- `src/commands/rapiball.ts` - Update import and execute function type
- `src/commands/stream.ts` - Update import and execute function type
- `src/tests/radio.test.ts` - Fix type assertion in mock

## Test plan
- [x] TypeScript compiles without errors
- [x] All 50 unit tests pass
- [ ] Verify slash commands work in Discord after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)