### PR TITLE
fix(embed-fix): suppress embeds on message edits for all platforms

### DIFF
--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -62,7 +62,7 @@ export const EMBED_FIX_CONFIG = {
     DUPLICATE_WINDOW_MS: 24 * 60 * 60 * 1000,  // 24 hours
 
     // Message edit monitoring window
-    MESSAGE_EDIT_WINDOW_MS: 24 * 60 * 60 * 1000,  // 24 hours - monitor edits for this long
+    MESSAGE_EDIT_WINDOW_MS: 72 * 60 * 60 * 1000,  // 72 hours - monitor edits for this long
 
     // Fixup service domains (used to detect when to show fallback message)
     FIXUP_DOMAINS: ['vxtwitter.com', 'fxtwitter.com', 'fixupx.com', 'fixvx.com', 'twittpr.com', 'girlcockx.com', 'cunnyx.com'],


### PR DESCRIPTION
## Summary
Fix double embeds appearing when users edit messages containing supported URLs.

## Problem
When users edit messages with Pixiv, Instagram, or Twitter fixup URLs:
1. Discord regenerates embeds on the edited message
2. The bot's existing reply remains
3. Results in double embeds (bot's reply + Discord's regenerated embed)

## Solution
- Add embed suppression to `processMessageEdit()` for ALL supported URLs (not just new URLs)
- Use delayed suppression (1.5s timeout) to catch Discord's async embed generation
- Extend monitoring window from 24h to **72 hours** for better coverage

## Platforms Affected
- Pixiv (pixiv.net, phixiv.net)
- Instagram (instagram.com, ddinstagram.com)
- Twitter fixups (vxtwitter, fxtwitter, etc.)

## Changes
- `embedFixConfig.ts`: Change MESSAGE_EDIT_WINDOW_MS from 24h to 72h
- `embedFixService.ts`: Add embed suppression at start of `processMessageEdit()`

## Test plan
- [x] All 311 tests passing
- [x] Type check passes
- [ ] User edits message with Pixiv URL - embed is suppressed
- [ ] User edits message with Instagram URL - embed is suppressed
- [ ] User edits message with Twitter fixup URL - embed is suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)