### PR TITLE
docs: update README and add CLAUDE.md for LLM context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md - LLM Context Guide
+
+## Project Overview
+Discord bot for gacha games: daily reset notifications, music playback, chat commands, and **coupon redemption system**.
+
+## Tech Stack
+- TypeScript, Node.js, Discord.js
+- AWS S3 for data persistence (JSON documents)
+- Vitest for testing
+- Docker for deployment
+
+## Key Directories
+```
+src/
+├── commands/           # Slash commands (/redeem, /spam, /gacha, etc.)
+├── services/           # Business logic (gachaRedemptionService, gachaDataService)
+├── utils/
+│   ├── data/          # Config files (gachaGamesConfig, gachaConfig)
+│   └── interfaces/    # TypeScript interfaces
+└── index.ts           # Entry point, cron jobs
+```
+
+## Gacha Coupon System (Primary Feature)
+
+### Architecture
+- `gachaDataService.ts` - S3 data operations (CRUD for coupons, subscriptions)
+- `gachaRedemptionService.ts` - Redemption logic, DM notifications, API calls
+- `gachaGamesConfig.ts` - Game configurations (BD2, NIKKE, Blue Archive)
+- `gachaConfig.ts` - Tunable parameters (timeouts, rate limits, retries)
+
+### Data Model (S3 JSON)
+```typescript
+GachaCouponData {
+  coupons: GachaCoupon[]           // gameId, code, rewards, expirationDate, isActive
+  subscriptions: UserSubscription[] // discordId, gameSubscriptions[]
+  redemptionHistory: RedemptionHistoryEntry[]
+}
+```
+
+### Key Commands
+| Command | Handler | Description |
+|---------|---------|-------------|
+| `/redeem subscribe` | `handleSubscribe` | Subscribe + immediate auto-redeem |
+| `/redeem subscribers` | `handleModSubscribers` | Paginated subscriber list (mod) |
+| `/redeem list` | `handleModList` | Codes with status indicators |
+| `/redeem help` | `handleHelp` | FAQs (mod-aware) |
+
+### Subscription Modes
+- **auto-redeem**: Immediate redemption on subscribe, then every 6h + on new codes
+- **notification-only**: DM alerts only, manual redemption
+
+### Important Behaviors
+1. **Auto-redeem on subscribe**: `redeemAllForUser()` called immediately
+2. **Expired code grace period**: 24h before `isActive=false`
+3. **DM skip logic**: No DM if only expired codes (no meaningful results)
+4. **Real-time filtering**: `getActiveCoupons()` filters by expiration date at runtime
+
+### Status Indicators (in /redeem list)
+- ✅ Active (not expiring soon)
+- ⏰ Expiring within 24h
+- ❌ Expired (in 24h grace period)
+
+## Permission System
+- Mod commands require `mods` role OR Administrator permission
+- Check: `checkModPermission(interaction)` in redeem.ts
+- modCommands array: `['add', 'remove', 'list', 'trigger', 'unsub', 'update', 'lookup', 'reset', 'scrape', 'stats', 'subscribers']`
+
+## Testing
+```bash
+npm run test:run        # Run all tests
+npx tsc --noEmit        # Type check
+```
+
+## Common Patterns
+
+### Adding a new /redeem subcommand
+1. Add to SlashCommandBuilder (around line 1170-1220)
+2. Create `handleXxx` function
+3. Add to switch statement in `execute()`
+4. If mod-only, add to `modCommands` array
+5. Update `handleHelp` if user-facing
+
+### Pagination (subscribers command)
+Uses inline ActionRowBuilder with Previous/Next buttons, 5-min timeout.
+
+## Environment Variables
+```
+WAIFUTOKEN, CLIENTID, CDN_DOMAIN_URL
+AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, S3_BUCKET
+```
+
+## Cron Jobs (index.ts)
+- Auto-redemption: every 6h (prod) / 3min (dev)
+- Code scraping: every 30min (prod) / 2min (dev)
+- Expired cleanup: daily midnight (prod) / 15min (dev)

--- a/readme.md
+++ b/readme.md
@@ -190,9 +190,10 @@ The bot includes a multi-game coupon redemption system that automatically redeem
 | `/redeem codes <game>` | View all active coupon codes |
 | `/redeem preferences <game> [options]` | Configure notification preferences |
 | `/redeem switch <game> <mode>` | Switch subscription mode without re-subscribing |
+| `/redeem help` | View help and FAQs about the redemption system |
 
 **Subscription Modes:**
-- **Auto-Redeem** (🤖): Bot automatically redeems new codes for you (BD2 only)
+- **Auto-Redeem** (🤖): Bot redeems all active codes immediately on subscribe, then every 6 hours + when new codes are added (BD2 only)
 - **Notification Only** (📬): Receive DM notifications about new and expiring codes
 
 **Notification Preferences:**
@@ -207,13 +208,14 @@ Users can customize which notifications they receive:
 |---------|-------------|
 | `/redeem add <game> <code> <rewards> [expiration] [source]` | Add a new coupon code |
 | `/redeem remove <game> <code>` | Deactivate a coupon code |
-| `/redeem list <game>` | View all codes and subscriber stats |
+| `/redeem list <game>` | View all codes with expiration status indicators |
 | `/redeem trigger <game>` | Manually trigger auto-redemption |
 | `/redeem scrape` | Fetch new codes from BD2 Pulse |
 | `/redeem stats [game]` | View redemption analytics |
+| `/redeem subscribers <game> [mode]` | View paginated list of subscribers |
+| `/redeem lookup <user>` | View a user's subscriptions |
 | `/redeem unsub <user> <game>` | Force unsubscribe a user |
 | `/redeem update <user> <game> <userid>` | Update a user's game ID |
-| `/redeem lookup <user>` | View a user's subscriptions |
 | `/redeem reset <user> <game>` | Reset a user's redeemed codes |
 
 ### Scheduled Tasks
@@ -227,6 +229,8 @@ The system runs five automated tasks:
 | Auto-Redemption | Every 6 hours | Every 3 min |
 | Code Scraping | Every 30 min | Every 2 min |
 | Expired Code Cleanup | Daily 00:00 UTC | Every 15 min |
+
+**Note:** Expired codes have a 24-hour grace period before being marked inactive to account for timezone differences. Codes show status indicators in `/redeem list`: ✅ active, ⏰ expiring within 24h, ❌ expired (grace period).
 
 ### Adding a New Game
 


### PR DESCRIPTION
## Summary
- Update README with recent gacha coupon system changes
- Add CLAUDE.md as LLM-optimized context guide

## README Changes
- Added `/redeem help` to user commands table
- Added `/redeem subscribers` to mod commands table
- Updated auto-redeem description to mention immediate redemption on subscribe
- Added note about 24-hour grace period for expired codes with status indicators
- Updated `/redeem list` description to mention status indicators

## CLAUDE.md
New file providing LLM-optimized context for the codebase:
- Project overview and tech stack
- Key directories and architecture
- Gacha coupon system details (primary feature)
- Data model and important behaviors
- Permission system and common patterns
- Testing and environment variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)