### PR TITLE
fix: downgrade p-limit to v3 for CommonJS compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.46",
         "node-schedule": "^2.1.1",
-        "p-limit": "^7.2.0",
+        "p-limit": "^3.1.0",
         "puppeteer": "^24.34.0",
         "twitch-api-v5": "^2.0.4",
         "uuid": "^10.0.0"
@@ -5951,15 +5951,15 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.2.0.tgz",
-      "integrity": "sha512-ATHLtwoTNDloHRFFxFJdHnG6n2WUeFjaR8XQMFdKIv0xkXjrER8/iG9iu265jOM95zXHAfv9oTkqhrfbIzosrQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^1.2.1"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7895,12 +7895,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.46",
     "node-schedule": "^2.1.1",
-    "p-limit": "^7.2.0",
+    "p-limit": "^3.1.0",
     "puppeteer": "^24.34.0",
     "twitch-api-v5": "^2.0.4",
     "uuid": "^10.0.0"


### PR DESCRIPTION
## Summary

- Downgrade `p-limit` from v7 to v3.1.0
- v4+ is ESM-only which breaks ts-node in Docker

## Problem

Docker container fails with:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/p-limit/index.js not supported
```

## Solution

Use the last CommonJS-compatible version (v3.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)