### PR TITLE
feat: add embed fixer for Twitter, Pixiv, and Instagram with voting and duplicate detection

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,0 +1,85 @@
+/**
+ * /embed command - Generate fixed embeds for social media URLs
+ */
+
+import {
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    MessageFlags,
+    SlashCommandBuilder,
+} from 'discord.js';
+import { getEmbedFixService } from '../services/embedFix/embedFixService';
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('embed')
+        .setDescription('Generate a fixed embed for a social media URL')
+        .addStringOption(option =>
+            option
+                .setName('url')
+                .setDescription('The URL to generate an embed for (Twitter/X supported)')
+                .setRequired(true)
+        ),
+
+    async execute(interaction: ChatInputCommandInteraction) {
+        const url = interaction.options.getString('url', true);
+
+        // Validate URL format
+        if (!url.startsWith('http://') && !url.startsWith('https://')) {
+            await interaction.reply({
+                content: 'Please provide a valid URL starting with http:// or https://',
+                flags: MessageFlags.Ephemeral,
+            });
+            return;
+        }
+
+        const service = getEmbedFixService();
+
+        // Check if URL is supported
+        if (!service.isUrlSupported(url)) {
+            const supportedPlatforms = service.getSupportedPlatforms();
+            await interaction.reply({
+                content: `This URL is not supported. Currently supported platforms: ${supportedPlatforms.join(', ')}`,
+                flags: MessageFlags.Ephemeral,
+            });
+            return;
+        }
+
+        // Defer reply as API call may take time
+        await interaction.deferReply();
+
+        try {
+            const embedData = await service.processUrlString(url);
+
+            if (!embedData) {
+                await interaction.editReply({
+                    content: 'Could not fetch embed data for this URL. The content may be unavailable or private.',
+                });
+                return;
+            }
+
+            // Build the embed
+            const embed = service.buildEmbed(embedData);
+
+            // Create bookmark button
+            const row = service.createBookmarkButton(interaction.id);
+
+            // Handle URL rewrite platforms differently
+            if (embedData._useUrlRewrite && embedData._rewrittenUrl) {
+                await interaction.editReply({
+                    content: embedData._rewrittenUrl,
+                });
+            } else {
+                await interaction.editReply({
+                    embeds: [embed],
+                    components: [row],
+                });
+            }
+        } catch (error) {
+            console.error('[/embed] Error processing URL:', error);
+            await interaction.editReply({
+                content: 'An error occurred while processing the URL. Please try again later.',
+            });
+        }
+    },
+};

