### PR TITLE
feat(embed-fix): display all images from tweets (up to 10)

### DIFF
--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -30,6 +30,7 @@ export const EMBED_FIX_CONFIG = {
 
     // Embed settings
     MAX_EMBEDS_PER_MESSAGE: 4,
+    MAX_IMAGES_PER_TWEET: 10,  // Max images to display per tweet (Discord's limit)
     BOOKMARK_BUTTON_TIMEOUT: 5 * 60 * 1000, // 5 minutes
 
     // Embed colors (hex)


### PR DESCRIPTION
## Summary
- Display all images from tweets as separate embeds (up to Discord's limit of 10)
- SaucyBot-style approach: one embed per image

## Changes
- Add `MAX_IMAGES_PER_TWEET` config constant (10)
- Update `buildEmbed()` to accept `imageIndex` parameter
- First image gets full metadata (author, description, timestamp, footer)
- Additional images are image-only embeds with same URL for visual grouping
- Update `sendEmbedResponse()` to loop through images array

## Behavior
| Images | Embeds Created |
|--------|---------------|
| 1 | 1 embed with full metadata |
| 4 | 4 embeds (first has metadata, rest image-only) |
| 12 | 10 embeds (Discord's limit) |
| 0 | 1 text-only embed |

## Test plan
- [x] All 310 tests passing
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)