### PR TITLE
fix: filter expired codes and add pagination to /redeem list

### DIFF
--- a/src/commands/tests/redeem.test.ts
+++ b/src/commands/tests/redeem.test.ts
@@ -802,6 +802,7 @@ describe('Redeem Command', () => {
 
             (mockInteraction.options!.getString as any).mockImplementation((name: string) => {
                 if (name === 'game') return 'bd2';
+                if (name === 'filter') return null;
                 return null;
             });
 
@@ -809,8 +810,9 @@ describe('Redeem Command', () => {
 
             expect(mockDataService.getAllCoupons).toHaveBeenCalledWith('bd2');
             expect(mockDataService.getGameStats).toHaveBeenCalledWith('bd2');
-            expect(mockInteraction.reply).toHaveBeenCalledWith(
-                expect.objectContaining({ embeds: expect.any(Array), ephemeral: true })
+            expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+            expect(mockInteraction.editReply).toHaveBeenCalledWith(
+                expect.objectContaining({ embeds: expect.any(Array) })
             );
         });
     });


### PR DESCRIPTION
## Summary
- Fix expired codes showing in `/redeem codes` command
- Add filter and pagination to `/redeem list` for mods

## Bug Fix
**Issue:** Expired codes like `BD2FF45` were showing in `/redeem codes` even after expiration.

**Root Cause:** `getActiveCoupons()` relied on a cached index built when data was loaded. If a code expired while the cache was still valid (5min TTL), it would still appear in results.

**Solution:**
- Filter by expiration date at read time to ensure expired codes never show
- Update index to remove expired codes after filtering (cleanup for subsequent calls)

## Enhancements to /redeem list
- Add optional `filter` parameter with choices:
  - All (default) - shows all codes
  - Active Only - shows only active codes
  - Expired/Inactive Only - shows only expired/removed codes
- Add pagination with Previous/Next buttons (10 codes per page)
- Mods can now browse full expired codes history with `filter:expired`

## Test plan
- [ ] Verify `/redeem codes` no longer shows expired codes
- [ ] Verify `/redeem list` shows all codes by default
- [ ] Verify `/redeem list filter:active` shows only active codes
- [ ] Verify `/redeem list filter:expired` shows all expired/inactive codes
- [ ] Verify pagination works when more than 10 codes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)