### PR TITLE
fix: add Chrome dependencies for Puppeteer in Docker

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -5,6 +5,7 @@ FROM node:18
 WORKDIR /app
 
 # Update apt-get and install FFmpeg + build tools for @discordjs/opus
+# Also install dependencies required for Puppeteer/Chromium
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     python3 \
@@ -12,7 +13,48 @@ RUN apt-get update && apt-get install -y \
     g++ \
     libtool \
     autoconf \
-    automake
+    automake \
+    # Puppeteer dependencies for headless Chrome
+    wget \
+    gnupg \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm1 \
+    libgcc1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxtst6 \
+    lsb-release \
+    xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy package.json and package-lock.json
 COPY package*.json ./


### PR DESCRIPTION
## Summary

Add required shared library dependencies for Puppeteer to run headless Chrome in the Docker container.

## Problem

```
error while loading shared libraries: libnspr4.so: cannot open shared object file
```

## Solution

Install all Chrome/Chromium dependencies in the Dockerfile:
- libnspr4, libnss3, libatk, libgtk-3, libgbm, etc.
- Cleans up apt cache to minimize image size

🤖 Generated with [Claude Code](https://claude.com/claude-code)