### PR TITLE
fix: update @discordjs/voice to 0.19.0 for new encryption modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.772.0",
         "@discordjs/opus": "^0.10.0",
-        "@discordjs/voice": "^0.17.0",
+        "@discordjs/voice": "^0.19.0",
         "axios": "^1.7.7",
         "discord.js": "^14.14.1",
         "dotenv": "^16.4.5",
@@ -953,15 +953,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.38.37",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/@discordjs/collection": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
@@ -985,15 +976,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/formatters/node_modules/discord-api-types": {
-      "version": "0.38.37",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/@discordjs/node-pre-gyp": {
       "version": "0.4.5",
@@ -1065,15 +1047,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
-      "version": "0.38.37",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/@discordjs/util": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
@@ -1089,30 +1062,20 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/util/node_modules/discord-api-types": {
-      "version": "0.38.37",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/@discordjs/voice": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.17.0.tgz",
-      "integrity": "sha512-hArn9FF5ZYi1IkxdJEVnJi+OxlwLV0NJYWpKXsmNOojtGtAZHxmsELA+MZlu2KW1F/K1/nt7lFOfcMXNYweq9w==",
-      "deprecated": "This version uses deprecated encryption modes. Please use a newer version.",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.0.tgz",
+      "integrity": "sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/ws": "^8.5.10",
-        "discord-api-types": "0.37.83",
+        "@types/ws": "^8.18.1",
+        "discord-api-types": "^0.38.16",
         "prism-media": "^1.3.5",
-        "tslib": "^2.6.2",
-        "ws": "^8.16.0"
+        "tslib": "^2.8.1",
+        "ws": "^8.18.3"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=22.12.0"
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
@@ -1152,15 +1115,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
-      "version": "0.38.37",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -3617,10 +3571,13 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.83",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
-      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA==",
-      "license": "MIT"
+      "version": "0.38.37",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
+      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
     },
     "node_modules/discord.js": {
       "version": "14.25.1",
@@ -3648,15 +3605,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/discord.js/node_modules/discord-api-types": {
-      "version": "0.38.37",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -6100,6 +6048,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.772.0",
     "@discordjs/opus": "^0.10.0",
-    "@discordjs/voice": "^0.17.0",
+    "@discordjs/voice": "^0.19.0",
     "axios": "^1.7.7",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
Update `@discordjs/voice` from 0.17.0 to 0.19.0 to support Discord's new voice encryption modes.

## Problem
```
Error: No compatible encryption modes. Available include: aead_aes256_gcm_rtpsize, aead_xchacha20_poly1305_rtpsize
```

Discord updated their voice servers to use new encryption modes that version 0.17.0 doesn't support.

## Solution
Update to `@discordjs/voice@0.19.0` which adds support for the new encryption modes.

## Test plan
- [x] TypeScript compiles without errors
- [x] All 50 unit tests pass
- [ ] Verify voice connection works after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)