### PR TITLE
fix: Prevent BD2 API rate limiting during batch redemption

### DIFF
--- a/src/services/gachaRedemptionService.ts
+++ b/src/services/gachaRedemptionService.ts
@@ -313,12 +313,16 @@ export class GachaRedemptionService {
     private lastRequestTime: Map<GachaGameId, number> = new Map();
     private handlers: Map<GachaGameId, GameRedemptionHandler> = new Map();
     private subscriberLimit = pLimit(GACHA_CONFIG.CONCURRENT_SUBSCRIBER_LIMIT);
+    private apiLimit: Map<GachaGameId, ReturnType<typeof pLimit>> = new Map();
 
     private constructor() {
         // Register game-specific handlers
         this.handlers.set('bd2', new BD2RedemptionHandler());
         // Add more handlers here as games are supported
         // this.handlers.set('nikke', new NikkeRedemptionHandler());
+
+        // Per-game API call serialization to prevent rate limit races
+        this.apiLimit.set('bd2', pLimit(1));
     }
 
     /**
@@ -407,8 +411,14 @@ export class GachaRedemptionService {
 
     /**
      * Redeem a single coupon code
+     * @param options.waitForCircuitBreaker - In batch mode, wait for circuit breaker cooldown instead of failing immediately
      */
-    public async redeemCode(gameId: GachaGameId, gameUserId: string, code: string): Promise<RedemptionResult> {
+    public async redeemCode(
+        gameId: GachaGameId,
+        gameUserId: string,
+        code: string,
+        options: { waitForCircuitBreaker?: boolean } = {}
+    ): Promise<RedemptionResult> {
         const handler = this.handlers.get(gameId);
 
         if (!handler) {
@@ -422,27 +432,45 @@ export class GachaRedemptionService {
             };
         }
 
+        const limiter = this.apiLimit.get(gameId);
+        if (limiter) {
+            return limiter(async () => {
+                if (options.waitForCircuitBreaker && circuitBreaker.isOpen(gameId)) {
+                    const status = circuitBreaker.getStatus(gameId);
+                    if (status.cooldownRemaining > 0) {
+                        logger.debug`Circuit breaker open for ${gameId}, waiting ${status.cooldownRemaining}ms...`;
+                        await new Promise(r => setTimeout(r, status.cooldownRemaining + 500));
+                    }
+                }
+                await this.enforceRateLimit(gameId);
+                return handler.redeem(gameUserId, code);
+            });
+        }
+
         await this.enforceRateLimit(gameId);
         return handler.redeem(gameUserId, code);
     }
 
     /**
      * Redeem multiple codes for a user
+     * @param options.waitForCircuitBreaker - In batch mode, wait for circuit breaker cooldown instead of failing
      */
     public async redeemMultipleCodes(
         gameId: GachaGameId,
         gameUserId: string,
-        codes: string[]
+        codes: string[],
+        options: { waitForCircuitBreaker?: boolean } = {}
     ): Promise<RedemptionResult[]> {
         const results: RedemptionResult[] = [];
 
         for (const code of codes) {
-            const result = await this.redeemCode(gameId, gameUserId, code);
+            const result = await this.redeemCode(gameId, gameUserId, code, options);
             results.push(result);
 
-            // Stop on rate limit or network errors
-            if (result.errorCode === 'RateLimited' || result.errorCode === 'NetworkError') {
-                logger.debug`Stopping batch redemption for ${gameId} due to: ${result.message}`;
+            // Only stop on hard network errors (server unreachable)
+            // RateLimited is handled by circuit breaker wait-and-retry when in batch mode
+            if (result.errorCode === 'NetworkError') {
+                logger.debug`Stopping batch for ${gameId} due to network error`;
                 break;
             }
         }
@@ -505,7 +533,8 @@ export class GachaRedemptionService {
                     const redemptionResults = await this.redeemMultipleCodes(
                         gameId,
                         subscription.gameUserId,
-                        codesToRedeem
+                        codesToRedeem,
+                        { waitForCircuitBreaker: true }
                     );
 
                     const successfulCodes = redemptionResults.filter(r => r.success).map(r => r.code);
@@ -639,8 +668,8 @@ export class GachaRedemptionService {
         const codes = activeCoupons.map(c => c.code);
         logger.debug`[Subscribe] Redeeming ${codes.length} codes for new subscriber ${gameUserId} in ${gameId}`;
 
-        // Redeem all codes
-        const results = await this.redeemMultipleCodes(gameId, gameUserId, codes);
+        // Redeem all codes (batch mode: wait for circuit breaker instead of failing)
+        const results = await this.redeemMultipleCodes(gameId, gameUserId, codes, { waitForCircuitBreaker: true });
 
         // Categorize results
         const successful = results.filter(r => r.success);

--- a/src/services/tests/gachaRedemptionService.test.ts
+++ b/src/services/tests/gachaRedemptionService.test.ts
@@ -302,7 +302,7 @@ describe('GachaRedemptionService', () => {
             expect(results[1].success).toBe(true);
         });
 
-        it('should stop on rate limit error', async () => {
+        it('should continue on rate limit error (handled by circuit breaker wait)', async () => {
             vi.mocked(global.fetch)
                 .mockResolvedValueOnce({
                     ok: true,
@@ -314,11 +314,12 @@ describe('GachaRedemptionService', () => {
                 } as Response);
 
             const service = getGachaRedemptionService();
-            const results = await service.redeemMultipleCodes('bd2', 'TestUser', ['CODE1', 'CODE2', 'CODE3']);
+            const results = await service.redeemMultipleCodes('bd2', 'TestUser', ['CODE1', 'CODE2']);
 
-            // Should stop after rate limit
-            expect(results).toHaveLength(1);
+            // RateLimited no longer stops the batch — circuit breaker wait-and-retry handles it
+            expect(results).toHaveLength(2);
             expect(results[0].errorCode).toBe('RateLimited');
+            expect(results[1].success).toBe(true);
         });
 
         it('should stop on network error', async () => {

--- a/src/utils/data/gachaConfig.ts
+++ b/src/utils/data/gachaConfig.ts
@@ -7,7 +7,7 @@ export const GACHA_CONFIG = {
     // API settings
     API_TIMEOUT_MS: 10000,
     MAX_RETRIES: 3,
-    RATE_LIMIT_DELAY: 2000,
+    RATE_LIMIT_DELAY: 2500,
 
     // Discord settings
     DM_RATE_LIMIT_DELAY: 100,


### PR DESCRIPTION
## Summary
- Serialize BD2 API calls with `pLimit(1)` to fix race condition where 5 concurrent subscribers bypass `enforceRateLimit()`
- Add circuit breaker wait-and-retry for batch operations instead of immediately aborting
- Bump `RATE_LIMIT_DELAY` from 2000ms to 2500ms

## Changes
- **Per-game API limiter**: `pLimit(1)` mutex ensures only one API call at a time per game, while subscriber processing (DM sending, filtering) stays parallel at `pLimit(5)`
- **Circuit breaker wait**: Batch methods (`processGameAutoRedemptions`, `redeemAllForUser`) wait for cooldown instead of returning `RateLimited` and aborting
- **Smarter batch break**: Only `NetworkError` (server unreachable) stops a batch; `RateLimited` is handled by the wait-and-retry

## Testing
- [x] `bunx tsc --noEmit` passes
- [x] All 712 tests pass
- [x] Updated rate limit test to match new batch-continues behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)