### PR TITLE
feat(coupon): add Lost Sword support with channel monitoring and reaction confirmations

### DIFF
--- a/src/commands/tests/redeem.test.ts
+++ b/src/commands/tests/redeem.test.ts
@@ -59,6 +59,7 @@ vi.mock('../../utils/data/gachaGamesConfig', () => ({
             maxNicknameLength: 24,
             maxCodeLength: 20,
             userIdFieldName: 'Nickname',
+            requiresUserId: true,
         },
         'nikke': {
             id: 'nikke',
@@ -71,6 +72,7 @@ vi.mock('../../utils/data/gachaGamesConfig', () => ({
             maxNicknameLength: 20,
             maxCodeLength: 20,
             userIdFieldName: 'Player ID',
+            requiresUserId: false,
         },
     },
     getGameConfig: vi.fn(),
@@ -194,6 +196,7 @@ describe('Redeem Command', () => {
                     maxNicknameLength: 24,
                     maxCodeLength: 20,
                     userIdFieldName: 'Nickname',
+                    requiresUserId: true,
                 },
                 'nikke': {
                     id: 'nikke',
@@ -206,6 +209,7 @@ describe('Redeem Command', () => {
                     maxNicknameLength: 20,
                     maxCodeLength: 20,
                     userIdFieldName: 'Player ID',
+                    requiresUserId: false,
                 },
             };
             return configs[gameId];
@@ -433,7 +437,7 @@ describe('Redeem Command', () => {
             );
         });
 
-        it('should reject empty usernames', async () => {
+        it('should reject empty usernames for games that require userId', async () => {
             (mockInteraction.options!.getString as any).mockImplementation((name: string) => {
                 if (name === 'game') return 'bd2';
                 if (name === 'userid') return '   '; // Whitespace only
@@ -446,7 +450,7 @@ describe('Redeem Command', () => {
             expect(mockDataService.subscribe).not.toHaveBeenCalled();
             expect(mockInteraction.reply).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    content: expect.stringContaining('cannot be empty'),
+                    content: expect.stringContaining('is required for'),
                     ephemeral: true
                 })
             );

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -12,7 +12,8 @@ import {
     ChannelType,
     ActionRowBuilder,
     ButtonBuilder,
-    ComponentType
+    ComponentType,
+    Partials
 } from "discord.js";
 import { REST } from '@discordjs/rest';
 import { Routes } from 'discord-api-types/v9';
@@ -103,6 +104,13 @@ const bot: CustomClient = new Client({
         GatewayIntentBits.GuildMembers,
         GatewayIntentBits.GuildVoiceStates,
         GatewayIntentBits.GuildMessageReactions,
+        GatewayIntentBits.DirectMessages,
+        GatewayIntentBits.DirectMessageReactions,
+    ],
+    partials: [
+        Partials.Message,
+        Partials.Channel,
+        Partials.Reaction,
     ],
 }) as CustomClient;
 

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -46,6 +46,8 @@ import { dailyResetServiceConfig } from './utils/data/gamesResetConfig';
 import { GachaCouponScheduler } from './services/gachaCouponScheduler';
 import { checkEmbedFixUrls, checkEmbedFixUrlsOnEdit, getEmbedFixService } from './services/embedFix/embedFixService';
 import { getEmbedVotesService } from './services/embedFix/embedVotesService';
+import { getChannelMonitorService } from './services/channelMonitorService';
+import { getReactionConfirmationService } from './services/reactionConfirmationService';
 
 // Destructure only the necessary functions from util
 const {
@@ -1897,6 +1899,15 @@ async function initDiscordBot() {
                 startupDelay: 10,               // Seconds to wait before startup trigger
             });
             gachaCouponScheduler.initializeSchedules();
+
+            // Initialize channel monitor service for coupon announcements (e.g., Lost Sword)
+            const channelMonitorService = getChannelMonitorService();
+            await channelMonitorService.initialize();
+            channelMonitorService.startMonitoring(bot);
+
+            // Initialize reaction confirmation service for manual redemption tracking
+            const reactionConfirmationService = getReactionConfirmationService();
+            reactionConfirmationService.startListening(bot);
 
             enableAutoComplete();
             handleMessages();

--- a/src/services/channelMonitorService.ts
+++ b/src/services/channelMonitorService.ts
@@ -1,0 +1,318 @@
+import { Client, Message, TextChannel } from 'discord.js';
+import { getGachaGuildConfigService, ChannelMonitorConfig } from './gachaGuildConfigService';
+import { getGachaDataService } from './gachaDataService';
+import { getGachaRedemptionService } from './gachaRedemptionService';
+import { GachaGameId, GachaCoupon } from '../utils/interfaces/GachaCoupon.interface';
+import { GACHA_GAMES, getGameConfig } from '../utils/data/gachaGamesConfig';
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+/**
+ * Parsed coupon information from an announcement message
+ */
+export interface ParsedCoupon {
+    code: string;
+    rewards: string;
+    expirationDate: string | null;
+}
+
+/**
+ * Mapping of channel IDs to their corresponding game IDs
+ */
+interface ChannelToGameMap {
+    channelId: string;
+    gameId: GachaGameId;
+    config: ChannelMonitorConfig;
+}
+
+/**
+ * Service for monitoring Discord channels for coupon announcements
+ * Generic implementation that works with any game that has parsePatterns defined
+ */
+class ChannelMonitorService {
+    private static instance: ChannelMonitorService;
+    private monitoredChannels: Map<string, ChannelToGameMap> = new Map();
+    private initialized: boolean = false;
+
+    private constructor() {}
+
+    public static getInstance(): ChannelMonitorService {
+        if (!ChannelMonitorService.instance) {
+            ChannelMonitorService.instance = new ChannelMonitorService();
+        }
+        return ChannelMonitorService.instance;
+    }
+
+    /**
+     * Initialize the service by loading channel configurations from S3
+     */
+    public async initialize(): Promise<void> {
+        if (this.initialized) return;
+
+        const configService = getGachaGuildConfigService();
+        const channelMonitors = await configService.getChannelMonitors();
+
+        // Build the channel-to-game mapping
+        for (const [gameId, config] of Object.entries(channelMonitors)) {
+            // Verify the game exists and has parsePatterns
+            if (!this.isValidGameId(gameId) || !GACHA_GAMES[gameId as GachaGameId].parsePatterns) {
+                console.warn(`[ChannelMonitor] Skipping ${gameId}: no parsePatterns defined`);
+                continue;
+            }
+
+            const channelId = isDevelopment ? config.devChannelId : config.prodChannelId;
+
+            this.monitoredChannels.set(channelId, {
+                channelId,
+                gameId: gameId as GachaGameId,
+                config,
+            });
+
+            console.log(`[ChannelMonitor] Monitoring channel ${channelId} for ${gameId} (${isDevelopment ? 'dev' : 'prod'})`);
+        }
+
+        this.initialized = true;
+        console.log(`[ChannelMonitor] Initialized with ${this.monitoredChannels.size} channels`);
+    }
+
+    /**
+     * Check if a game ID is valid
+     */
+    private isValidGameId(gameId: string): gameId is GachaGameId {
+        return gameId in GACHA_GAMES;
+    }
+
+    /**
+     * Check if a channel is being monitored and return the game ID
+     */
+    public isMonitoredChannel(channelId: string): GachaGameId | null {
+        const mapping = this.monitoredChannels.get(channelId);
+        return mapping ? mapping.gameId : null;
+    }
+
+    /**
+     * Get all monitored channel IDs
+     */
+    public getMonitoredChannelIds(): string[] {
+        return Array.from(this.monitoredChannels.keys());
+    }
+
+    /**
+     * Parse an announcement message and extract coupon information
+     */
+    public parseAnnouncementMessage(gameId: GachaGameId, content: string): ParsedCoupon | null {
+        const gameConfig = GACHA_GAMES[gameId];
+        if (!gameConfig.parsePatterns) {
+            console.warn(`[ChannelMonitor] No parse patterns for game: ${gameId}`);
+            return null;
+        }
+
+        const { code: codePattern, rewards: rewardsPattern, expiration: expirationPattern } = gameConfig.parsePatterns;
+
+        // Extract coupon code
+        const codeMatch = content.match(codePattern);
+        if (!codeMatch || !codeMatch[1]) {
+            return null;
+        }
+        const code = codeMatch[1].trim().toUpperCase();
+
+        // Extract rewards
+        const rewardsMatch = content.match(rewardsPattern);
+        const rewards = rewardsMatch?.[1]?.trim() || 'Unknown rewards';
+
+        // Extract expiration date
+        const expirationMatch = content.match(expirationPattern);
+        const expirationDate = expirationMatch?.[1]
+            ? this.parseExpirationDate(expirationMatch[1])
+            : null;
+
+        return { code, rewards, expirationDate };
+    }
+
+    /**
+     * Parse expiration date string to ISO format
+     * Handles format: "January 21, 23:59 (UTC+9)"
+     */
+    public parseExpirationDate(dateString: string): string | null {
+        try {
+            // Pattern: "January 21, 23:59 (UTC+9)" or "January 21 23:59 (UTC+9)"
+            const pattern = /(\w+)\s+(\d{1,2}),?\s+(\d{1,2}):(\d{2})\s*\(UTC([+-]\d+)\)/i;
+            const match = dateString.match(pattern);
+
+            if (!match) {
+                // Try simpler format: "January 21"
+                const simplePattern = /(\w+)\s+(\d{1,2})/i;
+                const simpleMatch = dateString.match(simplePattern);
+                if (simpleMatch) {
+                    const [, month, day] = simpleMatch;
+                    const year = new Date().getFullYear();
+                    const monthIndex = this.getMonthIndex(month);
+                    if (monthIndex === -1) return null;
+
+                    // Assume end of day in UTC for simple dates
+                    const date = new Date(Date.UTC(year, monthIndex, parseInt(day), 23, 59, 59));
+
+                    // If the date is in the past, assume next year
+                    if (date < new Date()) {
+                        date.setFullYear(date.getFullYear() + 1);
+                    }
+
+                    return date.toISOString();
+                }
+                return null;
+            }
+
+            const [, month, day, hour, minute, utcOffset] = match;
+            const year = new Date().getFullYear();
+            const monthIndex = this.getMonthIndex(month);
+            if (monthIndex === -1) return null;
+
+            // Parse the UTC offset (e.g., "+9" -> 9)
+            const offsetHours = parseInt(utcOffset);
+
+            // Create date in the specified timezone, then convert to UTC
+            const date = new Date(Date.UTC(
+                year,
+                monthIndex,
+                parseInt(day),
+                parseInt(hour) - offsetHours, // Convert to UTC
+                parseInt(minute),
+                59 // End of minute
+            ));
+
+            // If the date is in the past, assume next year
+            if (date < new Date()) {
+                date.setFullYear(date.getFullYear() + 1);
+            }
+
+            return date.toISOString();
+        } catch (error) {
+            console.error('[ChannelMonitor] Failed to parse expiration date:', dateString, error);
+            return null;
+        }
+    }
+
+    /**
+     * Get month index from month name
+     */
+    private getMonthIndex(monthName: string): number {
+        const months: Record<string, number> = {
+            'january': 0, 'jan': 0,
+            'february': 1, 'feb': 1,
+            'march': 2, 'mar': 2,
+            'april': 3, 'apr': 3,
+            'may': 4,
+            'june': 5, 'jun': 5,
+            'july': 6, 'jul': 6,
+            'august': 7, 'aug': 7,
+            'september': 8, 'sep': 8, 'sept': 8,
+            'october': 9, 'oct': 9,
+            'november': 10, 'nov': 10,
+            'december': 11, 'dec': 11,
+        };
+        return months[monthName.toLowerCase()] ?? -1;
+    }
+
+    /**
+     * Handle a message from a monitored channel
+     * Parses the message, adds the coupon if new, and notifies subscribers
+     */
+    public async handleMonitoredMessage(bot: Client, message: Message): Promise<void> {
+        const gameId = this.isMonitoredChannel(message.channelId);
+        if (!gameId) return;
+
+        const content = message.content;
+        console.log(`[ChannelMonitor] Processing message in ${gameId} channel: ${content.substring(0, 100)}...`);
+
+        // Parse the announcement
+        const parsed = this.parseAnnouncementMessage(gameId, content);
+        if (!parsed) {
+            console.log(`[ChannelMonitor] No coupon found in message`);
+            return;
+        }
+
+        console.log(`[ChannelMonitor] Found coupon: ${parsed.code}, Rewards: ${parsed.rewards}, Expires: ${parsed.expirationDate}`);
+
+        // Check if coupon already exists
+        const dataService = getGachaDataService();
+        const existingCoupons = await dataService.getAllCoupons(gameId);
+        const exists = existingCoupons.some(
+            c => c.code.toUpperCase() === parsed.code.toUpperCase()
+        );
+
+        if (exists) {
+            console.log(`[ChannelMonitor] Coupon ${parsed.code} already exists, skipping`);
+            return;
+        }
+
+        // Create the coupon object
+        const coupon: GachaCoupon = {
+            code: parsed.code,
+            gameId,
+            rewards: parsed.rewards,
+            expirationDate: parsed.expirationDate,
+            addedBy: 'channel-monitor',
+            addedAt: new Date().toISOString(),
+            isActive: true,
+            source: 'Discord Announcement',
+        };
+
+        // Add the coupon
+        try {
+            await dataService.addCoupon(coupon);
+            console.log(`[ChannelMonitor] Added new coupon: ${coupon.code}`);
+
+            // Notify subscribers
+            const redemptionService = getGachaRedemptionService();
+            await redemptionService.notifyNewCode(bot, coupon);
+            console.log(`[ChannelMonitor] Notifications sent for: ${coupon.code}`);
+        } catch (error) {
+            console.error(`[ChannelMonitor] Error adding coupon:`, error);
+        }
+    }
+
+    /**
+     * Set up the messageCreate event listener
+     */
+    public startMonitoring(bot: Client): void {
+        bot.on('messageCreate', async (message: Message) => {
+            // Ignore bot messages
+            if (message.author.bot) return;
+
+            // Check if this is a monitored channel
+            const gameId = this.isMonitoredChannel(message.channelId);
+            if (!gameId) return;
+
+            try {
+                await this.handleMonitoredMessage(bot, message);
+            } catch (error) {
+                console.error(`[ChannelMonitor] Error handling message:`, error);
+            }
+        });
+
+        console.log(`[ChannelMonitor] Message monitoring started`);
+    }
+
+    /**
+     * Convert an ISO date to Discord epoch timestamp
+     */
+    public toDiscordTimestamp(isoDate: string | null, format: 'R' | 'F' | 'f' | 'D' | 'd' | 'T' | 't' = 'R'): string {
+        if (!isoDate) return 'No expiration';
+        const epoch = Math.floor(new Date(isoDate).getTime() / 1000);
+        return `<t:${epoch}:${format}>`;
+    }
+
+    /**
+     * Reset the service (for testing)
+     */
+    public reset(): void {
+        this.monitoredChannels.clear();
+        this.initialized = false;
+    }
+}
+
+/**
+ * Get the singleton instance
+ */
+export const getChannelMonitorService = (): ChannelMonitorService =>
+    ChannelMonitorService.getInstance();

--- a/src/services/gachaDataService.ts
+++ b/src/services/gachaDataService.ts
@@ -490,6 +490,88 @@ export class GachaDataService {
     }
 
     /**
+     * Remove a code from a user's redeemed codes list
+     */
+    public async removeRedeemedCode(discordId: string, gameId: GachaGameId, code: string): Promise<boolean> {
+        const data = await this.getData();
+        const user = data.subscriptions.find(s => s.discordId === discordId);
+        const gameSub = user?.games[gameId];
+
+        if (!gameSub) {
+            return false;
+        }
+
+        const normalizedCode = code.toUpperCase();
+        const index = gameSub.redeemedCodes.indexOf(normalizedCode);
+        if (index === -1) {
+            return false;
+        }
+
+        gameSub.redeemedCodes.splice(index, 1);
+        await this.saveData(data);
+        return true;
+    }
+
+    /**
+     * Add a code to a user's ignored codes list
+     */
+    public async addIgnoredCode(discordId: string, gameId: GachaGameId, code: string): Promise<boolean> {
+        const data = await this.getData();
+        const user = data.subscriptions.find(s => s.discordId === discordId);
+        const gameSub = user?.games[gameId];
+
+        if (!gameSub) {
+            return false;
+        }
+
+        const normalizedCode = code.toUpperCase();
+        if (!gameSub.ignoredCodes) {
+            gameSub.ignoredCodes = [];
+        }
+
+        if (!gameSub.ignoredCodes.includes(normalizedCode)) {
+            gameSub.ignoredCodes.push(normalizedCode);
+            await this.saveData(data);
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove a code from a user's ignored codes list
+     */
+    public async removeIgnoredCode(discordId: string, gameId: GachaGameId, code: string): Promise<boolean> {
+        const data = await this.getData();
+        const user = data.subscriptions.find(s => s.discordId === discordId);
+        const gameSub = user?.games[gameId];
+
+        if (!gameSub || !gameSub.ignoredCodes) {
+            return false;
+        }
+
+        const normalizedCode = code.toUpperCase();
+        const index = gameSub.ignoredCodes.indexOf(normalizedCode);
+        if (index === -1) {
+            return false;
+        }
+
+        gameSub.ignoredCodes.splice(index, 1);
+        await this.saveData(data);
+        return true;
+    }
+
+    /**
+     * Check if a code is ignored by a user
+     */
+    public async isCodeIgnored(discordId: string, gameId: GachaGameId, code: string): Promise<boolean> {
+        const gameSub = await this.getGameSubscription(discordId, gameId);
+        if (!gameSub || !gameSub.ignoredCodes) {
+            return false;
+        }
+        return gameSub.ignoredCodes.includes(code.toUpperCase());
+    }
+
+    /**
      * Batch mark codes as redeemed for multiple users
      * Reduces S3 operations from N to 1 for batch processing
      */

--- a/src/services/gachaRedemptionService.ts
+++ b/src/services/gachaRedemptionService.ts
@@ -1029,8 +1029,8 @@ export class GachaRedemptionService {
                 value: reactionService.getReactionInstructions(),
             });
 
-            // Include metadata in footer for reaction handling
-            const footerText = reactionService.buildFooterText('Gacha Coupon System', coupon.gameId, coupon.code);
+            // Clean footer with game name (code is parsed from embed content)
+            const footerText = reactionService.buildFooterText('Gacha Coupon System', coupon.gameId);
             embed.setFooter({ text: footerText, iconURL: RAPI_BOT_THUMBNAIL_URL });
         } else {
             // Standard footer for auto-redeem games
@@ -1191,8 +1191,8 @@ export class GachaRedemptionService {
                                 })
                                 .setTimestamp();
 
-                            // Include metadata in footer for reaction handling
-                            const footerText = reactionService.buildFooterText('Gacha Coupon System', gameId, coupon.code);
+                            // Clean footer with game name (code is parsed from embed content)
+                            const footerText = reactionService.buildFooterText('Gacha Coupon System', gameId);
                             embed.setFooter({ text: footerText, iconURL: RAPI_BOT_THUMBNAIL_URL });
 
                             const message = await this.sendDMWithDelay(user, { embeds: [embed] }, gameId);

--- a/src/services/reactionConfirmationService.ts
+++ b/src/services/reactionConfirmationService.ts
@@ -1,0 +1,249 @@
+import { Client, Message, MessageReaction, User, PartialMessageReaction, PartialUser, EmbedBuilder } from 'discord.js';
+import { getGachaDataService } from './gachaDataService';
+import { GachaGameId } from '../utils/interfaces/GachaCoupon.interface';
+import { getGameConfig, GACHA_GAMES } from '../utils/data/gachaGamesConfig';
+
+/**
+ * Reaction emojis for manual confirmation
+ */
+export const CONFIRMATION_EMOJIS = {
+    REDEEMED: '✅',    // Mark as redeemed
+    IGNORE: '❌',       // Ignore warnings for this code
+    RESET: '🔄',        // Reset (undo previous reaction)
+} as const;
+
+/**
+ * Metadata stored in embed footer for parsing
+ * Format: "GAMEDATA:gameId:code"
+ */
+const METADATA_PREFIX = 'GAMEDATA';
+
+/**
+ * Service for handling reaction-based confirmations on DM messages
+ * Used for games that don't support auto-redemption (like Lost Sword)
+ */
+class ReactionConfirmationService {
+    private static instance: ReactionConfirmationService;
+
+    private constructor() {}
+
+    public static getInstance(): ReactionConfirmationService {
+        if (!ReactionConfirmationService.instance) {
+            ReactionConfirmationService.instance = new ReactionConfirmationService();
+        }
+        return ReactionConfirmationService.instance;
+    }
+
+    /**
+     * Add reaction buttons to a message
+     */
+    public async addReactionButtons(message: Message): Promise<void> {
+        await message.react(CONFIRMATION_EMOJIS.REDEEMED);
+        await message.react(CONFIRMATION_EMOJIS.IGNORE);
+        await message.react(CONFIRMATION_EMOJIS.RESET);
+    }
+
+    /**
+     * Create metadata string for embed footer
+     * This allows us to recover context when handling reactions
+     */
+    public createMetadata(gameId: GachaGameId, code: string): string {
+        return `${METADATA_PREFIX}:${gameId}:${code}`;
+    }
+
+    /**
+     * Parse metadata from embed footer
+     */
+    public parseMetadata(footerText: string): { gameId: GachaGameId; code: string } | null {
+        const parts = footerText.split(' | ');
+        for (const part of parts) {
+            if (part.startsWith(METADATA_PREFIX)) {
+                const [, gameId, code] = part.split(':');
+                if (gameId && code && gameId in GACHA_GAMES) {
+                    return { gameId: gameId as GachaGameId, code };
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Build embed footer text with metadata
+     */
+    public buildFooterText(baseText: string, gameId: GachaGameId, code: string): string {
+        return `${baseText} | ${this.createMetadata(gameId, code)}`;
+    }
+
+    /**
+     * Check if a game supports reaction-based confirmation
+     * (games without auto-redeem support)
+     */
+    public supportsReactionConfirmation(gameId: GachaGameId): boolean {
+        const config = GACHA_GAMES[gameId];
+        return !config.supportsAutoRedeem;
+    }
+
+    /**
+     * Handle a reaction on a DM message
+     */
+    public async handleReaction(
+        reaction: MessageReaction | PartialMessageReaction,
+        user: User | PartialUser,
+        bot: Client
+    ): Promise<void> {
+        // Ignore bot reactions
+        if (user.bot) return;
+
+        // Fetch partial reaction if needed
+        if (reaction.partial) {
+            try {
+                await reaction.fetch();
+            } catch (error) {
+                console.error('[ReactionConfirmation] Failed to fetch reaction:', error);
+                return;
+            }
+        }
+
+        // Fetch partial message if needed
+        let message = reaction.message;
+        if (message.partial) {
+            try {
+                message = await message.fetch();
+            } catch (error) {
+                console.error('[ReactionConfirmation] Failed to fetch message:', error);
+                return;
+            }
+        }
+
+        // Only handle DM messages
+        if (message.channel.isDMBased() === false) return;
+
+        // Only handle messages from the bot
+        if (message.author?.id !== bot.user?.id) return;
+
+        // Get the emoji
+        const emoji = reaction.emoji.name;
+        if (!emoji || !Object.values(CONFIRMATION_EMOJIS).includes(emoji as any)) return;
+
+        // Parse metadata from embed footer
+        const embed = message.embeds[0];
+        if (!embed?.footer?.text) return;
+
+        const metadata = this.parseMetadata(embed.footer.text);
+        if (!metadata) return;
+
+        const { gameId, code } = metadata;
+        const discordId = user.id;
+
+        console.log(`[ReactionConfirmation] User ${discordId} reacted with ${emoji} on ${gameId}:${code}`);
+
+        const dataService = getGachaDataService();
+
+        try {
+            switch (emoji) {
+                case CONFIRMATION_EMOJIS.REDEEMED:
+                    // Mark code as redeemed
+                    await dataService.markCodesRedeemed(discordId, gameId, [code]);
+                    await this.updateMessageForRedeemed(message, code);
+                    console.log(`[ReactionConfirmation] Marked ${code} as redeemed for ${discordId}`);
+                    break;
+
+                case CONFIRMATION_EMOJIS.IGNORE:
+                    // Add to ignored codes
+                    await dataService.addIgnoredCode(discordId, gameId, code);
+                    await this.updateMessageForIgnored(message, code);
+                    console.log(`[ReactionConfirmation] Added ${code} to ignored for ${discordId}`);
+                    break;
+
+                case CONFIRMATION_EMOJIS.RESET:
+                    // Remove from both redeemed and ignored
+                    await dataService.removeRedeemedCode(discordId, gameId, code);
+                    await dataService.removeIgnoredCode(discordId, gameId, code);
+                    await this.updateMessageForReset(message, code);
+                    console.log(`[ReactionConfirmation] Reset ${code} status for ${discordId}`);
+                    break;
+            }
+
+            // Remove user's reaction to allow re-use
+            await reaction.users.remove(user.id);
+        } catch (error) {
+            console.error(`[ReactionConfirmation] Error handling reaction:`, error);
+        }
+    }
+
+    /**
+     * Update message embed to show redeemed status
+     */
+    private async updateMessageForRedeemed(message: Message, code: string): Promise<void> {
+        const embed = message.embeds[0];
+        if (!embed) return;
+
+        const updatedEmbed = EmbedBuilder.from(embed)
+            .setColor(0x00FF00) // Green
+            .setDescription(`✅ **Code \`${code}\` marked as redeemed!**\n\nYou won't receive more reminders for this code.`);
+
+        await message.edit({ embeds: [updatedEmbed] });
+    }
+
+    /**
+     * Update message embed to show ignored status
+     */
+    private async updateMessageForIgnored(message: Message, code: string): Promise<void> {
+        const embed = message.embeds[0];
+        if (!embed) return;
+
+        const updatedEmbed = EmbedBuilder.from(embed)
+            .setColor(0x808080) // Gray
+            .setDescription(`❌ **Code \`${code}\` ignored.**\n\nYou won't receive more reminders for this code.\nReact with 🔄 to undo.`);
+
+        await message.edit({ embeds: [updatedEmbed] });
+    }
+
+    /**
+     * Update message embed to show reset status
+     */
+    private async updateMessageForReset(message: Message, code: string): Promise<void> {
+        const embed = message.embeds[0];
+        if (!embed) return;
+
+        const updatedEmbed = EmbedBuilder.from(embed)
+            .setColor(0xFFA500) // Orange (back to warning color)
+            .setDescription(`🔄 **Code \`${code}\` status reset.**\n\nYou'll receive reminders for this code again.`);
+
+        await message.edit({ embeds: [updatedEmbed] });
+    }
+
+    /**
+     * Set up the messageReactionAdd event listener
+     */
+    public startListening(bot: Client): void {
+        bot.on('messageReactionAdd', async (reaction, user) => {
+            try {
+                await this.handleReaction(reaction, user, bot);
+            } catch (error) {
+                console.error('[ReactionConfirmation] Error in reaction handler:', error);
+            }
+        });
+
+        console.log('[ReactionConfirmation] Reaction listening started');
+    }
+
+    /**
+     * Get instructions text for reaction-based games
+     */
+    public getReactionInstructions(): string {
+        return `
+━━━━━━━━━━━━━━━━━━━━━━
+**React to mark this code:**
+✅ - I've redeemed this code
+❌ - Ignore warnings for this code
+🔄 - Reset (undo previous reaction)
+`.trim();
+    }
+}
+
+/**
+ * Get the singleton instance
+ */
+export const getReactionConfirmationService = (): ReactionConfirmationService =>
+    ReactionConfirmationService.getInstance();

--- a/src/services/tests/channelMonitorService.test.ts
+++ b/src/services/tests/channelMonitorService.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getChannelMonitorService } from '../channelMonitorService';
+
+// Mock dependencies
+vi.mock('../gachaGuildConfigService', () => ({
+    getGachaGuildConfigService: vi.fn(() => ({
+        getChannelMonitors: vi.fn().mockResolvedValue({
+            'lost-sword': {
+                guildId: '1065055945123708928',
+                prodChannelId: '1458612534289629214',
+                devChannelId: '1458672383417253888',
+            },
+        }),
+    })),
+}));
+
+vi.mock('../gachaDataService', () => ({
+    getGachaDataService: vi.fn(() => ({
+        addCoupon: vi.fn().mockResolvedValue(undefined),
+        getAllCoupons: vi.fn().mockResolvedValue([]),
+    })),
+}));
+
+vi.mock('../gachaRedemptionService', () => ({
+    getGachaRedemptionService: vi.fn(() => ({
+        notifyNewCode: vi.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+describe('ChannelMonitorService', () => {
+    let service: ReturnType<typeof getChannelMonitorService>;
+
+    beforeEach(() => {
+        // Reset singleton
+        const ChannelMonitorService = getChannelMonitorService();
+        ChannelMonitorService.reset();
+        service = getChannelMonitorService();
+    });
+
+    describe('parseAnnouncementMessage', () => {
+        it('should extract coupon code from Lost Sword announcement', () => {
+            const content = `📌 Coupon Code
+GLORYLS26
+
+📌 Rewards
+Legendary Gift Box x5
+
+📌 Redemption Period
+Until January 21, 23:59 (UTC+9)`;
+
+            const result = service.parseAnnouncementMessage('lost-sword', content);
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toBe('GLORYLS26');
+        });
+
+        it('should extract rewards from announcement', () => {
+            const content = `📌 Coupon Code
+TESTCODE123
+
+📌 Rewards
+Legendary Gift Box x5
+
+📌 Redemption Period
+Until January 21, 23:59 (UTC+9)`;
+
+            const result = service.parseAnnouncementMessage('lost-sword', content);
+
+            expect(result).not.toBeNull();
+            expect(result?.rewards).toBe('Legendary Gift Box x5');
+        });
+
+        it('should parse expiration date with UTC+9 timezone', () => {
+            const content = `📌 Coupon Code
+TESTCODE123
+
+📌 Rewards
+Test Reward
+
+📌 Redemption Period
+Until January 21, 23:59 (UTC+9)`;
+
+            const result = service.parseAnnouncementMessage('lost-sword', content);
+
+            expect(result).not.toBeNull();
+            expect(result?.expirationDate).not.toBeNull();
+            // The date should be converted to UTC (23:59 UTC+9 = 14:59 UTC)
+            const expDate = new Date(result!.expirationDate!);
+            expect(expDate.getUTCHours()).toBe(14);
+            expect(expDate.getUTCMinutes()).toBe(59);
+        });
+
+        it('should return null if no coupon code found', () => {
+            const content = `This is just a regular announcement without any coupon code.`;
+
+            const result = service.parseAnnouncementMessage('lost-sword', content);
+
+            expect(result).toBeNull();
+        });
+
+        it('should handle missing rewards gracefully', () => {
+            const content = `📌 Coupon Code
+TESTCODE123
+
+📌 Redemption Period
+Until January 21, 23:59 (UTC+9)`;
+
+            const result = service.parseAnnouncementMessage('lost-sword', content);
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toBe('TESTCODE123');
+            expect(result?.rewards).toBe('Unknown rewards');
+        });
+
+        it('should handle missing expiration date', () => {
+            const content = `📌 Coupon Code
+TESTCODE123
+
+📌 Rewards
+Some Rewards`;
+
+            const result = service.parseAnnouncementMessage('lost-sword', content);
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toBe('TESTCODE123');
+            expect(result?.expirationDate).toBeNull();
+        });
+
+        it('should handle lowercase coupon codes and normalize to uppercase', () => {
+            const content = `📌 Coupon Code
+testcode123
+
+📌 Rewards
+Test Reward`;
+
+            const result = service.parseAnnouncementMessage('lost-sword', content);
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toBe('TESTCODE123');
+        });
+    });
+
+    describe('parseExpirationDate', () => {
+        it('should parse "January 21, 23:59 (UTC+9)" format', () => {
+            const result = service.parseExpirationDate('January 21, 23:59 (UTC+9)');
+
+            expect(result).not.toBeNull();
+            const date = new Date(result!);
+            expect(date.getUTCMonth()).toBe(0); // January
+            expect(date.getUTCDate()).toBe(21);
+            expect(date.getUTCHours()).toBe(14); // 23:59 UTC+9 = 14:59 UTC
+            expect(date.getUTCMinutes()).toBe(59);
+        });
+
+        it('should convert to UTC correctly for different timezones', () => {
+            const resultPlus9 = service.parseExpirationDate('February 15, 12:00 (UTC+9)');
+            const datePlus9 = new Date(resultPlus9!);
+
+            expect(datePlus9.getUTCHours()).toBe(3); // 12:00 UTC+9 = 03:00 UTC
+        });
+
+        it('should handle different month names', () => {
+            const months = [
+                { name: 'March 1, 10:00 (UTC+0)', expected: 2 },
+                { name: 'December 25, 18:00 (UTC+0)', expected: 11 },
+                { name: 'July 4, 12:00 (UTC+0)', expected: 6 },
+            ];
+
+            months.forEach(({ name, expected }) => {
+                const result = service.parseExpirationDate(name);
+                expect(result).not.toBeNull();
+                const date = new Date(result!);
+                expect(date.getUTCMonth()).toBe(expected);
+            });
+        });
+
+        it('should return null for unparseable dates', () => {
+            const result = service.parseExpirationDate('Not a valid date');
+
+            expect(result).toBeNull();
+        });
+
+        it('should handle simple date format without time', () => {
+            const result = service.parseExpirationDate('January 21');
+
+            expect(result).not.toBeNull();
+            const date = new Date(result!);
+            expect(date.getUTCMonth()).toBe(0); // January
+            expect(date.getUTCDate()).toBe(21);
+        });
+    });
+
+    describe('isMonitoredChannel', () => {
+        it('should return null for non-monitored channel when not initialized', () => {
+            const result = service.isMonitoredChannel('1234567890');
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('toDiscordTimestamp', () => {
+        it('should convert ISO date to Discord relative timestamp', () => {
+            const isoDate = '2025-01-21T14:59:00.000Z';
+            const result = service.toDiscordTimestamp(isoDate, 'R');
+
+            expect(result).toMatch(/^<t:\d+:R>$/);
+        });
+
+        it('should handle null date', () => {
+            const result = service.toDiscordTimestamp(null, 'R');
+
+            expect(result).toBe('No expiration');
+        });
+
+        it('should support different format specifiers', () => {
+            const isoDate = '2025-01-21T14:59:00.000Z';
+
+            expect(service.toDiscordTimestamp(isoDate, 'F')).toMatch(/^<t:\d+:F>$/);
+            expect(service.toDiscordTimestamp(isoDate, 'f')).toMatch(/^<t:\d+:f>$/);
+            expect(service.toDiscordTimestamp(isoDate, 'D')).toMatch(/^<t:\d+:D>$/);
+        });
+    });
+
+    describe('getMonitoredChannelIds', () => {
+        it('should return empty array when not initialized', () => {
+            const result = service.getMonitoredChannelIds();
+
+            expect(result).toEqual([]);
+        });
+    });
+});

--- a/src/services/tests/reactionConfirmationService.test.ts
+++ b/src/services/tests/reactionConfirmationService.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getReactionConfirmationService, CONFIRMATION_EMOJIS } from '../reactionConfirmationService';
+
+// Mock dependencies
+vi.mock('../gachaDataService', () => ({
+    getGachaDataService: vi.fn(() => ({
+        markCodesRedeemed: vi.fn().mockResolvedValue(true),
+        addIgnoredCode: vi.fn().mockResolvedValue(true),
+        removeRedeemedCode: vi.fn().mockResolvedValue(true),
+        removeIgnoredCode: vi.fn().mockResolvedValue(true),
+    })),
+}));
+
+vi.mock('../../utils/data/gachaGamesConfig', () => ({
+    GACHA_GAMES: {
+        'bd2': {
+            id: 'bd2',
+            name: 'Brown Dust 2',
+            supportsAutoRedeem: true,
+        },
+        'lost-sword': {
+            id: 'lost-sword',
+            name: 'Lost Sword',
+            supportsAutoRedeem: false,
+        },
+    },
+    getGameConfig: vi.fn((gameId: string) => ({
+        id: gameId,
+        name: gameId === 'bd2' ? 'Brown Dust 2' : 'Lost Sword',
+        supportsAutoRedeem: gameId === 'bd2',
+    })),
+}));
+
+describe('ReactionConfirmationService', () => {
+    let service: ReturnType<typeof getReactionConfirmationService>;
+
+    beforeEach(() => {
+        service = getReactionConfirmationService();
+    });
+
+    describe('CONFIRMATION_EMOJIS', () => {
+        it('should have correct emoji values', () => {
+            expect(CONFIRMATION_EMOJIS.REDEEMED).toBe('✅');
+            expect(CONFIRMATION_EMOJIS.IGNORE).toBe('❌');
+            expect(CONFIRMATION_EMOJIS.RESET).toBe('🔄');
+        });
+    });
+
+    describe('createMetadata', () => {
+        it('should create metadata string in correct format', () => {
+            const result = service.createMetadata('lost-sword', 'TESTCODE123');
+
+            expect(result).toBe('GAMEDATA:lost-sword:TESTCODE123');
+        });
+
+        it('should work with different game IDs', () => {
+            const result = service.createMetadata('bd2', 'BD2CODE');
+
+            expect(result).toBe('GAMEDATA:bd2:BD2CODE');
+        });
+    });
+
+    describe('parseMetadata', () => {
+        it('should parse metadata from footer text', () => {
+            const footerText = 'Gacha Coupon System | GAMEDATA:lost-sword:TESTCODE123';
+            const result = service.parseMetadata(footerText);
+
+            expect(result).not.toBeNull();
+            expect(result?.gameId).toBe('lost-sword');
+            expect(result?.code).toBe('TESTCODE123');
+        });
+
+        it('should return null for footer without metadata', () => {
+            const footerText = 'Gacha Coupon System';
+            const result = service.parseMetadata(footerText);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null for invalid game ID in metadata', () => {
+            const footerText = 'Gacha Coupon System | GAMEDATA:invalid-game:CODE';
+            const result = service.parseMetadata(footerText);
+
+            expect(result).toBeNull();
+        });
+
+        it('should handle metadata at different positions in footer', () => {
+            const footerText = 'GAMEDATA:lost-sword:CODE | Some other text';
+            const result = service.parseMetadata(footerText);
+
+            expect(result).not.toBeNull();
+            expect(result?.gameId).toBe('lost-sword');
+            expect(result?.code).toBe('CODE');
+        });
+    });
+
+    describe('buildFooterText', () => {
+        it('should build footer text with metadata', () => {
+            const result = service.buildFooterText('Gacha Coupon System', 'lost-sword', 'CODE123');
+
+            expect(result).toBe('Gacha Coupon System | GAMEDATA:lost-sword:CODE123');
+        });
+    });
+
+    describe('supportsReactionConfirmation', () => {
+        it('should return true for games without auto-redeem', () => {
+            const result = service.supportsReactionConfirmation('lost-sword');
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false for games with auto-redeem', () => {
+            const result = service.supportsReactionConfirmation('bd2');
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('getReactionInstructions', () => {
+        it('should return instructions string with all emojis', () => {
+            const result = service.getReactionInstructions();
+
+            expect(result).toContain('✅');
+            expect(result).toContain('❌');
+            expect(result).toContain('🔄');
+            expect(result).toContain('redeemed');
+            expect(result).toContain('Ignore');
+            expect(result).toContain('Reset');
+        });
+    });
+
+    describe('Metadata round-trip', () => {
+        it('should correctly round-trip metadata creation and parsing', () => {
+            const gameId = 'lost-sword';
+            const code = 'ROUNDTRIP123';
+
+            const footerText = service.buildFooterText('Gacha Coupon System', gameId, code);
+            const parsed = service.parseMetadata(footerText);
+
+            expect(parsed).not.toBeNull();
+            expect(parsed?.gameId).toBe(gameId);
+            expect(parsed?.code).toBe(code);
+        });
+    });
+});

--- a/src/utils/data/gachaGamesConfig.ts
+++ b/src/utils/data/gachaGamesConfig.ts
@@ -27,6 +27,7 @@ export const GACHA_GAMES: Record<GachaGameId, GachaGameConfig> = {
         maxNicknameLength: 24,
         maxCodeLength: 30,
         userIdFieldName: 'nickname',
+        requiresUserId: true,
     },
     'lost-sword': {
         id: 'lost-sword',
@@ -40,11 +41,17 @@ export const GACHA_GAMES: Record<GachaGameId, GachaGameConfig> = {
         maxNicknameLength: 20,
         maxCodeLength: 20,
         userIdFieldName: 'Account ID',
+        requiresUserId: false,
         hasChannelMonitor: true,
         parsePatterns: {
-            code: /📌\s*Coupon Code\s*\n([A-Z0-9]+)/i,
-            rewards: /📌\s*Rewards\s*\n(.+?)(?=\n📌|$)/s,
-            expiration: /📌\s*Redemption Period\s*\nUntil\s+(.+)/i,
+            // Match both formats:
+            // Simple: "📌 Coupon Code\nCODE123"
+            // Discord: "> **📌 Coupon Code**\n> `CODE123`"
+            code: /\*{0,2}📌\s*Coupon Code\*{0,2}\s*\n(?:>\s*)?`?([A-Z0-9]+)`?/i,
+            // Match rewards (handles both simple and Discord formatted)
+            rewards: /\*{0,2}📌\s*Rewards\*{0,2}\s*\n(?:>\s*)?-?\s*(.+?)(?=\n(?:>\s*)?\n|\n(?:>\s*)?\*{0,2}📌|$)/s,
+            // Match expiration date (handles both formats)
+            expiration: /\*{0,2}📌\s*Redemption Period\*{0,2}\s*\n(?:>\s*)?-?\s*Until\s+(.+)/i,
         },
     },
     // TODO: Implement NIKKE support later

--- a/src/utils/data/gachaGamesConfig.ts
+++ b/src/utils/data/gachaGamesConfig.ts
@@ -28,6 +28,25 @@ export const GACHA_GAMES: Record<GachaGameId, GachaGameConfig> = {
         maxCodeLength: 30,
         userIdFieldName: 'nickname',
     },
+    'lost-sword': {
+        id: 'lost-sword',
+        name: 'Lost Sword',
+        shortName: 'LS',
+        // Lost Sword uses in-game redemption only (Settings > Account > Redeem Coupon)
+        manualRedeemUrl: undefined,
+        supportsAutoRedeem: false,
+        logoPath: `${cdnDomainUrl}/assets/logos/lost-sword-logo.png`,
+        embedColor: 0x8B4513, // Brown/sword color
+        maxNicknameLength: 20,
+        maxCodeLength: 20,
+        userIdFieldName: 'Account ID',
+        hasChannelMonitor: true,
+        parsePatterns: {
+            code: /📌\s*Coupon Code\s*\n([A-Z0-9]+)/i,
+            rewards: /📌\s*Rewards\s*\n(.+?)(?=\n📌|$)/s,
+            expiration: /📌\s*Redemption Period\s*\nUntil\s+(.+)/i,
+        },
+    },
     // TODO: Implement NIKKE support later
     // 'nikke': {
     //     id: 'nikke',

--- a/src/utils/interfaces/GachaCoupon.interface.ts
+++ b/src/utils/interfaces/GachaCoupon.interface.ts
@@ -30,7 +30,7 @@
  * Add new games here as they are supported
  * TODO: Re-add 'nikke' | 'blue-archive' when those games are implemented
  */
-export type GachaGameId = 'bd2';
+export type GachaGameId = 'bd2' | 'lost-sword';
 
 /**
  * Configuration for a supported gacha game
@@ -64,6 +64,17 @@ export interface GachaGameConfig {
     maxCodeLength: number;
     /** Field name for user identifier (e.g., "nickname", "UID", "player ID") */
     userIdFieldName: string;
+    /** Whether this game uses Discord channel monitoring for code announcements */
+    hasChannelMonitor?: boolean;
+    /** Regex patterns for parsing announcement messages */
+    parsePatterns?: {
+        /** Pattern to extract coupon code */
+        code: RegExp;
+        /** Pattern to extract rewards description */
+        rewards: RegExp;
+        /** Pattern to extract expiration date/time */
+        expiration: RegExp;
+    };
 }
 
 /**
@@ -115,6 +126,8 @@ export interface GameSubscription {
     subscribedAt: string;
     /** Array of coupon codes already redeemed for this user */
     redeemedCodes: string[];
+    /** Array of coupon codes user chose to ignore (no more warnings) */
+    ignoredCodes?: string[];
     /** ISO timestamp of last notification sent */
     lastNotified?: string;
     /** ISO timestamp of last force re-run request (for cooldown tracking) */

--- a/src/utils/interfaces/GachaCoupon.interface.ts
+++ b/src/utils/interfaces/GachaCoupon.interface.ts
@@ -64,6 +64,8 @@ export interface GachaGameConfig {
     maxCodeLength: number;
     /** Field name for user identifier (e.g., "nickname", "UID", "player ID") */
     userIdFieldName: string;
+    /** Whether this game requires a user ID for subscription (e.g., for auto-redeem API calls) */
+    requiresUserId: boolean;
     /** Whether this game uses Discord channel monitoring for code announcements */
     hasChannelMonitor?: boolean;
     /** Regex patterns for parsing announcement messages */


### PR DESCRIPTION
## Summary

- Add Lost Sword game support with automatic coupon detection from Discord channel announcements
- Create reaction-based confirmation system for manual redemption tracking
- Make `userid` optional for games without auto-redeem (Lost Sword)
- Add DM reaction handling with confirmation messages

## Key Features

### Channel Monitoring
- Monitor Discord channels for forwarded coupon announcements
- Auto-parse coupon code, rewards, and expiration date from message patterns
- Convert timezone-specific dates (e.g., "Until January 21, 23:59 (UTC+9)") to UTC
- Support dev/prod channel switching for testing

### Reaction Confirmation System
- Add emoji reactions to DMs: ✅ (redeemed), ❌ (ignore), 🔄 (reset)
- Parse game/code from embed content (title shortName + Code field)
- Send confirmation DMs when users react
- Update message embed color/text to show status
- Filter out ignored codes from future expiration warnings

### Subscription UX Improvements
- Make `userid` optional for Lost Sword (no account ID needed)
- Force notification-only mode for games without auto-redeem
- Update help command with Lost Sword-specific instructions
- Conditionally show userid in success embeds

### Changes
- Add `lost-sword` to `GachaGameId` type with `parsePatterns` for message parsing
- Add `requiresUserId` to `GachaGameConfig` interface
- Create `channelMonitorService.ts` - generic channel monitoring for any game
- Create `reactionConfirmationService.ts` - DM reaction handling
- Add Discord intents: `DirectMessages`, `DirectMessageReactions`
- Add partials: `Message`, `Channel`, `Reaction` for DM reaction events
- Add `ignoredCodes` field to `GameSubscription` interface
- Add helper methods: `addIgnoredCode`, `removeIgnoredCode`, `removeRedeemedCode`

## S3 Config (Manual Setup Required)

Add to `data/gacha-coupons/guild-config.json`:
```json
{
    "allowedGuildIds": ["..."],
    "channelMonitors": {
        "lost-sword": {
            "guildId": "1065055945123708928",
            "prodChannelId": "1458612534289629214",
            "devChannelId": "1458672383417253888"
        }
    },
    "lastUpdated": "...",
    "schemaVersion": 2
}
```

## Test plan

- [x] Type check passes (`npx tsc --noEmit`)
- [x] All unit tests pass (341 tests)
- [ ] Test channel monitoring in dev mode
- [ ] Verify coupon is parsed and added correctly
- [ ] Verify DM sent with reaction buttons
- [ ] Test ✅ reaction marks code as redeemed + sends confirmation DM
- [ ] Test ❌ reaction ignores code + sends confirmation DM
- [ ] Test 🔄 reaction resets status + sends confirmation DM
- [ ] Test `/redeem subscribe game:Lost Sword mode:notification-only` works without userid
- [ ] Test `/redeem subscribe game:BD2` requires userid
- [ ] Verify `/redeem help` shows Lost Sword section

🤖 Generated with [Claude Code](https://claude.com/claude-code)