### PR TITLE
feat: skip redemption DM if only expired codes

### DIFF
--- a/src/services/gachaRedemptionService.ts
+++ b/src/services/gachaRedemptionService.ts
@@ -518,8 +518,10 @@ export class GachaRedemptionService {
                         console.error(`Redemption failed for ${subscription.gameUserId} - Code: ${failed.code}, Error: ${failed.errorCode || 'Unknown'}, Message: ${failed.message}`);
                     }
 
-                    // Send DM only if not disabled
-                    if (!dmDisabled) {
+                    // Send DM only if not disabled AND we have meaningful results
+                    // (skip if only expired codes or failures with nothing redeemed)
+                    const hasRedeemed = successfulCodes.length > 0 || alreadyRedeemed.length > 0;
+                    if (!dmDisabled && hasRedeemed) {
                         await this.sendRedemptionResultsDM(bot, discordId, gameId, redemptionResults, subscription.gameUserId);
                     }
 


### PR DESCRIPTION
## Summary
Skip sending redemption result DMs when only expired codes exist (no successful or already redeemed codes).

## Problem
Previously, users would receive DMs after auto-redemption even if all codes were just expired - resulting in unnecessary notifications with no meaningful information.

## Solution
Only send redemption result DM if:
- Successful redemptions > 0 OR
- Already redeemed codes > 0

If only expired codes or actual failures exist with nothing redeemed, skip the DM.

## Test plan
- [x] Added test: should skip DM if only expired codes exist
- [x] All 186 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)