### PR TITLE
fix(embed-fix): add NSFW Twitter proxies and fix Pixiv duplicate detection

### DIFF
--- a/src/services/embedFix/handlers/pixivHandler.ts
+++ b/src/services/embedFix/handlers/pixivHandler.ts
@@ -30,16 +30,20 @@ export class PixivHandler extends BaseHandler {
         // Use URL rewrite approach - phixiv.net handles the embed
         const rewrittenUrl = `${EMBED_FIX_CONFIG.PIXIV_PROXY}/artworks/${artworkId}`;
 
+        // Always use canonical pixiv.net URL for originalUrl
+        // This ensures duplicate detection works for both pixiv.net and phixiv.net URLs
+        const canonicalUrl = `https://www.pixiv.net/artworks/${artworkId}`;
+
         return {
             platform: 'pixiv',
             author: {
                 name: 'Pixiv Artist',
                 username: 'pixiv',
-                url: url,
+                url: canonicalUrl,
             },
             images: [],
             color: EMBED_FIX_CONFIG.EMBED_COLOR_PIXIV,
-            originalUrl: url,
+            originalUrl: canonicalUrl,
             _useUrlRewrite: true,
             _rewrittenUrl: rewrittenUrl,
         };

--- a/src/services/embedFix/handlers/twitterHandler.ts
+++ b/src/services/embedFix/handlers/twitterHandler.ts
@@ -64,6 +64,8 @@ export class TwitterHandler extends BaseHandler {
         /https?:\/\/(mobile\.)?(twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/i,
         // Fixup services (vxtwitter, fxtwitter, fixupx, fixvx, twittpr, etc.)
         /https?:\/\/(www\.)?(vxtwitter\.com|fxtwitter\.com|fixupx\.com|fixvx\.com|twittpr\.com)\/(\w+)\/status\/(\d+)/i,
+        // Additional NSFW fixup services
+        /https?:\/\/(www\.)?(girlcockx\.com|cunnyx\.com)\/(\w+)\/status\/(\d+)/i,
     ];
 
     async fetchEmbed(match: RegExpMatchArray, url: string): Promise<EmbedData | null> {

--- a/src/services/embedFix/tests/pixivHandler.test.ts
+++ b/src/services/embedFix/tests/pixivHandler.test.ts
@@ -54,7 +54,8 @@ describe('PixivHandler', () => {
             expect(result?.platform).toBe('pixiv');
             expect(result?._useUrlRewrite).toBe(true);
             expect(result?._rewrittenUrl).toBe('https://phixiv.net/artworks/12345678');
-            expect(result?.originalUrl).toBe('https://pixiv.net/artworks/12345678');
+            // originalUrl should always be canonical pixiv.net URL for duplicate detection
+            expect(result?.originalUrl).toBe('https://www.pixiv.net/artworks/12345678');
         });
 
         it('should return URL rewrite data for English artwork URL', async () => {
@@ -62,6 +63,8 @@ describe('PixivHandler', () => {
             const result = await handler.fetchEmbed(match, 'https://pixiv.net/en/artworks/87654321');
 
             expect(result?._rewrittenUrl).toBe('https://phixiv.net/artworks/87654321');
+            // originalUrl should always be canonical
+            expect(result?.originalUrl).toBe('https://www.pixiv.net/artworks/87654321');
         });
 
         it('should return URL rewrite data for legacy URL', async () => {
@@ -69,6 +72,17 @@ describe('PixivHandler', () => {
             const result = await handler.fetchEmbed(match, 'https://pixiv.net/member_illust.php?illust_id=11111111');
 
             expect(result?._rewrittenUrl).toBe('https://phixiv.net/artworks/11111111');
+            // originalUrl should always be canonical
+            expect(result?.originalUrl).toBe('https://www.pixiv.net/artworks/11111111');
+        });
+
+        it('should return canonical originalUrl for phixiv proxy URLs', async () => {
+            const match = handler.match('https://phixiv.net/artworks/99999999')!;
+            const result = await handler.fetchEmbed(match, 'https://phixiv.net/artworks/99999999');
+
+            expect(result?._rewrittenUrl).toBe('https://phixiv.net/artworks/99999999');
+            // Even for phixiv URLs, originalUrl should be canonical pixiv.net for duplicate detection
+            expect(result?.originalUrl).toBe('https://www.pixiv.net/artworks/99999999');
         });
 
         it('should have correct color', async () => {

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -65,7 +65,7 @@ export const EMBED_FIX_CONFIG = {
     MESSAGE_EDIT_WINDOW_MS: 24 * 60 * 60 * 1000,  // 24 hours - monitor edits for this long
 
     // Fixup service domains (used to detect when to show fallback message)
-    FIXUP_DOMAINS: ['vxtwitter.com', 'fxtwitter.com', 'fixupx.com', 'fixvx.com', 'twittpr.com'],
+    FIXUP_DOMAINS: ['vxtwitter.com', 'fxtwitter.com', 'fixupx.com', 'fixvx.com', 'twittpr.com', 'girlcockx.com', 'cunnyx.com'],
 
     // Channel patterns for stats tracking (PR4)
     TRACKED_CHANNEL_PATTERNS: ['art', 'nsfw', 'gallery', 'fanart'],


### PR DESCRIPTION
## Summary
- Add support for additional NSFW Twitter proxy domains
- Fix Pixiv duplicate detection to work across pixiv.net and phixiv.net URLs

## Changes

### Twitter Proxy Domains
Added support for 2 additional NSFW-focused Twitter proxy domains to the URL patterns and FIXUP_DOMAINS config.

### Pixiv Duplicate Detection Fix
Previously, if someone posted `phixiv.net/artworks/123` and then someone else posted `pixiv.net/artworks/123`, it wouldn't be detected as a duplicate because the `originalUrl` stored was different.

Now the handler always uses the canonical `https://www.pixiv.net/artworks/{id}` URL for `originalUrl`, ensuring duplicate detection works regardless of which URL format was originally posted.

## Files Changed
- `src/services/embedFix/handlers/twitterHandler.ts` - Add NSFW proxy patterns
- `src/utils/data/embedFixConfig.ts` - Add domains to FIXUP_DOMAINS
- `src/services/embedFix/handlers/pixivHandler.ts` - Use canonical URL for originalUrl
- `src/services/embedFix/tests/pixivHandler.test.ts` - Update tests and add new test case

## Test plan
- [x] All 311 tests passing
- [x] Type check passes
- [x] Test new Twitter proxy domains are detected
- [x] Test Pixiv duplicate detection across pixiv.net/phixiv.net URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)