--- a/src/services/embedFix/circuitBreaker.ts
+++ b/src/services/embedFix/circuitBreaker.ts
@@ -1,0 +1,108 @@
+/**
+ * Circuit breaker for external API calls
+ * Prevents hammering failing APIs by temporarily disabling requests
+ */
+
+import { EMBED_FIX_CONFIG } from '../../utils/data/embedFixConfig';
+import { CircuitBreakerState, EmbedPlatform } from '../../utils/interfaces/EmbedFix.interface';
+
+class CircuitBreaker {
+    private states: Map<EmbedPlatform, CircuitBreakerState> = new Map();
+
+    /**
+     * Check if the circuit is open (API disabled) for a platform
+     * @param platform The platform to check
+     * @returns true if circuit is open (should NOT make requests)
+     */
+    isOpen(platform: EmbedPlatform): boolean {
+        const state = this.states.get(platform);
+
+        if (!state) {
+            return false;
+        }
+
+        if (!state.isOpen) {
+            return false;
+        }
+
+        // Check if cooldown period has passed
+        if (Date.now() >= state.openUntil) {
+            // Reset to half-open state (allow one request to test)
+            state.isOpen = false;
+            state.failures = 0;
+            console.log(`[CircuitBreaker] Circuit for ${platform} is now half-open, allowing test request`);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Record a successful API call
+     * @param platform The platform
+     */
+    recordSuccess(platform: EmbedPlatform): void {
+        const state = this.states.get(platform);
+
+        if (state) {
+            // Reset failures on success
+            state.failures = 0;
+            state.isOpen = false;
+        }
+    }
+
+    /**
+     * Record a failed API call
+     * @param platform The platform
+     */
+    recordFailure(platform: EmbedPlatform): void {
+        let state = this.states.get(platform);
+
+        if (!state) {
+            state = {
+                failures: 0,
+                lastFailure: 0,
+                isOpen: false,
+                openUntil: 0,
+            };
+            this.states.set(platform, state);
+        }
+
+        const now = Date.now();
+        state.failures++;
+        state.lastFailure = now;
+
+        // Check if we should open the circuit
+        if (state.failures >= EMBED_FIX_CONFIG.CIRCUIT_BREAKER_THRESHOLD) {
+            state.isOpen = true;
+            state.openUntil = now + EMBED_FIX_CONFIG.CIRCUIT_BREAKER_TIMEOUT;
+            console.log(`[CircuitBreaker] Circuit for ${platform} is now OPEN until ${new Date(state.openUntil).toISOString()}`);
+        }
+    }
+
+    /**
+     * Get the current state for a platform (for debugging)
+     * @param platform The platform
+     */
+    getState(platform: EmbedPlatform): CircuitBreakerState | undefined {
+        return this.states.get(platform);
+    }
+
+    /**
+     * Reset all circuit breakers (for testing)
+     */
+    reset(): void {
+        this.states.clear();
+    }
+
+    /**
+     * Reset a specific platform's circuit breaker
+     * @param platform The platform to reset
+     */
+    resetPlatform(platform: EmbedPlatform): void {
+        this.states.delete(platform);
+    }
+}
+
+// Export singleton instance
+export const circuitBreaker = new CircuitBreaker();

--- a/src/services/embedFix/embedCache.ts
+++ b/src/services/embedFix/embedCache.ts
@@ -1,0 +1,151 @@
+/**
+ * LRU Cache for embed data
+ * Caches successful API responses to reduce external API calls
+ */
+
+import { EMBED_FIX_CONFIG } from '../../utils/data/embedFixConfig';
+import { CachedEmbed, EmbedData } from '../../utils/interfaces/EmbedFix.interface';
+
+class EmbedCache {
+    private cache: Map<string, CachedEmbed> = new Map();
+    private negativeCache: Map<string, number> = new Map(); // Stores expiry time for failed requests
+    private cleanupInterval: NodeJS.Timeout | null = null;
+
+    constructor() {
+        // Clean up expired entries every 10 minutes
+        this.cleanupInterval = setInterval(() => this.cleanup(), 10 * 60 * 1000);
+    }
+
+    /**
+     * Get cached embed data
+     * @param key Cache key (usually platform:id)
+     * @returns The cached embed data or null if not found/expired
+     */
+    get(key: string): EmbedData | null {
+        const entry = this.cache.get(key);
+
+        if (!entry) {
+            return null;
+        }
+
+        // Check if expired
+        if (Date.now() >= entry.expiresAt) {
+            this.cache.delete(key);
+            return null;
+        }
+
+        return entry.data;
+    }
+
+    /**
+     * Store embed data in cache
+     * @param key Cache key (usually platform:id)
+     * @param data The embed data to cache
+     */
+    set(key: string, data: EmbedData): void {
+        // Enforce max size - remove oldest entries if at capacity
+        if (this.cache.size >= EMBED_FIX_CONFIG.EMBED_CACHE_MAX_SIZE) {
+            const oldestKey = this.cache.keys().next().value;
+            if (oldestKey) {
+                this.cache.delete(oldestKey);
+            }
+        }
+
+        const now = Date.now();
+        this.cache.set(key, {
+            data,
+            timestamp: now,
+            expiresAt: now + EMBED_FIX_CONFIG.EMBED_CACHE_TTL,
+        });
+    }
+
+    /**
+     * Check if a key is in the negative cache (recently failed)
+     * @param key Cache key
+     * @returns true if the key recently failed and should not be retried
+     */
+    isNegativelyCached(key: string): boolean {
+        const expiresAt = this.negativeCache.get(key);
+
+        if (!expiresAt) {
+            return false;
+        }
+
+        if (Date.now() >= expiresAt) {
+            this.negativeCache.delete(key);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Add a key to the negative cache (mark as recently failed)
+     * @param key Cache key
+     */
+    setNegative(key: string): void {
+        this.negativeCache.set(key, Date.now() + EMBED_FIX_CONFIG.NEGATIVE_CACHE_TTL);
+    }
+
+    /**
+     * Remove an entry from the cache
+     * @param key Cache key
+     */
+    delete(key: string): void {
+        this.cache.delete(key);
+        this.negativeCache.delete(key);
+    }
+
+    /**
+     * Clean up expired entries
+     */
+    private cleanup(): void {
+        const now = Date.now();
+
+        // Clean positive cache
+        for (const [key, entry] of this.cache) {
+            if (now >= entry.expiresAt) {
+                this.cache.delete(key);
+            }
+        }
+
+        // Clean negative cache
+        for (const [key, expiresAt] of this.negativeCache) {
+            if (now >= expiresAt) {
+                this.negativeCache.delete(key);
+            }
+        }
+    }
+
+    /**
+     * Get cache stats (for debugging/monitoring)
+     */
+    getStats(): { size: number; negativeSize: number; maxSize: number } {
+        return {
+            size: this.cache.size,
+            negativeSize: this.negativeCache.size,
+            maxSize: EMBED_FIX_CONFIG.EMBED_CACHE_MAX_SIZE,
+        };
+    }
+
+    /**
+     * Clear all cache entries (for testing)
+     */
+    clear(): void {
+        this.cache.clear();
+        this.negativeCache.clear();
+    }
+
+    /**
+     * Stop the cleanup interval (for graceful shutdown)
+     */
+    destroy(): void {
+        if (this.cleanupInterval) {
+            clearInterval(this.cleanupInterval);
+            this.cleanupInterval = null;
+        }
+    }
+}
+
+// Export singleton instance
+export const embedCache = new EmbedCache();

--- a/src/services/embedFix/embedFixService.ts
+++ b/src/services/embedFix/embedFixService.ts
@@ -134,6 +134,11 @@ class EmbedFixService {
         const messageLink = `https://discord.com/channels/${message.guild!.id}/${originalShare.channelId}/${originalShare.messageId}`;
 
         try {
+            // Suppress the duplicate message's embeds so Discord doesn't show them
+            await message.suppressEmbeds(true).catch(() => {
+                // Ignore if we can't suppress embeds (missing permissions)
+            });
+
             await message.reply({
                 content: `🔄 This was shared ${timeAgo} → [Jump to original](${messageLink})`,
                 allowedMentions: { repliedUser: false },

--- a/src/services/embedFix/embedFixService.ts
+++ b/src/services/embedFix/embedFixService.ts
@@ -1,0 +1,341 @@
+/**
+ * Main Embed Fix Service
+ * Orchestrates URL detection, caching, rate limiting, and embed generation
+ */
+
+import {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonInteraction,
+    ButtonStyle,
+    EmbedBuilder,
+    Message,
+    MessageFlags,
+    TextChannel,
+} from 'discord.js';
+import { EMBED_FIX_CONFIG } from '../../utils/data/embedFixConfig';
+import { EmbedData, MatchedUrl } from '../../utils/interfaces/EmbedFix.interface';
+import { logError } from '../../utils/util';
+import { circuitBreaker } from './circuitBreaker';
+import { embedCache } from './embedCache';
+import { twitterHandler } from './handlers/twitterHandler';
+import { embedFixRateLimiter } from './rateLimiter';
+import { urlMatcher } from './urlMatcher';
+
+class EmbedFixService {
+    private static instance: EmbedFixService;
+    private initialized = false;
+
+    private constructor() {
+        // Private constructor for singleton
+    }
+
+    static getInstance(): EmbedFixService {
+        if (!EmbedFixService.instance) {
+            EmbedFixService.instance = new EmbedFixService();
+        }
+        return EmbedFixService.instance;
+    }
+
+    /**
+     * Initialize the service and register handlers
+     */
+    initialize(): void {
+        if (this.initialized) {
+            return;
+        }
+
+        // Register Twitter handler
+        urlMatcher.registerHandler(twitterHandler);
+
+        // Future handlers will be registered here:
+        // urlMatcher.registerHandler(pixivHandler);
+        // urlMatcher.registerHandler(instagramHandler);
+
+        this.initialized = true;
+        console.log('[EmbedFix] Service initialized with handlers:', urlMatcher.getHandlers().map(h => h.platform).join(', '));
+    }
+
+    /**
+     * Process a message for embed-worthy URLs
+     * This is the main entry point called from the message handler
+     * @param message The Discord message to process
+     */
+    async processMessage(message: Message): Promise<void> {
+        // Fast path checks
+        if (!message.content.includes('http')) return;
+        if (message.author.bot) return;
+        if (!message.guild) return;
+
+        // Check rate limits
+        if (!embedFixRateLimiter.check(message.guild.id, message.author.id)) {
+            return;
+        }
+
+        // Find matching URLs
+        const matches = urlMatcher.matchAllUrls(message.content);
+        if (matches.length === 0) return;
+
+        // Limit to max embeds per message
+        const limitedMatches = matches.slice(0, EMBED_FIX_CONFIG.MAX_EMBEDS_PER_MESSAGE);
+        const skippedCount = matches.length - limitedMatches.length;
+
+        // Process each URL in parallel
+        const embedPromises = limitedMatches.map(match => this.processUrl(match));
+        const results = await Promise.all(embedPromises);
+
+        // Filter out null results
+        const validEmbeds = results.filter((data): data is EmbedData => data !== null);
+
+        if (validEmbeds.length === 0) return;
+
+        // Send the response
+        await this.sendEmbedResponse(message, validEmbeds, skippedCount);
+    }
+
+    /**
+     * Process a single URL for embed generation
+     * Used by both message handler and /embed command
+     * @param url The URL to process
+     */
+    async processUrl(matched: MatchedUrl): Promise<EmbedData | null> {
+        const { platform, match, handler, url } = matched;
+
+        // Check circuit breaker
+        if (circuitBreaker.isOpen(platform)) {
+            console.log(`[EmbedFix] Circuit breaker open for ${platform}, skipping ${url}`);
+            return null;
+        }
+
+        // Generate cache key
+        const cacheKey = `${platform}:${url}`;
+
+        // Check positive cache
+        const cached = embedCache.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+
+        // Check negative cache
+        if (embedCache.isNegativelyCached(cacheKey)) {
+            return null;
+        }
+
+        try {
+            // Fetch from API
+            const embedData = await handler.fetchEmbed(match, url);
+
+            if (embedData) {
+                // Cache successful result
+                embedCache.set(cacheKey, embedData);
+                circuitBreaker.recordSuccess(platform);
+                return embedData;
+            } else {
+                // Cache negative result
+                embedCache.setNegative(cacheKey);
+                circuitBreaker.recordFailure(platform);
+                return null;
+            }
+        } catch (error) {
+            console.error(`[EmbedFix] Error processing ${url}:`, error);
+            embedCache.setNegative(cacheKey);
+            circuitBreaker.recordFailure(platform);
+            return null;
+        }
+    }
+
+    /**
+     * Process a single URL string (convenience method for /embed command)
+     * @param url The URL string to process
+     */
+    async processUrlString(url: string): Promise<EmbedData | null> {
+        const matched = urlMatcher.matchUrl(url);
+        if (!matched) return null;
+        return this.processUrl(matched);
+    }
+
+    /**
+     * Send embed response to a message
+     */
+    private async sendEmbedResponse(
+        message: Message,
+        embedDataList: EmbedData[],
+        skippedCount: number
+    ): Promise<void> {
+        const embeds: EmbedBuilder[] = [];
+        const urlRewrites: string[] = [];
+
+        for (const data of embedDataList) {
+            if (data._useUrlRewrite && data._rewrittenUrl) {
+                // URL rewrite approach (Pixiv, Instagram)
+                urlRewrites.push(data._rewrittenUrl);
+            } else {
+                // Custom embed approach (Twitter)
+                embeds.push(this.buildEmbed(data));
+            }
+        }
+
+        // Build content string
+        let content = '';
+        if (urlRewrites.length > 0) {
+            content = urlRewrites.join('\n');
+        }
+        if (skippedCount > 0) {
+            content += content ? '\n' : '';
+            content += `...and ${skippedCount} more ${skippedCount === 1 ? 'link' : 'links'}`;
+        }
+
+        // Create bookmark button
+        const row = this.createBookmarkButton(message.id);
+
+        try {
+            // Suppress the original message's embeds
+            if (message.embeds.length > 0 || message.content.includes('http')) {
+                await message.suppressEmbeds(true).catch(() => {
+                    // Ignore if we can't suppress embeds (missing permissions)
+                });
+            }
+
+            // Send the fixed embed(s)
+            await message.reply({
+                content: content || undefined,
+                embeds: embeds.length > 0 ? embeds : undefined,
+                components: embeds.length > 0 ? [row] : undefined,
+                allowedMentions: { repliedUser: false },
+            });
+        } catch (error) {
+            if (message.guild) {
+                logError(message.guild.id, message.guild.name, error as Error, 'EmbedFix.sendEmbedResponse');
+            }
+        }
+    }
+
+    /**
+     * Build a Discord embed from embed data
+     */
+    buildEmbed(data: EmbedData): EmbedBuilder {
+        const embed = new EmbedBuilder()
+            .setColor(data.color)
+            .setURL(data.originalUrl)
+            .setFooter({
+                text: `${data.author.name} (@${data.author.username})`,
+            });
+
+        // Set timestamp if available
+        if (data.timestamp) {
+            embed.setTimestamp(new Date(data.timestamp));
+        }
+
+        // Set author with icon if available
+        if (data.author.iconUrl) {
+            embed.setAuthor({
+                name: data.author.name,
+                url: data.author.url,
+                iconURL: data.author.iconUrl,
+            });
+        } else {
+            embed.setAuthor({
+                name: data.author.name,
+                url: data.author.url,
+            });
+        }
+
+        // Set description (tweet text, etc.)
+        if (data.description) {
+            embed.setDescription(data.description.slice(0, 4096));
+        }
+
+        // Set image (first image only in main embed)
+        if (data.images.length > 0) {
+            embed.setImage(data.images[0]);
+        }
+
+        // Set title if available
+        if (data.title) {
+            embed.setTitle(data.title.slice(0, 256));
+        }
+
+        return embed;
+    }
+
+    /**
+     * Create bookmark button row
+     */
+    createBookmarkButton(messageId: string): ActionRowBuilder<ButtonBuilder> {
+        return new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`embed_save:${messageId}`)
+                .setLabel('Save')
+                .setEmoji('🔖')
+                .setStyle(ButtonStyle.Secondary)
+        );
+    }
+
+    /**
+     * Handle bookmark button interaction
+     */
+    async handleBookmarkInteraction(interaction: ButtonInteraction): Promise<void> {
+        try {
+            const originalMessage = interaction.message;
+            const embed = originalMessage.embeds[0];
+
+            if (!embed?.url) {
+                await interaction.reply({
+                    content: 'Could not find the original link.',
+                    flags: MessageFlags.Ephemeral,
+                });
+                return;
+            }
+
+            // Send DM with the saved link
+            await interaction.user.send({
+                content: `**Saved Link**\n${embed.url}`,
+                embeds: [EmbedBuilder.from(embed)],
+            });
+
+            await interaction.reply({
+                content: 'Link saved to your DMs!',
+                flags: MessageFlags.Ephemeral,
+            });
+        } catch (error) {
+            await interaction.reply({
+                content: 'Could not send DM. Please check your privacy settings.',
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+    }
+
+    /**
+     * Check if a URL is supported
+     */
+    isUrlSupported(url: string): boolean {
+        return urlMatcher.matchUrl(url) !== null;
+    }
+
+    /**
+     * Get supported platforms
+     */
+    getSupportedPlatforms(): string[] {
+        return urlMatcher.getHandlers().map(h => h.platform);
+    }
+}
+
+// Export singleton getter
+export function getEmbedFixService(): EmbedFixService {
+    return EmbedFixService.getInstance();
+}
+
+// Export for message handler hook
+export async function checkEmbedFixUrls(message: Message): Promise<void> {
+    // Fast path checks
+    if (!message.content.includes('http')) return;
+    if (message.author.bot) return;
+    if (!message.guild) return;
+
+    // Fire-and-forget - errors are logged internally
+    getEmbedFixService().processMessage(message).catch(err => {
+        if (message.guild) {
+            logError(message.guild.id, message.guild.name, err as Error, 'EmbedFix');
+        }
+    });
+}

--- a/src/services/embedFix/embedFixService.ts
+++ b/src/services/embedFix/embedFixService.ts
@@ -218,7 +218,7 @@ class EmbedFixService {
             .setColor(data.color)
             .setURL(data.originalUrl)
             .setFooter({
-                text: `${data.author.name} (@${data.author.username})`,
+                text: `${data.author.name} (@${data.author.username}) • Click DM to save`,
             });
 
         // Set timestamp if available
@@ -259,20 +259,20 @@ class EmbedFixService {
     }
 
     /**
-     * Create bookmark button row
+     * Create DM button row
      */
     createBookmarkButton(messageId: string): ActionRowBuilder<ButtonBuilder> {
         return new ActionRowBuilder<ButtonBuilder>().addComponents(
             new ButtonBuilder()
                 .setCustomId(`embed_save:${messageId}`)
-                .setLabel('Save')
-                .setEmoji('🔖')
+                .setLabel('DM')
+                .setEmoji('✉️')
                 .setStyle(ButtonStyle.Secondary)
         );
     }
 
     /**
-     * Handle bookmark button interaction
+     * Handle DM button interaction
      */
     async handleBookmarkInteraction(interaction: ButtonInteraction): Promise<void> {
         try {
@@ -294,7 +294,7 @@ class EmbedFixService {
             });
 
             await interaction.reply({
-                content: 'Link saved to your DMs!',
+                content: 'Sent to your DMs!',
                 flags: MessageFlags.Ephemeral,
             });
         } catch (error) {

--- a/src/services/embedFix/embedVotesService.ts
+++ b/src/services/embedFix/embedVotesService.ts
@@ -1,0 +1,408 @@
+/**
+ * Embed Votes Service
+ * Manages artwork votes with S3 persistence
+ */
+
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { s3Client, S3_BUCKET } from '../../utils/cdn/config';
+import { EMBED_FIX_CONFIG } from '../../utils/data/embedFixConfig';
+import {
+    ArtworkVotes,
+    EmbedPlatform,
+    EmbedVotesData,
+    GuildVoteData,
+    VotePeriodData,
+    VoteTimeAggregations,
+} from '../../utils/interfaces/EmbedFix.interface';
+
+const CURRENT_SCHEMA_VERSION = 1;
+
+class EmbedVotesService {
+    private static instance: EmbedVotesService;
+    private cache: EmbedVotesData | null = null;
+    private cacheExpiry: number = 0;
+
+    private constructor() {}
+
+    static getInstance(): EmbedVotesService {
+        if (!EmbedVotesService.instance) {
+            EmbedVotesService.instance = new EmbedVotesService();
+        }
+        return EmbedVotesService.instance;
+    }
+
+    /**
+     * Get votes data from S3 with caching
+     */
+    async getData(): Promise<EmbedVotesData> {
+        if (this.cache && Date.now() < this.cacheExpiry) {
+            return this.cache;
+        }
+
+        try {
+            const response = await s3Client.send(new GetObjectCommand({
+                Bucket: S3_BUCKET,
+                Key: EMBED_FIX_CONFIG.S3_VOTES_KEY,
+            }));
+
+            const bodyContents = await response.Body?.transformToString();
+            if (!bodyContents) {
+                return this.getDefaultData();
+            }
+
+            this.cache = JSON.parse(bodyContents) as EmbedVotesData;
+            this.cacheExpiry = Date.now() + EMBED_FIX_CONFIG.VOTES_CACHE_TTL;
+            return this.cache;
+        } catch (error: any) {
+            if (error.name === 'NoSuchKey' || error.Code === 'NoSuchKey') {
+                console.log(`[EmbedVotes] Data file not found, creating default...`);
+                const defaultData = this.getDefaultData();
+                await this.saveData(defaultData);
+                return defaultData;
+            }
+            console.error('[EmbedVotes] Error fetching data:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Save votes data to S3 and update cache
+     */
+    async saveData(data: EmbedVotesData): Promise<void> {
+        data.lastUpdated = new Date().toISOString();
+
+        await s3Client.send(new PutObjectCommand({
+            Bucket: S3_BUCKET,
+            Key: EMBED_FIX_CONFIG.S3_VOTES_KEY,
+            Body: JSON.stringify(data, null, 2),
+            ContentType: 'application/json',
+        }));
+
+        this.cache = data;
+        this.cacheExpiry = Date.now() + EMBED_FIX_CONFIG.VOTES_CACHE_TTL;
+    }
+
+    /**
+     * Get default empty data structure
+     */
+    private getDefaultData(): EmbedVotesData {
+        const now = new Date().toISOString();
+        return {
+            votes: {},
+            timeAggregations: this.getDefaultTimeAggregations(now),
+            schemaVersion: CURRENT_SCHEMA_VERSION,
+            lastUpdated: now,
+        };
+    }
+
+    /**
+     * Get default time aggregations
+     */
+    private getDefaultTimeAggregations(now: string): VoteTimeAggregations {
+        const emptyPeriod: VotePeriodData = {
+            byGuild: {},
+            global: 0,
+            topArtwork: [],
+            topArtists: {},
+        };
+
+        return {
+            weekly: { ...emptyPeriod },
+            monthly: { ...emptyPeriod },
+            yearly: { ...emptyPeriod },
+            lastReset: {
+                weekly: now,
+                monthly: now,
+                yearly: now,
+            },
+        };
+    }
+
+    /**
+     * Toggle a vote for an artwork (add if not voted, remove if already voted)
+     * Returns the new guild vote count
+     */
+    async toggleVote(
+        artworkId: string,
+        guildId: string,
+        userId: string
+    ): Promise<{ added: boolean; newCount: number }> {
+        const data = await this.getData();
+        const artwork = data.votes[artworkId];
+
+        if (!artwork) {
+            // Artwork not found - shouldn't happen if recordArtwork was called
+            console.warn(`[EmbedVotes] Artwork ${artworkId} not found for voting`);
+            return { added: false, newCount: 0 };
+        }
+
+        const guildData = artwork.guildVotes[guildId];
+        if (!guildData) {
+            console.warn(`[EmbedVotes] Guild ${guildId} not found for artwork ${artworkId}`);
+            return { added: false, newCount: 0 };
+        }
+
+        const voterIndex = guildData.voters.indexOf(userId);
+        const wasVoted = voterIndex !== -1;
+
+        if (wasVoted) {
+            // Remove vote
+            guildData.voters.splice(voterIndex, 1);
+            guildData.voteCount--;
+            artwork.globalVoteCount--;
+
+            // Update time aggregations (decrement)
+            this.updateTimeAggregations(data, guildId, artwork.artistUsername, -1);
+        } else {
+            // Add vote
+            guildData.voters.push(userId);
+            guildData.voteCount++;
+            artwork.globalVoteCount++;
+            artwork.lastVotedAt = new Date().toISOString();
+
+            // Update time aggregations (increment)
+            this.updateTimeAggregations(data, guildId, artwork.artistUsername, 1);
+        }
+
+        await this.saveData(data);
+
+        return {
+            added: !wasVoted,
+            newCount: guildData.voteCount,
+        };
+    }
+
+    /**
+     * Update time-based aggregations when a vote changes
+     */
+    private updateTimeAggregations(
+        data: EmbedVotesData,
+        guildId: string,
+        artistUsername: string,
+        delta: number
+    ): void {
+        const periods: Array<'weekly' | 'monthly' | 'yearly'> = ['weekly', 'monthly', 'yearly'];
+
+        for (const period of periods) {
+            const periodData = data.timeAggregations[period];
+
+            // Update guild count
+            periodData.byGuild[guildId] = (periodData.byGuild[guildId] || 0) + delta;
+            if (periodData.byGuild[guildId] <= 0) {
+                delete periodData.byGuild[guildId];
+            }
+
+            // Update global count
+            periodData.global += delta;
+
+            // Update artist count
+            periodData.topArtists[artistUsername] = (periodData.topArtists[artistUsername] || 0) + delta;
+            if (periodData.topArtists[artistUsername] <= 0) {
+                delete periodData.topArtists[artistUsername];
+            }
+        }
+    }
+
+    /**
+     * Get vote count for an artwork
+     */
+    async getVoteCount(artworkId: string, guildId?: string): Promise<number> {
+        const data = await this.getData();
+        const artwork = data.votes[artworkId];
+
+        if (!artwork) return 0;
+
+        if (guildId) {
+            return artwork.guildVotes[guildId]?.voteCount || 0;
+        }
+
+        return artwork.globalVoteCount;
+    }
+
+    /**
+     * Check if a user has voted for an artwork in a guild
+     */
+    async hasUserVoted(artworkId: string, guildId: string, userId: string): Promise<boolean> {
+        const data = await this.getData();
+        const artwork = data.votes[artworkId];
+
+        if (!artwork) return false;
+
+        const guildData = artwork.guildVotes[guildId];
+        if (!guildData) return false;
+
+        return guildData.voters.includes(userId);
+    }
+
+    /**
+     * Record a new artwork when it's first shared
+     */
+    async recordArtwork(
+        artworkId: string,
+        details: {
+            originalUrl: string;
+            platform: EmbedPlatform;
+            artistUsername: string;
+            artistName: string;
+            guildId: string;
+            channelId: string;
+            messageId: string;
+            sharedBy: string;
+        }
+    ): Promise<void> {
+        const data = await this.getData();
+        const now = new Date().toISOString();
+
+        // Check if artwork already exists
+        if (!data.votes[artworkId]) {
+            // New artwork
+            data.votes[artworkId] = {
+                artworkId,
+                originalUrl: details.originalUrl,
+                platform: details.platform,
+                artistUsername: details.artistUsername,
+                artistName: details.artistName,
+                guildVotes: {},
+                globalVoteCount: 0,
+                firstSharedAt: now,
+                lastVotedAt: now,
+            };
+        }
+
+        // Add guild entry if not exists
+        if (!data.votes[artworkId].guildVotes[details.guildId]) {
+            data.votes[artworkId].guildVotes[details.guildId] = {
+                voters: [],
+                voteCount: 0,
+                sharedBy: details.sharedBy,
+                sharedAt: now,
+                messageId: details.messageId,
+                channelId: details.channelId,
+            };
+        }
+
+        await this.saveData(data);
+    }
+
+    /**
+     * Get stats for a specific period
+     */
+    async getStats(
+        guildId: string,
+        period: 'weekly' | 'monthly' | 'yearly' | 'alltime'
+    ): Promise<{
+        guildVotes: number;
+        globalVotes: number;
+        topArtwork: ArtworkVotes[];
+        topArtists: Array<{ username: string; votes: number }>;
+    }> {
+        const data = await this.getData();
+
+        if (period === 'alltime') {
+            // Calculate all-time stats from raw vote data
+            let guildVotes = 0;
+            let globalVotes = 0;
+            const artistVotes: Record<string, number> = {};
+            const artworkList: ArtworkVotes[] = [];
+
+            for (const artwork of Object.values(data.votes)) {
+                globalVotes += artwork.globalVoteCount;
+                artworkList.push(artwork);
+
+                // Artist aggregation
+                artistVotes[artwork.artistUsername] = (artistVotes[artwork.artistUsername] || 0) + artwork.globalVoteCount;
+
+                // Guild-specific count
+                if (artwork.guildVotes[guildId]) {
+                    guildVotes += artwork.guildVotes[guildId].voteCount;
+                }
+            }
+
+            // Sort artwork by global votes
+            artworkList.sort((a, b) => b.globalVoteCount - a.globalVoteCount);
+
+            // Sort artists by votes
+            const topArtists = Object.entries(artistVotes)
+                .map(([username, votes]) => ({ username, votes }))
+                .sort((a, b) => b.votes - a.votes)
+                .slice(0, 10);
+
+            return {
+                guildVotes,
+                globalVotes,
+                topArtwork: artworkList.slice(0, 10),
+                topArtists,
+            };
+        }
+
+        // Time-based stats
+        const periodData = data.timeAggregations[period];
+
+        // Get top artwork for period
+        const topArtwork = periodData.topArtwork
+            .map(id => data.votes[id])
+            .filter(Boolean)
+            .slice(0, 10);
+
+        // Get top artists for period
+        const topArtists = Object.entries(periodData.topArtists)
+            .map(([username, votes]) => ({ username, votes }))
+            .sort((a, b) => b.votes - a.votes)
+            .slice(0, 10);
+
+        return {
+            guildVotes: periodData.byGuild[guildId] || 0,
+            globalVotes: periodData.global,
+            topArtwork,
+            topArtists,
+        };
+    }
+
+    /**
+     * Reset a time period (called by cron job)
+     */
+    async resetPeriod(period: 'weekly' | 'monthly' | 'yearly'): Promise<void> {
+        const data = await this.getData();
+        const now = new Date().toISOString();
+
+        data.timeAggregations[period] = {
+            byGuild: {},
+            global: 0,
+            topArtwork: [],
+            topArtists: {},
+        };
+        data.timeAggregations.lastReset[period] = now;
+
+        await this.saveData(data);
+        console.log(`[EmbedVotes] Reset ${period} aggregations`);
+    }
+
+    /**
+     * Generate artwork ID from platform and URL
+     */
+    static generateArtworkId(platform: EmbedPlatform, url: string): string {
+        // Extract ID based on platform
+        if (platform === 'twitter') {
+            const match = url.match(/status\/(\d+)/);
+            return match ? `twitter:${match[1]}` : `twitter:${url}`;
+        }
+        // Add more platforms as needed
+        return `${platform}:${url}`;
+    }
+
+    /**
+     * Invalidate cache (for testing)
+     */
+    invalidateCache(): void {
+        this.cache = null;
+        this.cacheExpiry = 0;
+    }
+}
+
+// Export singleton getter
+export function getEmbedVotesService(): EmbedVotesService {
+    return EmbedVotesService.getInstance();
+}
+
+// Export class for testing
+export { EmbedVotesService };

--- a/src/services/embedFix/handlers/baseHandler.ts
+++ b/src/services/embedFix/handlers/baseHandler.ts
@@ -1,0 +1,66 @@
+/**
+ * Base class for platform-specific embed handlers
+ * Provides common functionality and defines the contract for handlers
+ */
+
+import { EMBED_FIX_CONFIG } from '../../../utils/data/embedFixConfig';
+import { EmbedData, EmbedPlatform, PlatformHandler } from '../../../utils/interfaces/EmbedFix.interface';
+
+export abstract class BaseHandler implements PlatformHandler {
+    abstract platform: EmbedPlatform;
+    abstract patterns: RegExp[];
+
+    /**
+     * Match a URL against this handler's patterns
+     * @param url The URL to match
+     * @returns The regex match array if matched, null otherwise
+     */
+    match(url: string): RegExpMatchArray | null {
+        for (const pattern of this.patterns) {
+            const match = url.match(pattern);
+            if (match) {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Fetch embed data from the platform's API
+     * Must be implemented by subclasses
+     */
+    abstract fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null>;
+
+    /**
+     * Fetch with timeout helper
+     * @param url The URL to fetch
+     * @param timeout Timeout in ms (defaults to config)
+     */
+    protected async fetchWithTimeout(
+        url: string,
+        timeout: number = EMBED_FIX_CONFIG.API_TIMEOUT_MS
+    ): Promise<Response> {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+        try {
+            const response = await fetch(url, {
+                signal: controller.signal,
+                headers: {
+                    'User-Agent': 'RapiBot/1.0 (Discord Bot)',
+                },
+            });
+            return response;
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+
+    /**
+     * Generate a cache key for this platform
+     * @param identifier Unique identifier (e.g., tweet ID, artwork ID)
+     */
+    protected getCacheKey(identifier: string): string {
+        return `${this.platform}:${identifier}`;
+    }
+}

--- a/src/services/embedFix/handlers/instagramHandler.ts
+++ b/src/services/embedFix/handlers/instagramHandler.ts
@@ -1,0 +1,46 @@
+/**
+ * Instagram Handler
+ * Uses URL rewrite approach with ddinstagram.com proxy
+ */
+
+import { EMBED_FIX_CONFIG } from '../../../utils/data/embedFixConfig';
+import { EmbedData, EmbedPlatform } from '../../../utils/interfaces/EmbedFix.interface';
+import { BaseHandler } from './baseHandler';
+
+export class InstagramHandler extends BaseHandler {
+    platform: EmbedPlatform = 'instagram';
+
+    patterns: RegExp[] = [
+        // Post URLs
+        /https?:\/\/(www\.)?instagram\.com\/p\/([A-Za-z0-9_-]+)/i,
+        // Reel URLs
+        /https?:\/\/(www\.)?instagram\.com\/reel\/([A-Za-z0-9_-]+)/i,
+        // TV URLs
+        /https?:\/\/(www\.)?instagram\.com\/tv\/([A-Za-z0-9_-]+)/i,
+        // Already-fixed ddinstagram URLs
+        /https?:\/\/(www\.)?ddinstagram\.com\/(p|reel|tv)\/([A-Za-z0-9_-]+)/i,
+    ];
+
+    async fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null> {
+        // Rewrite instagram.com to ddinstagram.com
+        const rewrittenUrl = url
+            .replace(/instagram\.com/, EMBED_FIX_CONFIG.INSTAGRAM_PROXY)
+            .replace(/www\./, '');
+
+        return {
+            platform: 'instagram',
+            author: {
+                name: 'Instagram',
+                username: 'instagram',
+                url: url,
+            },
+            images: [],
+            color: EMBED_FIX_CONFIG.EMBED_COLOR_INSTAGRAM,
+            originalUrl: url,
+            _useUrlRewrite: true,
+            _rewrittenUrl: rewrittenUrl,
+        };
+    }
+}
+
+export const instagramHandler = new InstagramHandler();

--- a/src/services/embedFix/handlers/pixivHandler.ts
+++ b/src/services/embedFix/handlers/pixivHandler.ts
@@ -1,0 +1,66 @@
+/**
+ * Pixiv Handler
+ * Uses URL rewrite approach with phixiv.net proxy
+ */
+
+import { EMBED_FIX_CONFIG } from '../../../utils/data/embedFixConfig';
+import { EmbedData, EmbedPlatform } from '../../../utils/interfaces/EmbedFix.interface';
+import { BaseHandler } from './baseHandler';
+
+export class PixivHandler extends BaseHandler {
+    platform: EmbedPlatform = 'pixiv';
+
+    patterns: RegExp[] = [
+        // Standard artwork URLs
+        /https?:\/\/(www\.)?pixiv\.net\/(en\/)?artworks\/(\d+)/i,
+        // Legacy illustration URLs
+        /https?:\/\/(www\.)?pixiv\.net\/member_illust\.php\?.*illust_id=(\d+)/i,
+        // Phixiv proxy URLs (already fixed)
+        /https?:\/\/(www\.)?phixiv\.net\/artworks\/(\d+)/i,
+    ];
+
+    async fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null> {
+        // Extract artwork ID from different URL patterns
+        const artworkId = this.extractArtworkId(match, url);
+        if (!artworkId) {
+            console.log(`[PixivHandler] Could not extract artwork ID from ${url}`);
+            return null;
+        }
+
+        // Use URL rewrite approach - phixiv.net handles the embed
+        const rewrittenUrl = `${EMBED_FIX_CONFIG.PIXIV_PROXY}/artworks/${artworkId}`;
+
+        return {
+            platform: 'pixiv',
+            author: {
+                name: 'Pixiv Artist',
+                username: 'pixiv',
+                url: url,
+            },
+            images: [],
+            color: EMBED_FIX_CONFIG.EMBED_COLOR_PIXIV,
+            originalUrl: url,
+            _useUrlRewrite: true,
+            _rewrittenUrl: rewrittenUrl,
+        };
+    }
+
+    /**
+     * Extract artwork ID from various Pixiv URL formats
+     */
+    private extractArtworkId(match: RegExpMatchArray, url: string): string | null {
+        // Check for illust_id parameter in legacy URLs
+        const paramMatch = url.match(/illust_id=(\d+)/);
+        if (paramMatch) return paramMatch[1];
+
+        // Return last captured group that is numeric (artwork ID)
+        for (let i = match.length - 1; i >= 0; i--) {
+            if (match[i] && /^\d+$/.test(match[i])) {
+                return match[i];
+            }
+        }
+        return null;
+    }
+}
+
+export const pixivHandler = new PixivHandler();

--- a/src/services/embedFix/handlers/twitterHandler.ts
+++ b/src/services/embedFix/handlers/twitterHandler.ts
@@ -1,0 +1,138 @@
+/**
+ * Twitter/X Handler
+ * Uses FxTwitter API to fetch tweet data for embed generation
+ */
+
+import { EMBED_FIX_CONFIG } from '../../../utils/data/embedFixConfig';
+import { EmbedData, EmbedPlatform } from '../../../utils/interfaces/EmbedFix.interface';
+import { BaseHandler } from './baseHandler';
+
+interface FxTwitterAuthor {
+    name: string;
+    screen_name: string;
+    avatar_url?: string;
+    url?: string;
+}
+
+interface FxTwitterMedia {
+    photos?: Array<{ url: string }>;
+    videos?: Array<{ url: string; thumbnail_url?: string }>;
+}
+
+interface FxTwitterTweet {
+    text: string;
+    created_at?: string;
+    author: FxTwitterAuthor;
+    media?: FxTwitterMedia;
+    possibly_sensitive?: boolean;
+}
+
+interface FxTwitterResponse {
+    code: number;
+    message: string;
+    tweet?: FxTwitterTweet;
+}
+
+export class TwitterHandler extends BaseHandler {
+    platform: EmbedPlatform = 'twitter';
+
+    patterns: RegExp[] = [
+        // Standard twitter.com URLs
+        /https?:\/\/(www\.)?(twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/i,
+        // Mobile URLs
+        /https?:\/\/(mobile\.)?(twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/i,
+        // vxtwitter and fxtwitter URLs (already fixed, but we can enhance)
+        /https?:\/\/(www\.)?(vxtwitter\.com|fxtwitter\.com)\/(\w+)\/status\/(\d+)/i,
+    ];
+
+    async fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null> {
+        // Extract username and status ID from the match
+        // Pattern groups: [full, www?, domain, username, statusId]
+        const username = match[3];
+        const statusId = match[4];
+
+        if (!username || !statusId) {
+            console.log('[TwitterHandler] Could not extract username or statusId from URL:', url);
+            return null;
+        }
+
+        try {
+            const apiUrl = `${EMBED_FIX_CONFIG.TWITTER_API}/${username}/status/${statusId}`;
+            const response = await this.fetchWithTimeout(apiUrl);
+
+            if (!response.ok) {
+                console.log(`[TwitterHandler] API returned ${response.status} for ${url}`);
+                return null;
+            }
+
+            const data: FxTwitterResponse = await response.json();
+
+            if (data.code !== 200 || !data.tweet) {
+                console.log(`[TwitterHandler] Invalid response for ${url}:`, data.message);
+                return null;
+            }
+
+            const tweet = data.tweet;
+            const author = tweet.author;
+
+            // Extract images from media
+            const images: string[] = [];
+            if (tweet.media?.photos) {
+                for (const photo of tweet.media.photos) {
+                    if (photo.url) {
+                        images.push(photo.url);
+                    }
+                }
+            }
+
+            // Extract videos from media
+            const videos: Array<{ url: string; thumbnail?: string }> = [];
+            if (tweet.media?.videos) {
+                for (const video of tweet.media.videos) {
+                    if (video.url) {
+                        videos.push({
+                            url: video.url,
+                            thumbnail: video.thumbnail_url,
+                        });
+                    }
+                }
+            }
+
+            return {
+                platform: 'twitter',
+                description: tweet.text,
+                author: {
+                    name: author.name,
+                    username: author.screen_name,
+                    url: `https://twitter.com/${author.screen_name}`,
+                    iconUrl: author.avatar_url,
+                },
+                images,
+                videos: videos.length > 0 ? videos : undefined,
+                timestamp: tweet.created_at,
+                color: EMBED_FIX_CONFIG.EMBED_COLOR_TWITTER,
+                originalUrl: url,
+                isNsfw: tweet.possibly_sensitive,
+            };
+        } catch (error) {
+            if (error instanceof Error && error.name === 'AbortError') {
+                console.log(`[TwitterHandler] Request timed out for ${url}`);
+            } else {
+                console.error(`[TwitterHandler] Error fetching ${url}:`, error);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Get cache key for a Twitter URL
+     * @param match The regex match from the URL
+     */
+    getCacheKeyFromMatch(match: RegExpMatchArray): string {
+        const statusId = match[4];
+        return this.getCacheKey(statusId);
+    }
+}
+
+// Export singleton instance
+export const twitterHandler = new TwitterHandler();

--- a/src/services/embedFix/handlers/twitterHandler.ts
+++ b/src/services/embedFix/handlers/twitterHandler.ts
@@ -37,12 +37,12 @@ export class TwitterHandler extends BaseHandler {
     platform: EmbedPlatform = 'twitter';
 
     patterns: RegExp[] = [
-        // Standard twitter.com URLs
+        // Standard twitter.com and x.com URLs
         /https?:\/\/(www\.)?(twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/i,
         // Mobile URLs
         /https?:\/\/(mobile\.)?(twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/i,
-        // vxtwitter and fxtwitter URLs (already fixed, but we can enhance)
-        /https?:\/\/(www\.)?(vxtwitter\.com|fxtwitter\.com)\/(\w+)\/status\/(\d+)/i,
+        // Fixup services (vxtwitter, fxtwitter, fixupx, fixvx, twittpr, etc.)
+        /https?:\/\/(www\.)?(vxtwitter\.com|fxtwitter\.com|fixupx\.com|fixvx\.com|twittpr\.com)\/(\w+)\/status\/(\d+)/i,
     ];
 
     async fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null> {

--- a/src/services/embedFix/rateLimiter.ts
+++ b/src/services/embedFix/rateLimiter.ts
@@ -1,0 +1,129 @@
+/**
+ * Rate limiter for embed fix requests
+ * Limits requests per guild and per user to prevent spam
+ */
+
+import { EMBED_FIX_CONFIG } from '../../utils/data/embedFixConfig';
+import { RateLimitEntry } from '../../utils/interfaces/EmbedFix.interface';
+
+class EmbedFixRateLimiter {
+    private guildLimits: Map<string, RateLimitEntry> = new Map();
+    private userLimits: Map<string, RateLimitEntry> = new Map();
+    private cleanupInterval: NodeJS.Timeout | null = null;
+
+    constructor() {
+        // Clean up old entries every 5 minutes
+        this.cleanupInterval = setInterval(() => this.cleanup(), 5 * 60 * 1000);
+    }
+
+    /**
+     * Check if a request is allowed based on rate limits
+     * @param guildId The guild ID
+     * @param userId The user ID
+     * @returns true if request is allowed, false if rate limited
+     */
+    check(guildId: string, userId: string): boolean {
+        const now = Date.now();
+
+        // Check guild limit
+        if (!this.checkLimit(this.guildLimits, guildId, EMBED_FIX_CONFIG.GUILD_RATE_LIMIT, now)) {
+            return false;
+        }
+
+        // Check user limit
+        if (!this.checkLimit(this.userLimits, `${guildId}:${userId}`, EMBED_FIX_CONFIG.USER_RATE_LIMIT, now)) {
+            return false;
+        }
+
+        // Increment counters
+        this.incrementLimit(this.guildLimits, guildId, now);
+        this.incrementLimit(this.userLimits, `${guildId}:${userId}`, now);
+
+        return true;
+    }
+
+    /**
+     * Check a specific limit map
+     */
+    private checkLimit(map: Map<string, RateLimitEntry>, key: string, limit: number, now: number): boolean {
+        const entry = map.get(key);
+
+        if (!entry) {
+            return true;
+        }
+
+        // Check if window has expired
+        if (now - entry.windowStart >= EMBED_FIX_CONFIG.RATE_WINDOW_MS) {
+            return true;
+        }
+
+        // Check if under limit
+        return entry.count < limit;
+    }
+
+    /**
+     * Increment the counter for a limit
+     */
+    private incrementLimit(map: Map<string, RateLimitEntry>, key: string, now: number): void {
+        const entry = map.get(key);
+
+        if (!entry || now - entry.windowStart >= EMBED_FIX_CONFIG.RATE_WINDOW_MS) {
+            // Start new window
+            map.set(key, { count: 1, windowStart: now });
+        } else {
+            // Increment existing window
+            entry.count++;
+        }
+    }
+
+    /**
+     * Clean up expired entries to prevent memory leaks
+     */
+    private cleanup(): void {
+        const now = Date.now();
+        const expiredThreshold = now - EMBED_FIX_CONFIG.RATE_WINDOW_MS;
+
+        for (const [key, entry] of this.guildLimits) {
+            if (entry.windowStart < expiredThreshold) {
+                this.guildLimits.delete(key);
+            }
+        }
+
+        for (const [key, entry] of this.userLimits) {
+            if (entry.windowStart < expiredThreshold) {
+                this.userLimits.delete(key);
+            }
+        }
+    }
+
+    /**
+     * Get current stats (for debugging/monitoring)
+     */
+    getStats(): { guildEntries: number; userEntries: number } {
+        return {
+            guildEntries: this.guildLimits.size,
+            userEntries: this.userLimits.size,
+        };
+    }
+
+    /**
+     * Clear all rate limits (for testing)
+     */
+    clear(): void {
+        this.guildLimits.clear();
+        this.userLimits.clear();
+    }
+
+    /**
+     * Stop the cleanup interval (for graceful shutdown)
+     */
+    destroy(): void {
+        if (this.cleanupInterval) {
+            clearInterval(this.cleanupInterval);
+            this.cleanupInterval = null;
+        }
+    }
+}
+
+// Export singleton instance
+export const embedFixRateLimiter = new EmbedFixRateLimiter();

--- a/src/services/embedFix/tests/circuitBreaker.test.ts
+++ b/src/services/embedFix/tests/circuitBreaker.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Mock the config before importing
+vi.mock('../../../utils/data/embedFixConfig', () => ({
+    EMBED_FIX_CONFIG: {
+        CIRCUIT_BREAKER_THRESHOLD: 3,
+        CIRCUIT_BREAKER_TIMEOUT: 1000, // 1 second for testing
+    },
+}));
+
+// Import after mocking
+import { circuitBreaker } from '../circuitBreaker';
+
+describe('CircuitBreaker', () => {
+    beforeEach(() => {
+        circuitBreaker.reset();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('isOpen', () => {
+        it('should return false for new platform', () => {
+            expect(circuitBreaker.isOpen('twitter')).toBe(false);
+        });
+
+        it('should return false when failures below threshold', () => {
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            expect(circuitBreaker.isOpen('twitter')).toBe(false);
+        });
+
+        it('should return true when failures reach threshold', () => {
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            expect(circuitBreaker.isOpen('twitter')).toBe(true);
+        });
+
+        it('should return false after timeout (half-open state)', () => {
+            // Open the circuit
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            expect(circuitBreaker.isOpen('twitter')).toBe(true);
+
+            // Advance past timeout
+            vi.advanceTimersByTime(1100);
+
+            // Should be half-open now
+            expect(circuitBreaker.isOpen('twitter')).toBe(false);
+        });
+    });
+
+    describe('recordSuccess', () => {
+        it('should reset failures', () => {
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordSuccess('twitter');
+
+            const state = circuitBreaker.getState('twitter');
+            expect(state?.failures).toBe(0);
+            expect(state?.isOpen).toBe(false);
+        });
+
+        it('should close the circuit after being open', () => {
+            // Open the circuit
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            expect(circuitBreaker.isOpen('twitter')).toBe(true);
+
+            // Wait for half-open state
+            vi.advanceTimersByTime(1100);
+            expect(circuitBreaker.isOpen('twitter')).toBe(false);
+
+            // Success closes the circuit
+            circuitBreaker.recordSuccess('twitter');
+            expect(circuitBreaker.isOpen('twitter')).toBe(false);
+
+            const state = circuitBreaker.getState('twitter');
+            expect(state?.failures).toBe(0);
+        });
+    });
+
+    describe('recordFailure', () => {
+        it('should increment failure count', () => {
+            circuitBreaker.recordFailure('twitter');
+            const state = circuitBreaker.getState('twitter');
+            expect(state?.failures).toBe(1);
+        });
+
+        it('should open circuit at threshold', () => {
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+
+            const state = circuitBreaker.getState('twitter');
+            expect(state?.isOpen).toBe(true);
+            expect(state?.openUntil).toBeGreaterThan(Date.now());
+        });
+    });
+
+    describe('platform isolation', () => {
+        it('should track platforms independently', () => {
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+
+            expect(circuitBreaker.isOpen('twitter')).toBe(true);
+            expect(circuitBreaker.isOpen('pixiv')).toBe(false);
+        });
+    });
+
+    describe('resetPlatform', () => {
+        it('should reset a specific platform', () => {
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('pixiv');
+
+            circuitBreaker.resetPlatform('twitter');
+
+            expect(circuitBreaker.getState('twitter')).toBeUndefined();
+            expect(circuitBreaker.getState('pixiv')).toBeDefined();
+        });
+    });
+
+    describe('reset', () => {
+        it('should reset all platforms', () => {
+            circuitBreaker.recordFailure('twitter');
+            circuitBreaker.recordFailure('pixiv');
+            circuitBreaker.recordFailure('instagram');
+
+            circuitBreaker.reset();
+
+            expect(circuitBreaker.getState('twitter')).toBeUndefined();
+            expect(circuitBreaker.getState('pixiv')).toBeUndefined();
+            expect(circuitBreaker.getState('instagram')).toBeUndefined();
+        });
+    });
+});

--- a/src/services/embedFix/tests/embedCache.test.ts
+++ b/src/services/embedFix/tests/embedCache.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Mock the config before importing
+vi.mock('../../../utils/data/embedFixConfig', () => ({
+    EMBED_FIX_CONFIG: {
+        EMBED_CACHE_TTL: 1000, // 1 second for testing
+        EMBED_CACHE_MAX_SIZE: 3,
+        NEGATIVE_CACHE_TTL: 500, // 0.5 second for testing
+    },
+}));
+
+// Import after mocking
+import { embedCache } from '../embedCache';
+import { EmbedData } from '../../../utils/interfaces/EmbedFix.interface';
+
+describe('EmbedCache', () => {
+    const createMockEmbedData = (id: string): EmbedData => ({
+        platform: 'twitter',
+        author: {
+            name: `Test Author ${id}`,
+            username: `testuser${id}`,
+            url: `https://twitter.com/testuser${id}`,
+        },
+        images: ['https://example.com/image.jpg'],
+        color: 0x1DA1F2,
+        originalUrl: `https://twitter.com/test/status/${id}`,
+    });
+
+    beforeEach(() => {
+        embedCache.clear();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('get/set', () => {
+        it('should store and retrieve embed data', () => {
+            const data = createMockEmbedData('1');
+            embedCache.set('twitter:1', data);
+
+            const retrieved = embedCache.get('twitter:1');
+            expect(retrieved).toEqual(data);
+        });
+
+        it('should return null for non-existent key', () => {
+            expect(embedCache.get('nonexistent')).toBeNull();
+        });
+
+        it('should return null for expired entries', () => {
+            const data = createMockEmbedData('1');
+            embedCache.set('twitter:1', data);
+
+            // Advance time past TTL
+            vi.advanceTimersByTime(1100);
+
+            expect(embedCache.get('twitter:1')).toBeNull();
+        });
+
+        it('should enforce max size by removing oldest entries', () => {
+            embedCache.set('twitter:1', createMockEmbedData('1'));
+            embedCache.set('twitter:2', createMockEmbedData('2'));
+            embedCache.set('twitter:3', createMockEmbedData('3'));
+            embedCache.set('twitter:4', createMockEmbedData('4')); // Should evict twitter:1
+
+            expect(embedCache.get('twitter:1')).toBeNull();
+            expect(embedCache.get('twitter:2')).not.toBeNull();
+            expect(embedCache.get('twitter:3')).not.toBeNull();
+            expect(embedCache.get('twitter:4')).not.toBeNull();
+        });
+    });
+
+    describe('negative cache', () => {
+        it('should mark key as negatively cached', () => {
+            embedCache.setNegative('twitter:failed');
+            expect(embedCache.isNegativelyCached('twitter:failed')).toBe(true);
+        });
+
+        it('should return false for non-negative cached keys', () => {
+            expect(embedCache.isNegativelyCached('twitter:unknown')).toBe(false);
+        });
+
+        it('should expire negative cache entries', () => {
+            embedCache.setNegative('twitter:failed');
+            expect(embedCache.isNegativelyCached('twitter:failed')).toBe(true);
+
+            // Advance time past negative cache TTL
+            vi.advanceTimersByTime(600);
+
+            expect(embedCache.isNegativelyCached('twitter:failed')).toBe(false);
+        });
+    });
+
+    describe('delete', () => {
+        it('should delete entry from positive cache', () => {
+            embedCache.set('twitter:1', createMockEmbedData('1'));
+            embedCache.delete('twitter:1');
+            expect(embedCache.get('twitter:1')).toBeNull();
+        });
+
+        it('should delete entry from negative cache', () => {
+            embedCache.setNegative('twitter:failed');
+            embedCache.delete('twitter:failed');
+            expect(embedCache.isNegativelyCached('twitter:failed')).toBe(false);
+        });
+    });
+
+    describe('getStats', () => {
+        it('should return correct stats', () => {
+            embedCache.set('twitter:1', createMockEmbedData('1'));
+            embedCache.set('twitter:2', createMockEmbedData('2'));
+            embedCache.setNegative('twitter:failed1');
+            embedCache.setNegative('twitter:failed2');
+            embedCache.setNegative('twitter:failed3');
+
+            const stats = embedCache.getStats();
+            expect(stats.size).toBe(2);
+            expect(stats.negativeSize).toBe(3);
+            expect(stats.maxSize).toBe(3);
+        });
+    });
+
+    describe('clear', () => {
+        it('should clear all cache entries', () => {
+            embedCache.set('twitter:1', createMockEmbedData('1'));
+            embedCache.setNegative('twitter:failed');
+
+            embedCache.clear();
+
+            const stats = embedCache.getStats();
+            expect(stats.size).toBe(0);
+            expect(stats.negativeSize).toBe(0);
+        });
+    });
+});

--- a/src/services/embedFix/tests/embedVotesService.test.ts
+++ b/src/services/embedFix/tests/embedVotesService.test.ts
@@ -298,6 +298,27 @@ describe('EmbedVotesService', () => {
             expect(twitterId).toBe('twitter:123456789');
         });
 
+        it('should generate same ID for all Twitter/X fixup service URLs', () => {
+            const statusId = '123456789';
+            const urls = [
+                `https://twitter.com/user/status/${statusId}`,
+                `https://x.com/user/status/${statusId}`,
+                `https://vxtwitter.com/user/status/${statusId}`,
+                `https://fxtwitter.com/user/status/${statusId}`,
+                `https://fixupx.com/user/status/${statusId}`,
+                `https://fixvx.com/user/status/${statusId}`,
+                `https://twittpr.com/user/status/${statusId}`,
+            ];
+
+            const ids = urls.map(url => EmbedVotesService.generateArtworkId('twitter', url));
+
+            // All should generate the same ID
+            const expectedId = `twitter:${statusId}`;
+            ids.forEach((id, index) => {
+                expect(id).toBe(expectedId);
+            });
+        });
+
         it('should handle URL without status ID', () => {
             const id = EmbedVotesService.generateArtworkId('twitter', 'https://twitter.com/user');
             expect(id).toBe('twitter:https://twitter.com/user');

--- a/src/services/embedFix/tests/embedVotesService.test.ts
+++ b/src/services/embedFix/tests/embedVotesService.test.ts
@@ -291,6 +291,13 @@ describe('EmbedVotesService', () => {
             expect(id).toBe('twitter:123456789');
         });
 
+        it('should generate same ID for twitter.com and x.com URLs', () => {
+            const twitterId = EmbedVotesService.generateArtworkId('twitter', 'https://twitter.com/user/status/123456789');
+            const xId = EmbedVotesService.generateArtworkId('twitter', 'https://x.com/user/status/123456789');
+            expect(twitterId).toBe(xId);
+            expect(twitterId).toBe('twitter:123456789');
+        });
+
         it('should handle URL without status ID', () => {
             const id = EmbedVotesService.generateArtworkId('twitter', 'https://twitter.com/user');
             expect(id).toBe('twitter:https://twitter.com/user');

--- a/src/services/embedFix/tests/embedVotesService.test.ts
+++ b/src/services/embedFix/tests/embedVotesService.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Mock S3 client
+vi.mock('../../../utils/cdn/config', () => ({
+    s3Client: {
+        send: vi.fn(),
+    },
+    S3_BUCKET: 'test-bucket',
+}));
+
+// Mock config
+vi.mock('../../../utils/data/embedFixConfig', () => ({
+    EMBED_FIX_CONFIG: {
+        S3_VOTES_KEY: 'data/embed-fix/test-votes.json',
+        VOTES_CACHE_TTL: 1000,
+    },
+}));
+
+import { s3Client } from '../../../utils/cdn/config';
+import { EmbedVotesService, getEmbedVotesService } from '../embedVotesService';
+import { EmbedVotesData } from '../../../utils/interfaces/EmbedFix.interface';
+
+describe('EmbedVotesService', () => {
+    let service: EmbedVotesService;
+    let mockData: EmbedVotesData;
+
+    beforeEach(() => {
+        // Reset singleton
+        (EmbedVotesService as any).instance = null;
+        service = getEmbedVotesService();
+        service.invalidateCache();
+
+        vi.mocked(s3Client.send).mockReset();
+
+        // Create mock data
+        const now = new Date().toISOString();
+        mockData = {
+            votes: {
+                'twitter:123456': {
+                    artworkId: 'twitter:123456',
+                    originalUrl: 'https://twitter.com/artist/status/123456',
+                    platform: 'twitter',
+                    artistUsername: 'artist',
+                    artistName: 'Test Artist',
+                    guildVotes: {
+                        'guild1': {
+                            voters: ['user1', 'user2'],
+                            voteCount: 2,
+                            sharedBy: 'user1',
+                            sharedAt: now,
+                            messageId: 'msg1',
+                            channelId: 'chan1',
+                        },
+                    },
+                    globalVoteCount: 2,
+                    firstSharedAt: now,
+                    lastVotedAt: now,
+                },
+            },
+            timeAggregations: {
+                weekly: { byGuild: { 'guild1': 2 }, global: 2, topArtwork: [], topArtists: { 'artist': 2 } },
+                monthly: { byGuild: { 'guild1': 2 }, global: 2, topArtwork: [], topArtists: { 'artist': 2 } },
+                yearly: { byGuild: { 'guild1': 2 }, global: 2, topArtwork: [], topArtists: { 'artist': 2 } },
+                lastReset: { weekly: now, monthly: now, yearly: now },
+            },
+            schemaVersion: 1,
+            lastUpdated: now,
+        };
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('getData', () => {
+        it('should fetch data from S3', async () => {
+            vi.mocked(s3Client.send).mockResolvedValueOnce({
+                Body: {
+                    transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                },
+            } as any);
+
+            const data = await service.getData();
+            expect(data).toEqual(mockData);
+            expect(s3Client.send).toHaveBeenCalledTimes(1);
+        });
+
+        it('should return cached data on subsequent calls', async () => {
+            vi.mocked(s3Client.send).mockResolvedValueOnce({
+                Body: {
+                    transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                },
+            } as any);
+
+            await service.getData();
+            await service.getData();
+
+            expect(s3Client.send).toHaveBeenCalledTimes(1);
+        });
+
+        it('should create default data if file not found', async () => {
+            vi.mocked(s3Client.send)
+                .mockRejectedValueOnce({ name: 'NoSuchKey' })
+                .mockResolvedValueOnce({} as any); // For saveData
+
+            const data = await service.getData();
+            expect(data.votes).toEqual({});
+            expect(data.schemaVersion).toBe(1);
+        });
+    });
+
+    describe('toggleVote', () => {
+        beforeEach(() => {
+            vi.mocked(s3Client.send)
+                .mockResolvedValueOnce({
+                    Body: {
+                        transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                    },
+                } as any)
+                .mockResolvedValue({} as any); // For saveData
+        });
+
+        it('should add vote when user has not voted', async () => {
+            const result = await service.toggleVote('twitter:123456', 'guild1', 'user3');
+
+            expect(result.added).toBe(true);
+            expect(result.newCount).toBe(3);
+        });
+
+        it('should remove vote when user has already voted', async () => {
+            const result = await service.toggleVote('twitter:123456', 'guild1', 'user1');
+
+            expect(result.added).toBe(false);
+            expect(result.newCount).toBe(1);
+        });
+
+        it('should return 0 count for non-existent artwork', async () => {
+            const result = await service.toggleVote('twitter:nonexistent', 'guild1', 'user1');
+
+            expect(result.added).toBe(false);
+            expect(result.newCount).toBe(0);
+        });
+    });
+
+    describe('getVoteCount', () => {
+        beforeEach(() => {
+            vi.mocked(s3Client.send).mockResolvedValue({
+                Body: {
+                    transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                },
+            } as any);
+        });
+
+        it('should return guild vote count when guildId provided', async () => {
+            const count = await service.getVoteCount('twitter:123456', 'guild1');
+            expect(count).toBe(2);
+        });
+
+        it('should return global vote count when no guildId', async () => {
+            const count = await service.getVoteCount('twitter:123456');
+            expect(count).toBe(2);
+        });
+
+        it('should return 0 for non-existent artwork', async () => {
+            const count = await service.getVoteCount('twitter:nonexistent');
+            expect(count).toBe(0);
+        });
+    });
+
+    describe('hasUserVoted', () => {
+        beforeEach(() => {
+            vi.mocked(s3Client.send).mockResolvedValue({
+                Body: {
+                    transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                },
+            } as any);
+        });
+
+        it('should return true when user has voted', async () => {
+            const hasVoted = await service.hasUserVoted('twitter:123456', 'guild1', 'user1');
+            expect(hasVoted).toBe(true);
+        });
+
+        it('should return false when user has not voted', async () => {
+            const hasVoted = await service.hasUserVoted('twitter:123456', 'guild1', 'user3');
+            expect(hasVoted).toBe(false);
+        });
+
+        it('should return false for non-existent artwork', async () => {
+            const hasVoted = await service.hasUserVoted('twitter:nonexistent', 'guild1', 'user1');
+            expect(hasVoted).toBe(false);
+        });
+    });
+
+    describe('recordArtwork', () => {
+        beforeEach(() => {
+            vi.mocked(s3Client.send)
+                .mockResolvedValueOnce({
+                    Body: {
+                        transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                    },
+                } as any)
+                .mockResolvedValue({} as any);
+        });
+
+        it('should create new artwork entry', async () => {
+            await service.recordArtwork('twitter:999999', {
+                originalUrl: 'https://twitter.com/new/status/999999',
+                platform: 'twitter',
+                artistUsername: 'newartist',
+                artistName: 'New Artist',
+                guildId: 'guild2',
+                channelId: 'chan2',
+                messageId: 'msg2',
+                sharedBy: 'user5',
+            });
+
+            // Verify saveData was called
+            expect(s3Client.send).toHaveBeenCalledTimes(2);
+        });
+
+        it('should add guild entry to existing artwork', async () => {
+            await service.recordArtwork('twitter:123456', {
+                originalUrl: 'https://twitter.com/artist/status/123456',
+                platform: 'twitter',
+                artistUsername: 'artist',
+                artistName: 'Test Artist',
+                guildId: 'guild2',
+                channelId: 'chan2',
+                messageId: 'msg2',
+                sharedBy: 'user5',
+            });
+
+            expect(s3Client.send).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('getStats', () => {
+        beforeEach(() => {
+            vi.mocked(s3Client.send).mockResolvedValue({
+                Body: {
+                    transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                },
+            } as any);
+        });
+
+        it('should return alltime stats', async () => {
+            const stats = await service.getStats('guild1', 'alltime');
+
+            expect(stats.guildVotes).toBe(2);
+            expect(stats.globalVotes).toBe(2);
+            expect(stats.topArtists.length).toBeGreaterThan(0);
+        });
+
+        it('should return weekly stats', async () => {
+            const stats = await service.getStats('guild1', 'weekly');
+
+            expect(stats.guildVotes).toBe(2);
+            expect(stats.globalVotes).toBe(2);
+        });
+
+        it('should return 0 for guild without votes', async () => {
+            const stats = await service.getStats('guild999', 'weekly');
+
+            expect(stats.guildVotes).toBe(0);
+        });
+    });
+
+    describe('resetPeriod', () => {
+        beforeEach(() => {
+            vi.mocked(s3Client.send)
+                .mockResolvedValueOnce({
+                    Body: {
+                        transformToString: () => Promise.resolve(JSON.stringify(mockData)),
+                    },
+                } as any)
+                .mockResolvedValue({} as any);
+        });
+
+        it('should reset weekly aggregations', async () => {
+            await service.resetPeriod('weekly');
+
+            // Verify saveData was called
+            expect(s3Client.send).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('generateArtworkId', () => {
+        it('should generate ID for Twitter URL', () => {
+            const id = EmbedVotesService.generateArtworkId('twitter', 'https://twitter.com/user/status/123456789');
+            expect(id).toBe('twitter:123456789');
+        });
+
+        it('should handle URL without status ID', () => {
+            const id = EmbedVotesService.generateArtworkId('twitter', 'https://twitter.com/user');
+            expect(id).toBe('twitter:https://twitter.com/user');
+        });
+    });
+
+    describe('singleton', () => {
+        it('should return same instance', () => {
+            const instance1 = getEmbedVotesService();
+            const instance2 = getEmbedVotesService();
+            expect(instance1).toBe(instance2);
+        });
+    });
+});

--- a/src/services/embedFix/tests/instagramHandler.test.ts
+++ b/src/services/embedFix/tests/instagramHandler.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InstagramHandler, instagramHandler } from '../handlers/instagramHandler';
+
+describe('InstagramHandler', () => {
+    let handler: InstagramHandler;
+
+    beforeEach(() => {
+        handler = new InstagramHandler();
+    });
+
+    describe('patterns', () => {
+        it('should match post URLs', () => {
+            const match = handler.match('https://instagram.com/p/ABC123xyz/');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match post URLs with www', () => {
+            const match = handler.match('https://www.instagram.com/p/ABC123xyz/');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match reel URLs', () => {
+            const match = handler.match('https://instagram.com/reel/XYZ789abc/');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match TV URLs', () => {
+            const match = handler.match('https://instagram.com/tv/DEF456ghi/');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match ddinstagram proxy URLs', () => {
+            const match = handler.match('https://ddinstagram.com/p/ABC123xyz/');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match ddinstagram reel URLs', () => {
+            const match = handler.match('https://ddinstagram.com/reel/XYZ789abc/');
+            expect(match).not.toBeNull();
+        });
+
+        it('should not match user profile URLs', () => {
+            const match = handler.match('https://instagram.com/username');
+            expect(match).toBeNull();
+        });
+
+        it('should not match story URLs', () => {
+            const match = handler.match('https://instagram.com/stories/username/123456');
+            expect(match).toBeNull();
+        });
+
+        it('should not match non-instagram URLs', () => {
+            const match = handler.match('https://example.com/p/ABC123xyz/');
+            expect(match).toBeNull();
+        });
+    });
+
+    describe('fetchEmbed', () => {
+        it('should return URL rewrite data for post URL', async () => {
+            const match = handler.match('https://instagram.com/p/ABC123xyz/')!;
+            const result = await handler.fetchEmbed(match, 'https://instagram.com/p/ABC123xyz/');
+
+            expect(result).not.toBeNull();
+            expect(result?.platform).toBe('instagram');
+            expect(result?._useUrlRewrite).toBe(true);
+            expect(result?._rewrittenUrl).toBe('https://ddinstagram.com/p/ABC123xyz/');
+            expect(result?.originalUrl).toBe('https://instagram.com/p/ABC123xyz/');
+        });
+
+        it('should return URL rewrite data for reel URL', async () => {
+            const match = handler.match('https://instagram.com/reel/XYZ789abc/')!;
+            const result = await handler.fetchEmbed(match, 'https://instagram.com/reel/XYZ789abc/');
+
+            expect(result?._rewrittenUrl).toBe('https://ddinstagram.com/reel/XYZ789abc/');
+        });
+
+        it('should strip www from URL', async () => {
+            const match = handler.match('https://www.instagram.com/p/ABC123xyz/')!;
+            const result = await handler.fetchEmbed(match, 'https://www.instagram.com/p/ABC123xyz/');
+
+            expect(result?._rewrittenUrl).toBe('https://ddinstagram.com/p/ABC123xyz/');
+        });
+
+        it('should have correct color', async () => {
+            const match = handler.match('https://instagram.com/p/ABC123xyz/')!;
+            const result = await handler.fetchEmbed(match, 'https://instagram.com/p/ABC123xyz/');
+
+            expect(result?.color).toBe(0xE1306C);
+        });
+    });
+
+    describe('singleton instance', () => {
+        it('should export a singleton instance', () => {
+            expect(instagramHandler).toBeInstanceOf(InstagramHandler);
+            expect(instagramHandler.platform).toBe('instagram');
+        });
+    });
+});

--- a/src/services/embedFix/tests/pixivHandler.test.ts
+++ b/src/services/embedFix/tests/pixivHandler.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PixivHandler, pixivHandler } from '../handlers/pixivHandler';
+
+describe('PixivHandler', () => {
+    let handler: PixivHandler;
+
+    beforeEach(() => {
+        handler = new PixivHandler();
+    });
+
+    describe('patterns', () => {
+        it('should match standard artwork URLs', () => {
+            const match = handler.match('https://pixiv.net/artworks/12345678');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match artwork URLs with www', () => {
+            const match = handler.match('https://www.pixiv.net/artworks/12345678');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match English artwork URLs', () => {
+            const match = handler.match('https://pixiv.net/en/artworks/12345678');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match legacy illustration URLs', () => {
+            const match = handler.match('https://pixiv.net/member_illust.php?mode=medium&illust_id=12345678');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match phixiv proxy URLs', () => {
+            const match = handler.match('https://phixiv.net/artworks/12345678');
+            expect(match).not.toBeNull();
+        });
+
+        it('should not match user profile URLs', () => {
+            const match = handler.match('https://pixiv.net/users/12345678');
+            expect(match).toBeNull();
+        });
+
+        it('should not match non-pixiv URLs', () => {
+            const match = handler.match('https://example.com/artworks/12345678');
+            expect(match).toBeNull();
+        });
+    });
+
+    describe('fetchEmbed', () => {
+        it('should return URL rewrite data for standard artwork URL', async () => {
+            const match = handler.match('https://pixiv.net/artworks/12345678')!;
+            const result = await handler.fetchEmbed(match, 'https://pixiv.net/artworks/12345678');
+
+            expect(result).not.toBeNull();
+            expect(result?.platform).toBe('pixiv');
+            expect(result?._useUrlRewrite).toBe(true);
+            expect(result?._rewrittenUrl).toBe('https://phixiv.net/artworks/12345678');
+            expect(result?.originalUrl).toBe('https://pixiv.net/artworks/12345678');
+        });
+
+        it('should return URL rewrite data for English artwork URL', async () => {
+            const match = handler.match('https://pixiv.net/en/artworks/87654321')!;
+            const result = await handler.fetchEmbed(match, 'https://pixiv.net/en/artworks/87654321');
+
+            expect(result?._rewrittenUrl).toBe('https://phixiv.net/artworks/87654321');
+        });
+
+        it('should return URL rewrite data for legacy URL', async () => {
+            const match = handler.match('https://pixiv.net/member_illust.php?illust_id=11111111')!;
+            const result = await handler.fetchEmbed(match, 'https://pixiv.net/member_illust.php?illust_id=11111111');
+
+            expect(result?._rewrittenUrl).toBe('https://phixiv.net/artworks/11111111');
+        });
+
+        it('should have correct color', async () => {
+            const match = handler.match('https://pixiv.net/artworks/12345678')!;
+            const result = await handler.fetchEmbed(match, 'https://pixiv.net/artworks/12345678');
+
+            expect(result?.color).toBe(0x0096FA);
+        });
+    });
+
+    describe('singleton instance', () => {
+        it('should export a singleton instance', () => {
+            expect(pixivHandler).toBeInstanceOf(PixivHandler);
+            expect(pixivHandler.platform).toBe('pixiv');
+        });
+    });
+});

--- a/src/services/embedFix/tests/rateLimiter.test.ts
+++ b/src/services/embedFix/tests/rateLimiter.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Mock the config before importing the rate limiter
+vi.mock('../../../utils/data/embedFixConfig', () => ({
+    EMBED_FIX_CONFIG: {
+        GUILD_RATE_LIMIT: 3,
+        USER_RATE_LIMIT: 2,
+        RATE_WINDOW_MS: 1000, // 1 second for testing
+    },
+}));
+
+// Import after mocking
+import { embedFixRateLimiter } from '../rateLimiter';
+
+describe('EmbedFixRateLimiter', () => {
+    beforeEach(() => {
+        embedFixRateLimiter.clear();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('check', () => {
+        it('should allow first request', () => {
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+        });
+
+        it('should allow requests within user limit', () => {
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+        });
+
+        it('should reject requests exceeding user limit', () => {
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(false); // 3rd request, limit is 2
+        });
+
+        it('should allow requests from different users (within guild limit)', () => {
+            // Guild limit is 3, so we can only do 3 total requests per guild
+            // User 1 makes 1 request, user 2 makes 2 requests = 3 total (at guild limit)
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user2')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user2')).toBe(true);
+        });
+
+        it('should reject requests exceeding guild limit', () => {
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user2')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user3')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user4')).toBe(false); // 4th request, guild limit is 3
+        });
+
+        it('should reset limits after window expires', () => {
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(false);
+
+            // Advance time past the rate window
+            vi.advanceTimersByTime(1100);
+
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+        });
+
+        it('should track guilds independently', () => {
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(true);
+            expect(embedFixRateLimiter.check('guild1', 'user1')).toBe(false);
+
+            // Different guild should still work
+            expect(embedFixRateLimiter.check('guild2', 'user1')).toBe(true);
+        });
+    });
+
+    describe('getStats', () => {
+        it('should return correct stats', () => {
+            embedFixRateLimiter.check('guild1', 'user1');
+            embedFixRateLimiter.check('guild1', 'user2');
+            embedFixRateLimiter.check('guild2', 'user1');
+
+            const stats = embedFixRateLimiter.getStats();
+            expect(stats.guildEntries).toBe(2);
+            expect(stats.userEntries).toBe(3);
+        });
+    });
+
+    describe('clear', () => {
+        it('should clear all entries', () => {
+            embedFixRateLimiter.check('guild1', 'user1');
+            embedFixRateLimiter.check('guild1', 'user2');
+
+            embedFixRateLimiter.clear();
+
+            const stats = embedFixRateLimiter.getStats();
+            expect(stats.guildEntries).toBe(0);
+            expect(stats.userEntries).toBe(0);
+        });
+    });
+});

--- a/src/services/embedFix/tests/twitterHandler.test.ts
+++ b/src/services/embedFix/tests/twitterHandler.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock config
+vi.mock('../../../utils/data/embedFixConfig', () => ({
+    EMBED_FIX_CONFIG: {
+        API_TIMEOUT_MS: 5000,
+        TWITTER_API: 'https://api.fxtwitter.com',
+        EMBED_COLOR_TWITTER: 0x1DA1F2,
+    },
+}));
+
+import { TwitterHandler, twitterHandler } from '../handlers/twitterHandler';
+
+describe('TwitterHandler', () => {
+    let handler: TwitterHandler;
+
+    beforeEach(() => {
+        handler = new TwitterHandler();
+        mockFetch.mockReset();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('patterns', () => {
+        it('should match twitter.com URLs', () => {
+            const match = handler.match('https://twitter.com/user/status/1234567890');
+            expect(match).not.toBeNull();
+            expect(match?.[3]).toBe('user');
+            expect(match?.[4]).toBe('1234567890');
+        });
+
+        it('should match x.com URLs', () => {
+            const match = handler.match('https://x.com/someuser/status/9876543210');
+            expect(match).not.toBeNull();
+            expect(match?.[3]).toBe('someuser');
+            expect(match?.[4]).toBe('9876543210');
+        });
+
+        it('should match www URLs', () => {
+            const match = handler.match('https://www.twitter.com/user/status/123');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match mobile URLs', () => {
+            const match = handler.match('https://mobile.twitter.com/user/status/123');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match vxtwitter URLs', () => {
+            const match = handler.match('https://vxtwitter.com/user/status/123');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match fxtwitter URLs', () => {
+            const match = handler.match('https://fxtwitter.com/user/status/123');
+            expect(match).not.toBeNull();
+        });
+
+        it('should not match invalid URLs', () => {
+            expect(handler.match('https://twitter.com/user')).toBeNull();
+            expect(handler.match('https://twitter.com/user/following')).toBeNull();
+            expect(handler.match('https://example.com/tweet')).toBeNull();
+        });
+    });
+
+    describe('fetchEmbed', () => {
+        const mockApiResponse = {
+            code: 200,
+            message: 'OK',
+            tweet: {
+                text: 'Hello, world!',
+                created_at: '2024-01-15T12:00:00Z',
+                author: {
+                    name: 'Test User',
+                    screen_name: 'testuser',
+                    avatar_url: 'https://example.com/avatar.jpg',
+                },
+                media: {
+                    photos: [
+                        { url: 'https://pbs.twimg.com/media/photo1.jpg' },
+                        { url: 'https://pbs.twimg.com/media/photo2.jpg' },
+                    ],
+                },
+                possibly_sensitive: false,
+            },
+        };
+
+        it('should fetch and parse tweet data successfully', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(mockApiResponse),
+            });
+
+            const match = handler.match('https://twitter.com/testuser/status/123456')!;
+            const result = await handler.fetchEmbed(match, 'https://twitter.com/testuser/status/123456');
+
+            expect(result).not.toBeNull();
+            expect(result?.platform).toBe('twitter');
+            expect(result?.description).toBe('Hello, world!');
+            expect(result?.author.name).toBe('Test User');
+            expect(result?.author.username).toBe('testuser');
+            expect(result?.author.iconUrl).toBe('https://example.com/avatar.jpg');
+            expect(result?.images).toHaveLength(2);
+            expect(result?.isNsfw).toBe(false);
+            expect(result?.color).toBe(0x1DA1F2);
+        });
+
+        it('should return null on API error', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+            });
+
+            const match = handler.match('https://twitter.com/testuser/status/123456')!;
+            const result = await handler.fetchEmbed(match, 'https://twitter.com/testuser/status/123456');
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null on invalid API response', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ code: 404, message: 'Not found' }),
+            });
+
+            const match = handler.match('https://twitter.com/testuser/status/123456')!;
+            const result = await handler.fetchEmbed(match, 'https://twitter.com/testuser/status/123456');
+
+            expect(result).toBeNull();
+        });
+
+        it('should handle tweet with video', async () => {
+            const responseWithVideo = {
+                ...mockApiResponse,
+                tweet: {
+                    ...mockApiResponse.tweet,
+                    media: {
+                        videos: [
+                            {
+                                url: 'https://video.twimg.com/video.mp4',
+                                thumbnail_url: 'https://pbs.twimg.com/thumb.jpg',
+                            },
+                        ],
+                    },
+                },
+            };
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(responseWithVideo),
+            });
+
+            const match = handler.match('https://twitter.com/testuser/status/123456')!;
+            const result = await handler.fetchEmbed(match, 'https://twitter.com/testuser/status/123456');
+
+            expect(result?.videos).toHaveLength(1);
+            expect(result?.videos?.[0].url).toBe('https://video.twimg.com/video.mp4');
+            expect(result?.videos?.[0].thumbnail).toBe('https://pbs.twimg.com/thumb.jpg');
+        });
+
+        it('should handle sensitive tweet', async () => {
+            const sensitiveResponse = {
+                ...mockApiResponse,
+                tweet: {
+                    ...mockApiResponse.tweet,
+                    possibly_sensitive: true,
+                },
+            };
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(sensitiveResponse),
+            });
+
+            const match = handler.match('https://twitter.com/testuser/status/123456')!;
+            const result = await handler.fetchEmbed(match, 'https://twitter.com/testuser/status/123456');
+
+            expect(result?.isNsfw).toBe(true);
+        });
+
+        it('should handle fetch error', async () => {
+            mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+            const match = handler.match('https://twitter.com/testuser/status/123456')!;
+            const result = await handler.fetchEmbed(match, 'https://twitter.com/testuser/status/123456');
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('singleton instance', () => {
+        it('should export a singleton instance', () => {
+            expect(twitterHandler).toBeInstanceOf(TwitterHandler);
+            expect(twitterHandler.platform).toBe('twitter');
+        });
+    });
+});

--- a/src/services/embedFix/tests/twitterHandler.test.ts
+++ b/src/services/embedFix/tests/twitterHandler.test.ts
@@ -63,6 +63,21 @@ describe('TwitterHandler', () => {
             expect(match).not.toBeNull();
         });
 
+        it('should match fixupx URLs', () => {
+            const match = handler.match('https://fixupx.com/user/status/123');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match fixvx URLs', () => {
+            const match = handler.match('https://fixvx.com/user/status/123');
+            expect(match).not.toBeNull();
+        });
+
+        it('should match twittpr URLs', () => {
+            const match = handler.match('https://twittpr.com/user/status/123');
+            expect(match).not.toBeNull();
+        });
+
         it('should not match invalid URLs', () => {
             expect(handler.match('https://twitter.com/user')).toBeNull();
             expect(handler.match('https://twitter.com/user/following')).toBeNull();

--- a/src/services/embedFix/tests/urlMatcher.test.ts
+++ b/src/services/embedFix/tests/urlMatcher.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { urlMatcher } from '../urlMatcher';
+import { EmbedData, PlatformHandler } from '../../../utils/interfaces/EmbedFix.interface';
+
+// Create a mock handler for testing
+class MockHandler implements PlatformHandler {
+    platform = 'twitter' as const;
+    patterns = [
+        /https?:\/\/(www\.)?(twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/i,
+    ];
+
+    match(url: string): RegExpMatchArray | null {
+        for (const pattern of this.patterns) {
+            const match = url.match(pattern);
+            if (match) return match;
+        }
+        return null;
+    }
+
+    async fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null> {
+        return {
+            platform: 'twitter',
+            author: {
+                name: 'Test Author',
+                username: match[3],
+                url: `https://twitter.com/${match[3]}`,
+            },
+            images: [],
+            color: 0x1DA1F2,
+            originalUrl: url,
+        };
+    }
+}
+
+describe('UrlMatcher', () => {
+    beforeEach(() => {
+        urlMatcher.clear();
+    });
+
+    describe('registerHandler', () => {
+        it('should register a handler', () => {
+            const handler = new MockHandler();
+            urlMatcher.registerHandler(handler);
+            expect(urlMatcher.hasHandlers()).toBe(true);
+        });
+    });
+
+    describe('getHandler', () => {
+        it('should return registered handler', () => {
+            const handler = new MockHandler();
+            urlMatcher.registerHandler(handler);
+            expect(urlMatcher.getHandler('twitter')).toBe(handler);
+        });
+
+        it('should return undefined for non-registered platform', () => {
+            expect(urlMatcher.getHandler('pixiv')).toBeUndefined();
+        });
+    });
+
+    describe('matchUrl', () => {
+        beforeEach(() => {
+            urlMatcher.registerHandler(new MockHandler());
+        });
+
+        it('should match valid Twitter URL', () => {
+            const result = urlMatcher.matchUrl('https://twitter.com/user/status/123456789');
+            expect(result).not.toBeNull();
+            expect(result?.platform).toBe('twitter');
+            expect(result?.url).toBe('https://twitter.com/user/status/123456789');
+        });
+
+        it('should match x.com URL', () => {
+            const result = urlMatcher.matchUrl('https://x.com/user/status/123456789');
+            expect(result).not.toBeNull();
+            expect(result?.platform).toBe('twitter');
+        });
+
+        it('should return null for non-matching URL', () => {
+            const result = urlMatcher.matchUrl('https://example.com/page');
+            expect(result).toBeNull();
+        });
+
+        it('should return null for empty URL', () => {
+            const result = urlMatcher.matchUrl('');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('matchAllUrls', () => {
+        beforeEach(() => {
+            urlMatcher.registerHandler(new MockHandler());
+        });
+
+        it('should return empty array for content without http', () => {
+            const result = urlMatcher.matchAllUrls('Just some text without links');
+            expect(result).toEqual([]);
+        });
+
+        it('should match single URL in content', () => {
+            const content = 'Check out this tweet: https://twitter.com/user/status/123456789';
+            const result = urlMatcher.matchAllUrls(content);
+            expect(result).toHaveLength(1);
+            expect(result[0].platform).toBe('twitter');
+        });
+
+        it('should match multiple URLs in content', () => {
+            const content = `
+                First: https://twitter.com/user1/status/111
+                Second: https://x.com/user2/status/222
+                Third: https://twitter.com/user3/status/333
+            `;
+            const result = urlMatcher.matchAllUrls(content);
+            expect(result).toHaveLength(3);
+        });
+
+        it('should skip duplicate URLs', () => {
+            const content = `
+                https://twitter.com/user/status/123
+                Same again: https://twitter.com/user/status/123
+            `;
+            const result = urlMatcher.matchAllUrls(content);
+            expect(result).toHaveLength(1);
+        });
+
+        it('should skip non-matching URLs', () => {
+            const content = `
+                https://twitter.com/user/status/123
+                https://example.com/not-twitter
+                https://twitter.com/user/status/456
+            `;
+            const result = urlMatcher.matchAllUrls(content);
+            expect(result).toHaveLength(2);
+        });
+    });
+
+    describe('hasHandlers', () => {
+        it('should return false when no handlers registered', () => {
+            expect(urlMatcher.hasHandlers()).toBe(false);
+        });
+
+        it('should return true when handlers are registered', () => {
+            urlMatcher.registerHandler(new MockHandler());
+            expect(urlMatcher.hasHandlers()).toBe(true);
+        });
+    });
+
+    describe('clear', () => {
+        it('should remove all handlers', () => {
+            urlMatcher.registerHandler(new MockHandler());
+            expect(urlMatcher.hasHandlers()).toBe(true);
+
+            urlMatcher.clear();
+            expect(urlMatcher.hasHandlers()).toBe(false);
+        });
+    });
+});

--- a/src/services/embedFix/urlMatcher.ts
+++ b/src/services/embedFix/urlMatcher.ts
@@ -1,0 +1,109 @@
+/**
+ * URL Matcher for embed fix feature
+ * Compiles regex patterns once at initialization and matches URLs against handlers
+ */
+
+import { EmbedPlatform, MatchedUrl, PlatformHandler } from '../../utils/interfaces/EmbedFix.interface';
+
+class UrlMatcher {
+    private handlers: Map<EmbedPlatform, PlatformHandler> = new Map();
+
+    /**
+     * Register a platform handler
+     * @param handler The handler to register
+     */
+    registerHandler(handler: PlatformHandler): void {
+        this.handlers.set(handler.platform, handler);
+    }
+
+    /**
+     * Get a registered handler by platform
+     * @param platform The platform to get handler for
+     */
+    getHandler(platform: EmbedPlatform): PlatformHandler | undefined {
+        return this.handlers.get(platform);
+    }
+
+    /**
+     * Get all registered handlers
+     */
+    getHandlers(): PlatformHandler[] {
+        return Array.from(this.handlers.values());
+    }
+
+    /**
+     * Match a single URL against registered handlers
+     * @param url The URL to match
+     * @returns The matched URL info or null if no match
+     */
+    matchUrl(url: string): MatchedUrl | null {
+        for (const handler of this.handlers.values()) {
+            const match = handler.match(url);
+            if (match) {
+                return {
+                    url,
+                    platform: handler.platform,
+                    match,
+                    handler,
+                };
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract all URLs from content and match against handlers
+     * @param content The message content to search
+     * @returns Array of matched URLs (may be empty)
+     */
+    matchAllUrls(content: string): MatchedUrl[] {
+        // Early exit if no http present
+        if (!content.includes('http')) {
+            return [];
+        }
+
+        // Extract all URLs from the content
+        const urlRegex = /https?:\/\/[^\s<>"{}|\\^`[\]]+/gi;
+        const urls = content.match(urlRegex);
+
+        if (!urls) {
+            return [];
+        }
+
+        // Match each URL against handlers
+        const matches: MatchedUrl[] = [];
+        const seenUrls = new Set<string>();
+
+        for (const url of urls) {
+            // Skip duplicates
+            if (seenUrls.has(url)) {
+                continue;
+            }
+            seenUrls.add(url);
+
+            const matched = this.matchUrl(url);
+            if (matched) {
+                matches.push(matched);
+            }
+        }
+
+        return matches;
+    }
+
+    /**
+     * Check if any handlers are registered
+     */
+    hasHandlers(): boolean {
+        return this.handlers.size > 0;
+    }
+
+    /**
+     * Clear all handlers (for testing)
+     */
+    clear(): void {
+        this.handlers.clear();
+    }
+}
+
+// Export singleton instance
+export const urlMatcher = new UrlMatcher();

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -37,11 +37,17 @@ export const EMBED_FIX_CONFIG = {
     EMBED_COLOR_PIXIV: 0x0096FA,
     EMBED_COLOR_INSTAGRAM: 0xE1306C,
 
-    // S3 paths (PR4 - stats only)
+    // S3 paths
     DATA_PATH: 'data/embed-fix',
     S3_STATS_KEY: isDevelopment
         ? 'data/embed-fix/dev-embed-fix-stats.json'
         : 'data/embed-fix/embed-fix-stats.json',
+    S3_VOTES_KEY: isDevelopment
+        ? 'data/embed-fix/dev-embed-votes.json'
+        : 'data/embed-fix/embed-votes.json',
+
+    // Votes cache
+    VOTES_CACHE_TTL: 60_000,  // 1 minute cache for votes data
 
     // Channel patterns for stats tracking (PR4)
     TRACKED_CHANNEL_PATTERNS: ['art', 'nsfw', 'gallery', 'fanart'],

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -49,6 +49,9 @@ export const EMBED_FIX_CONFIG = {
     // Votes cache
     VOTES_CACHE_TTL: 60_000,  // 1 minute cache for votes data
 
+    // Duplicate detection
+    DUPLICATE_WINDOW_MS: 24 * 60 * 60 * 1000,  // 24 hours
+
     // Channel patterns for stats tracking (PR4)
     TRACKED_CHANNEL_PATTERNS: ['art', 'nsfw', 'gallery', 'fanart'],
 } as const;

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -1,0 +1,48 @@
+/**
+ * Configuration constants for the Embed Fix feature
+ * Similar pattern to gachaConfig.ts
+ */
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export const EMBED_FIX_CONFIG = {
+    // Timeouts
+    API_TIMEOUT_MS: 8000,
+
+    // Rate limits
+    GUILD_RATE_LIMIT: 15,      // Max requests per guild per minute
+    USER_RATE_LIMIT: 5,        // Max requests per user per minute
+    RATE_WINDOW_MS: 60_000,    // 1 minute window
+
+    // Caching
+    EMBED_CACHE_TTL: 30 * 60 * 1000,      // 30 minutes
+    EMBED_CACHE_MAX_SIZE: 500,             // Max cached entries
+    NEGATIVE_CACHE_TTL: 5 * 60 * 1000,     // 5 minutes for failed requests
+
+    // Circuit breaker
+    CIRCUIT_BREAKER_THRESHOLD: 5,          // Failures before opening
+    CIRCUIT_BREAKER_TIMEOUT: 2 * 60 * 1000, // 2 minutes cooldown
+
+    // External APIs
+    TWITTER_API: 'https://api.fxtwitter.com',
+    PIXIV_PROXY: 'https://phixiv.net',
+    INSTAGRAM_PROXY: 'ddinstagram.com',
+
+    // Embed settings
+    MAX_EMBEDS_PER_MESSAGE: 4,
+    BOOKMARK_BUTTON_TIMEOUT: 5 * 60 * 1000, // 5 minutes
+
+    // Embed colors (hex)
+    EMBED_COLOR_TWITTER: 0x1DA1F2,
+    EMBED_COLOR_PIXIV: 0x0096FA,
+    EMBED_COLOR_INSTAGRAM: 0xE1306C,
+
+    // S3 paths (PR4 - stats only)
+    DATA_PATH: 'data/embed-fix',
+    S3_STATS_KEY: isDevelopment
+        ? 'data/embed-fix/dev-embed-fix-stats.json'
+        : 'data/embed-fix/embed-fix-stats.json',
+
+    // Channel patterns for stats tracking (PR4)
+    TRACKED_CHANNEL_PATTERNS: ['art', 'nsfw', 'gallery', 'fanart'],
+} as const;

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -52,6 +52,12 @@ export const EMBED_FIX_CONFIG = {
     // Duplicate detection
     DUPLICATE_WINDOW_MS: 24 * 60 * 60 * 1000,  // 24 hours
 
+    // Message edit monitoring window
+    MESSAGE_EDIT_WINDOW_MS: 24 * 60 * 60 * 1000,  // 24 hours - monitor edits for this long
+
+    // Fixup service domains (used to detect when to show fallback message)
+    FIXUP_DOMAINS: ['vxtwitter.com', 'fxtwitter.com', 'fixupx.com', 'fixvx.com', 'twittpr.com'],
+
     // Channel patterns for stats tracking (PR4)
     TRACKED_CHANNEL_PATTERNS: ['art', 'nsfw', 'gallery', 'fanart'],
 } as const;

--- a/src/utils/interfaces/EmbedFix.interface.ts
+++ b/src/utils/interfaces/EmbedFix.interface.ts
@@ -1,0 +1,131 @@
+/**
+ * Embed Fix Feature Interfaces
+ * Types for the SaucyBot-like embed fixing functionality
+ */
+
+/**
+ * Supported platforms for embed fixing
+ */
+export type EmbedPlatform = 'twitter' | 'pixiv' | 'instagram';
+
+/**
+ * Data extracted from a platform's API for building embeds
+ */
+export interface EmbedData {
+    platform: EmbedPlatform;
+    title?: string;
+    description?: string;
+    author: {
+        name: string;
+        username: string;
+        url: string;
+        iconUrl?: string;
+    };
+    images: string[];
+    videos?: Array<{
+        url: string;
+        thumbnail?: string;
+    }>;
+    timestamp?: string;
+    color: number;
+    originalUrl: string;
+    isNsfw?: boolean;
+    /** If true, use URL rewrite instead of custom embed */
+    _useUrlRewrite?: boolean;
+    /** The rewritten URL for platforms that use URL proxies */
+    _rewrittenUrl?: string;
+}
+
+/**
+ * Interface for platform-specific handlers
+ */
+export interface PlatformHandler {
+    /** The platform this handler supports */
+    platform: EmbedPlatform;
+    /** Regex patterns to match URLs for this platform */
+    patterns: RegExp[];
+    /**
+     * Try to match a URL against this handler's patterns
+     * @param url The URL to match
+     * @returns The regex match array if matched, null otherwise
+     */
+    match(url: string): RegExpMatchArray | null;
+    /**
+     * Fetch embed data from the platform's API
+     * @param match The regex match from the URL
+     * @param url The original URL
+     * @returns The embed data or null if fetch failed
+     */
+    fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null>;
+}
+
+/**
+ * Cached embed entry with TTL
+ */
+export interface CachedEmbed {
+    data: EmbedData;
+    timestamp: number;
+    expiresAt: number;
+}
+
+/**
+ * Rate limit entry for a guild or user
+ */
+export interface RateLimitEntry {
+    count: number;
+    windowStart: number;
+}
+
+/**
+ * Circuit breaker state for an API
+ */
+export interface CircuitBreakerState {
+    failures: number;
+    lastFailure: number;
+    isOpen: boolean;
+    openUntil: number;
+}
+
+/**
+ * Result of URL matching
+ */
+export interface MatchedUrl {
+    url: string;
+    platform: EmbedPlatform;
+    match: RegExpMatchArray;
+    handler: PlatformHandler;
+}
+
+/**
+ * Stats data for a user (PR4)
+ */
+export interface UserStats {
+    totalShares: number;
+    weeklyShares: number;
+    lastShare: string;
+    byPlatform: Record<EmbedPlatform, number>;
+}
+
+/**
+ * Guild stats data (PR4)
+ */
+export interface GuildStats {
+    users: Record<string, UserStats>;
+    weekStarted: string;
+}
+
+/**
+ * Root stats data structure for S3 (PR4)
+ */
+export interface EmbedStatsData {
+    stats: Record<string, GuildStats>;
+    schemaVersion: number;
+    lastUpdated: string;
+}
+
+/**
+ * Leaderboard entry
+ */
+export interface LeaderboardEntry extends UserStats {
+    userId: string;
+}

--- a/src/utils/interfaces/EmbedFix.interface.ts
+++ b/src/utils/interfaces/EmbedFix.interface.ts
@@ -129,3 +129,68 @@ export interface EmbedStatsData {
 export interface LeaderboardEntry extends UserStats {
     userId: string;
 }
+
+// ============================================
+// Voting/Like System Interfaces
+// ============================================
+
+/**
+ * Root document for votes stored in S3
+ */
+export interface EmbedVotesData {
+    votes: Record<string, ArtworkVotes>;  // Keyed by artworkId (platform:id)
+    timeAggregations: VoteTimeAggregations;
+    schemaVersion: number;
+    lastUpdated: string;
+}
+
+/**
+ * Per-artwork vote tracking
+ */
+export interface ArtworkVotes {
+    artworkId: string;           // e.g., "twitter:1234567890"
+    originalUrl: string;
+    platform: EmbedPlatform;
+    artistUsername: string;
+    artistName: string;
+    guildVotes: Record<string, GuildVoteData>;  // Keyed by guildId
+    globalVoteCount: number;     // Denormalized all-time count
+    firstSharedAt: string;
+    lastVotedAt: string;
+}
+
+/**
+ * Per-guild vote data for an artwork
+ */
+export interface GuildVoteData {
+    voters: string[];            // Array of discordIds who voted
+    voteCount: number;           // Denormalized count
+    sharedBy: string;            // Original poster's discordId
+    sharedAt: string;
+    messageId: string;
+    channelId: string;
+}
+
+/**
+ * Time-based vote aggregations
+ */
+export interface VoteTimeAggregations {
+    weekly: VotePeriodData;
+    monthly: VotePeriodData;
+    yearly: VotePeriodData;
+    lastReset: {
+        weekly: string;
+        monthly: string;
+        yearly: string;
+    };
+}
+
+/**
+ * Vote data for a specific time period
+ */
+export interface VotePeriodData {
+    byGuild: Record<string, number>;     // guildId -> vote count
+    global: number;
+    topArtwork: string[];                // Top artworkIds for period
+    topArtists: Record<string, number>;  // artistUsername -> vote count
+}


### PR DESCRIPTION
## Summary
- Add embed fixer service for Twitter/X, Pixiv, and Instagram with automatic embed enhancement
- Add voting system with heart emoji button for artwork embeds
- Add duplicate/repost detection (24h window per guild)
- Add message edit monitoring (24h) for typo/mislink corrections
- Add `/embed` command for manual URL processing

## Features

### Platform Support
| Platform | Method | Proxy |
|----------|--------|-------|
| Twitter/X | Custom embed | fxtwitter.com API |
| Pixiv | URL rewrite | phixiv.net |
| Instagram | URL rewrite | ddinstagram.com |

**Twitter/X URL variants supported:**
- `twitter.com`, `x.com`
- `vxtwitter.com`, `fxtwitter.com`
- `fixupx.com`, `fixvx.com`, `twittpr.com`
- Mobile URLs (`mobile.twitter.com`)

### Voting System
- ❤️ Heart button on embeds to vote for artwork
- Vote count displayed per guild
- Toggle vote on/off by clicking
- S3 persistence with caching

### Duplicate Detection
- Detects reposts within 24-hour window per guild
- Works across all URL variants (twitter.com and x.com = same tweet)
- Skips creating new embed for duplicates
- Suppresses Discord's embed on duplicate message
- Replies with "🔄 This was shared Xh Ym ago → [Jump to original](link)"

### Message Edit Monitoring
- Monitors edits to messages for 24 hours
- Detects when users fix typos or correct mislinks
- Only processes newly added URLs (avoids duplicates)

### Fixup URL Fallback
- When fixup URLs (vxtwitter, fxtwitter, etc.) can't be processed
- Shows helpful message suggesting original twitter.com/x.com URLs

### Artist Spotlight Embed Design
- Title: "Artwork by {artist name}"
- Author: @username with profile link and avatar
- Description: Tweet/post text (if any)
- Footer: "Click ❤️ to vote • ✉️ to DM"
- Platform-specific colors

### Channel Filtering
- Only processes links in `#art` and `#nsfw` channels
- Fast-path checks for performance

### Infrastructure
- LRU caching (500 entries, 30min TTL)
- Rate limiting (5/min per user, 15/min per guild)
- Circuit breaker pattern for API failures
- Negative caching for failed lookups (5min)

## Test plan
- [x] Unit tests for all handlers (Twitter, Pixiv, Instagram)
- [x] Unit tests for URL matcher
- [x] Unit tests for embed cache
- [x] Unit tests for rate limiter
- [x] Unit tests for circuit breaker
- [x] Unit tests for votes service
- [x] Unit tests for duplicate detection
- [x] Unit tests for cross-domain artwork ID generation
- [x] All 310 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)