### PR TITLE
feat(embed-fix): batch user uploads with S3 temp storage

### DIFF
--- a/src/services/embedFix/embedFixService.ts
+++ b/src/services/embedFix/embedFixService.ts
@@ -268,6 +268,8 @@ class EmbedFixService {
      * Process user-uploaded images/videos (with duplicate detection)
      */
     private async processUserUpload(message: Message): Promise<void> {
+        console.log(`[EmbedFix] processUserUpload called for message ${message.id} in #${(message.channel as TextChannel).name}`);
+
         // Get filenames for duplicate checking
         const filenames = message.attachments
             .filter(att =>
@@ -377,6 +379,7 @@ class EmbedFixService {
 
         // Handle user uploads (embeds but no tracking)
         if (hasMediaUploads && !hasUrls) {
+            console.log(`[EmbedFix] Detected upload in #${channelName}, hasMedia=${hasMediaUploads}, hasUrls=${hasUrls}, content="${message.content.slice(0, 50)}"`);
             await this.processUserUpload(message);
             return;
         }

--- a/src/services/embedFix/embedFixService.ts
+++ b/src/services/embedFix/embedFixService.ts
@@ -275,11 +275,10 @@ class EmbedFixService {
             }
 
             if (deleteSucceeded) {
-                // Send new message with embeds (not a reply since original is deleted)
+                // Send new message with embeds only (author credit is in the embed)
+                // If user had text content, include it as message content
                 const newMessage = await channel.send({
-                    content: originalContent
-                        ? `**${originalAuthor.displayName || originalAuthor.username}** shared:\n${originalContent}`
-                        : `**${originalAuthor.displayName || originalAuthor.username}** shared:`,
+                    content: originalContent || undefined,
                     embeds,
                     allowedMentions: { users: [] },
                 });

--- a/src/services/embedFix/embedFixService.ts
+++ b/src/services/embedFix/embedFixService.ts
@@ -346,10 +346,12 @@ class EmbedFixService {
 
             // NOW delete the original message after embed is sent
             // The images are already fetched/cached by Discord at this point
+            console.log(`[EmbedFix] Attempting to delete original message ${message.id}`);
             try {
                 await message.delete();
-            } catch {
-                console.log('[EmbedFix] Could not delete original upload message');
+                console.log(`[EmbedFix] Successfully deleted original message ${message.id}`);
+            } catch (deleteError) {
+                console.log(`[EmbedFix] Could not delete original upload message: ${deleteError}`);
             }
         } catch (error) {
             if (message.guild) {

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -62,6 +62,10 @@ export const EMBED_FIX_CONFIG = {
     // Duplicate detection
     DUPLICATE_WINDOW_MS: 24 * 60 * 60 * 1000,  // 24 hours
 
+    // Upload batching
+    UPLOAD_BATCH_WINDOW_MS: 2 * 60 * 1000,  // 2 minutes - batch uploads from same user
+    MAX_IMAGES_PER_BATCH: 10,               // Discord's max embeds per message
+
     // Message edit monitoring window
     MESSAGE_EDIT_WINDOW_MS: 72 * 60 * 60 * 1000,  // 72 hours - monitor edits for this long
 

--- a/src/utils/data/embedFixConfig.ts
+++ b/src/utils/data/embedFixConfig.ts
@@ -42,6 +42,7 @@ export const EMBED_FIX_CONFIG = {
     EMBED_COLOR_TWITTER: 0x1DA1F2,
     EMBED_COLOR_PIXIV: 0x0096FA,
     EMBED_COLOR_INSTAGRAM: 0xE1306C,
+    EMBED_COLOR_UPLOAD: 0x5865F2,  // Discord Blurple
 
     // Platform icons for footer
     TWITTER_ICON_URL: 'https://abs.twimg.com/icons/apple-touch-icon-192x192.png',

--- a/src/utils/interfaces/EmbedFix.interface.ts
+++ b/src/utils/interfaces/EmbedFix.interface.ts
@@ -6,7 +6,7 @@
 /**
  * Supported platforms for embed fixing
  */
-export type EmbedPlatform = 'twitter' | 'pixiv' | 'instagram';
+export type EmbedPlatform = 'twitter' | 'pixiv' | 'instagram' | 'upload';
 
 /**
  * Data extracted from a platform's API for building embeds


### PR DESCRIPTION
## Summary
- Batch multiple user-uploaded images from the same user within a 2-minute window into a single embed message
- Delete original poster's message and repost as clean bot embed with attachments
- Use S3 temporary storage to avoid memory pressure and handle CDN URL expiration
- Support up to 10 images per embed (Discord limit), overflow creates new batch

## Key Features
- **Batching**: Multiple uploads within 2 minutes are combined into one embed
- **S3 Temp Storage**: Images stored on S3 during batch window, then attached to Discord
- **Auto-cleanup**: S3 temp files deleted after batch window + 5 min buffer
- **Duplicate Detection**: Same user/filename/guild within 24h window is skipped
- **Overflow Handling**: >10 images creates a new batch automatically

## Technical Flow
1. User uploads image → download from Discord CDN → upload to S3 temp
2. First upload → send embed with attachment → delete original message
3. Additional uploads → delete bot message → resend with all images attached
4. After batch window → cleanup S3 temp files (Discord now hosts permanently)

## Changes
- Add `downloadAndStoreImage()` - uploads to S3 temp storage
- Add `downloadFromCdn()` - retrieves images for Discord attachments  
- Add `cleanupTempImages()` - deletes S3 files after batch window
- Add `UploadBatch` interface with S3 key tracking
- Add batch tracking with `uploadBatches` Map
- Add scheduled cleanup for expired batches

## Config
- `UPLOAD_BATCH_WINDOW_MS`: 2 minutes
- `MAX_IMAGES_PER_BATCH`: 10 (Discord limit)
- S3 temp path: `data/embed-fix/temp-uploads/{guildId}:{userId}/`

## Test plan
- [ ] Single image upload creates embed with attachment
- [ ] Multiple images within 2 min are batched into one embed
- [ ] 11+ images overflow into second embed message
- [ ] Original poster's message is deleted
- [ ] S3 temp files are cleaned up after batch window
- [ ] ❤️ and ✉️ reactions work on batched embeds
- [ ] Duplicate uploads (same filename) within 24h are skipped
- [ ] Different users have separate batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)