### PR TITLE
feat(embed-fix): video attachments and engagement metrics (saucy-bot style)

### DIFF
--- a/src/services/embedFix/handlers/twitterHandler.ts
+++ b/src/services/embedFix/handlers/twitterHandler.ts
@@ -40,6 +40,12 @@ interface FxTwitterTweet {
     author: FxTwitterAuthor;
     media?: FxTwitterMedia;
     possibly_sensitive?: boolean;
+    // Engagement metrics
+    likes?: number;
+    retweets?: number;
+    replies?: number;
+    views?: number | null;
+    bookmarks?: number | null;
 }
 
 interface FxTwitterResponse {
@@ -140,6 +146,13 @@ export class TwitterHandler extends BaseHandler {
                 color: EMBED_FIX_CONFIG.EMBED_COLOR_TWITTER,
                 originalUrl: url,
                 isNsfw: tweet.possibly_sensitive,
+                engagement: {
+                    likes: tweet.likes,
+                    retweets: tweet.retweets,
+                    replies: tweet.replies,
+                    views: tweet.views ?? undefined,
+                    bookmarks: tweet.bookmarks ?? undefined,
+                },
             };
         } catch (error) {
             if (error instanceof Error && error.name === 'AbortError') {

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -43,6 +43,9 @@ export const EMBED_FIX_CONFIG = {
     EMBED_COLOR_PIXIV: 0x0096FA,
     EMBED_COLOR_INSTAGRAM: 0xE1306C,
 
+    // Platform icons for footer
+    TWITTER_ICON_URL: 'https://abs.twimg.com/icons/apple-touch-icon-192x192.png',
+
     // S3 paths
     DATA_PATH: 'data/embed-fix',
     S3_STATS_KEY: isDevelopment

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -33,6 +33,11 @@ export const EMBED_FIX_CONFIG = {
     MAX_IMAGES_PER_TWEET: 10,  // Max images to display per tweet (Discord's limit)
     BOOKMARK_BUTTON_TIMEOUT: 5 * 60 * 1000, // 5 minutes
 
+    // Video settings
+    MAX_VIDEO_SIZE_BYTES: 8_388_119,  // ~8MB - Discord's non-nitro limit
+    VIDEO_DOWNLOAD_TIMEOUT_MS: 30_000,  // 30 seconds for video download
+    VXTWITTER_FALLBACK: 'https://vxtwitter.com',  // Fallback for large videos
+
     // Embed colors (hex)
     EMBED_COLOR_TWITTER: 0x1DA1F2,
     EMBED_COLOR_PIXIV: 0x0096FA,

--- a/src/utils/interfaces/EmbedFix.interface.ts
+++ b/src/utils/interfaces/EmbedFix.interface.ts
@@ -37,6 +37,14 @@ export interface EmbedData {
     color: number;
     originalUrl: string;
     isNsfw?: boolean;
+    /** Engagement metrics */
+    engagement?: {
+        likes?: number;
+        retweets?: number;
+        replies?: number;
+        views?: number;
+        bookmarks?: number;
+    };
     /** If true, use URL rewrite instead of custom embed */
     _useUrlRewrite?: boolean;
     /** The rewritten URL for platforms that use URL proxies */

--- a/src/utils/interfaces/EmbedFix.interface.ts
+++ b/src/utils/interfaces/EmbedFix.interface.ts
@@ -25,6 +25,13 @@ export interface EmbedData {
     videos?: Array<{
         url: string;
         thumbnail?: string;
+        /** Video variants sorted by quality (highest first) */
+        variants?: Array<{
+            url: string;
+            bitrate?: number;
+            content_type?: string;
+        }>;
+        type?: 'video' | 'gif';
     }>;
     timestamp?: string;
     color: number;
@@ -34,6 +41,13 @@ export interface EmbedData {
     _useUrlRewrite?: boolean;
     /** The rewritten URL for platforms that use URL proxies */
     _rewrittenUrl?: string;
+    /** Video attachment data (after download) */
+    _videoAttachment?: {
+        buffer: Buffer;
+        filename: string;
+    };
+    /** Fallback URL if video is too large to attach */
+    _videoFallbackUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Download and attach video files directly to Discord messages (like saucy-bot)
- Display engagement metrics (likes, retweets, views) as inline fields
- Add Twitter branding with logo in footer
- Fallback to vxtwitter.com URL for videos exceeding Discord's 8MB limit

## Features

### Video Handling (saucy-bot style)
1. Detect video tweet (has videos, no images)
2. Extract video variants from FxTwitter API (sorted by bitrate, highest first)
3. Check each variant's file size via HEAD request
4. Download first variant that fits under 8MB limit
5. Attach video file with embed using `video.url: attachment://filename`
6. If all variants too large → reply with vxtwitter.com link

### Engagement Metrics
- Display likes (❤️), retweets (🔁), and views (👁️) as inline fields
- Smart number formatting (1.2K, 3.5M, etc.)
- Twitter logo in embed footer

### Configuration
| Constant | Value | Description |
|----------|-------|-------------|
| `MAX_VIDEO_SIZE_BYTES` | 8,388,119 | ~8MB Discord non-nitro limit |
| `VIDEO_DOWNLOAD_TIMEOUT_MS` | 30,000 | 30s timeout for download |
| `VXTWITTER_FALLBACK` | https://vxtwitter.com | Fallback for large videos |
| `TWITTER_ICON_URL` | Twitter icon | Footer branding |

## Changes
- `embedFixConfig.ts`: Add video settings and Twitter icon URL
- `twitterHandler.ts`: Extract video variants and engagement metrics
- `EmbedFix.interface.ts`: Add engagement object and video types
- `embedFixService.ts`: 
  - Add `downloadVideo()` helper with size checking
  - Add `findBestVideoUrl()` for quality selection
  - Add `buildVideoEmbed()` using video property (like saucy-bot)
  - Add `formatNumber()` for K/M formatting
  - Display engagement metrics in embeds

## Test plan
- [x] All tests passing
- [x] Type check passes
- [ ] Test video tweet - video plays inline
- [ ] Test large video - falls back to vxtwitter
- [ ] Test engagement metrics display

🤖 Generated with [Claude Code](https://claude.com/claude-code)