### PR TITLE
feat: auto-redeem all active codes immediately on subscribe

### DIFF
--- a/src/commands/tests/redeem.test.ts
+++ b/src/commands/tests/redeem.test.ts
@@ -159,6 +159,12 @@ describe('Redeem Command', () => {
                 failed: 1,
                 skipped: 0,
             }),
+            redeemAllForUser: vi.fn().mockResolvedValue({
+                successful: 2,
+                alreadyRedeemed: 0,
+                failed: 0,
+                total: 2,
+            }),
         };
         vi.mocked(getGachaRedemptionService).mockReturnValue(mockRedemptionService);
 


### PR DESCRIPTION
## Summary
When a user subscribes with auto-redeem mode, immediately redeem all currently active codes instead of waiting for the next cron cycle.

## Changes
- Add `redeemAllForUser()` method to redemption service
- Update subscribe handler to call `redeemAllForUser` for auto-redeem subscribers
- Show redemption summary in subscription confirmation embed
- Send DM with detailed redemption results

## User Experience
Before: User subscribes → waits up to 6 hours for next auto-redemption cron
After: User subscribes → immediately gets all active codes redeemed → sees summary in confirmation

## Test plan
- [x] Added 4 new tests for `redeemAllForUser` method
- [x] Updated mock in redeem.test.ts
- [x] All 190 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)