### PR TITLE
feat: YouTube upload notification system

### DIFF
--- a/src/bootstrap/serviceInitializer.ts
+++ b/src/bootstrap/serviceInitializer.ts
@@ -5,6 +5,7 @@ import { GachaCouponScheduler } from '../services/gachaCouponScheduler.js';
 import { getChannelMonitorService } from '../services/channelMonitorService.js';
 import { getReactionConfirmationService } from '../services/reactionConfirmationService.js';
 import { getRulesManagementService } from '../services/rulesManagementService.js';
+import { YouTubeNotificationScheduler } from '../services/youtubeNotificationScheduler.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -51,6 +52,11 @@ export async function initializeServices(bot: Client): Promise<void> {
         } else {
             logger.info`Rules management service initialized`;
         }
+
+        // Initialize YouTube upload notification scheduler
+        const youtubeScheduler = new YouTubeNotificationScheduler(bot);
+        youtubeScheduler.initializeSchedules();
+        logger.info`YouTube notification scheduler initialized`;
 
         logger.info`All services initialized successfully`;
     } catch (error) {

--- a/src/bootstrap/serviceInitializer.ts
+++ b/src/bootstrap/serviceInitializer.ts
@@ -55,7 +55,7 @@ export async function initializeServices(bot: Client): Promise<void> {
 
         // Initialize YouTube upload notification scheduler
         const youtubeScheduler = new YouTubeNotificationScheduler(bot);
-        youtubeScheduler.initializeSchedules();
+        await youtubeScheduler.initializeSchedules();
         logger.info`YouTube notification scheduler initialized`;
 
         logger.info`All services initialized successfully`;

--- a/src/services/gachaGuildConfigService.ts
+++ b/src/services/gachaGuildConfigService.ts
@@ -21,6 +21,16 @@ export interface ChannelMonitorConfig {
 }
 
 /**
+ * Per-guild YouTube notification target
+ */
+export interface YouTubeGuildNotification {
+    /** Discord guild/server ID */
+    guildId: string;
+    /** Discord channel ID to post notifications to */
+    channelId: string;
+}
+
+/**
  * Guild configuration for the gacha coupon system
  * Stored in S3 to keep server IDs private (not in open source code)
  */
@@ -29,11 +39,8 @@ export interface GachaGuildConfig {
     allowedGuildIds: string[];
     /** Channel monitoring configurations keyed by game ID */
     channelMonitors?: Record<string, ChannelMonitorConfig>;
-    /** YouTube notification settings */
-    youtubeConfig?: {
-        /** Whether YouTube notifications are enabled for this guild (default: true for all allowed guilds) */
-        enabled?: boolean;
-    };
+    /** YouTube notification settings — only guilds with entries here receive notifications */
+    youtubeNotifications?: YouTubeGuildNotification[];
     /** Rules message configuration for primary server */
     rulesConfig?: {
         /** Discord guild/server ID where rules message is managed */

--- a/src/services/gachaGuildConfigService.ts
+++ b/src/services/gachaGuildConfigService.ts
@@ -29,6 +29,11 @@ export interface GachaGuildConfig {
     allowedGuildIds: string[];
     /** Channel monitoring configurations keyed by game ID */
     channelMonitors?: Record<string, ChannelMonitorConfig>;
+    /** YouTube notification settings */
+    youtubeConfig?: {
+        /** Whether YouTube notifications are enabled for this guild (default: true for all allowed guilds) */
+        enabled?: boolean;
+    };
     /** Rules message configuration for primary server */
     rulesConfig?: {
         /** Discord guild/server ID where rules message is managed */

--- a/src/services/tests/youtubeNotificationService.test.ts
+++ b/src/services/tests/youtubeNotificationService.test.ts
@@ -56,18 +56,21 @@ const SAMPLE_RSS = `<?xml version="1.0" encoding="UTF-8"?>
     <title>Newest Video Title</title>
     <author><name>Test Channel</name></author>
     <published>2026-03-05T12:00:00+00:00</published>
+    <updated>2026-03-05T12:00:01+00:00</updated>
   </entry>
   <entry>
     <yt:videoId>video_middle</yt:videoId>
     <title>Middle Video Title</title>
     <author><name>Test Channel</name></author>
     <published>2026-03-04T12:00:00+00:00</published>
+    <updated>2026-03-04T12:00:01+00:00</updated>
   </entry>
   <entry>
     <yt:videoId>video_oldest</yt:videoId>
     <title>Oldest Video Title</title>
     <author><name>Test Channel</name></author>
     <published>2026-03-03T12:00:00+00:00</published>
+    <updated>2026-03-03T12:00:01+00:00</updated>
   </entry>
 </feed>`;
 
@@ -81,6 +84,24 @@ const SAMPLE_RSS_WITH_ENTITIES = `<?xml version="1.0" encoding="UTF-8"?>
   </entry>
 </feed>`;
 
+const SAMPLE_RSS_WITH_LIVE = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">
+  <entry>
+    <yt:videoId>live_stream_1</yt:videoId>
+    <title>🔴LIVE — Playing games</title>
+    <author><name>Test Channel</name></author>
+    <published>2026-03-05T20:00:00+00:00</published>
+    <updated>2026-03-05T23:30:00+00:00</updated>
+  </entry>
+  <entry>
+    <yt:videoId>upload_1</yt:videoId>
+    <title>Regular Upload Video</title>
+    <author><name>Test Channel</name></author>
+    <published>2026-03-05T14:00:00+00:00</published>
+    <updated>2026-03-05T14:00:01+00:00</updated>
+  </entry>
+</feed>`;
+
 const EMPTY_RSS = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">
   <title>Empty Channel</title>
@@ -89,7 +110,7 @@ const EMPTY_RSS = `<?xml version="1.0" encoding="UTF-8"?>
 function createMockS3Data(overrides: Partial<YouTubeNotificationData> = {}): YouTubeNotificationData {
     return {
         monitoredChannels: [
-            { channelId: 'UC_test_channel', channelName: 'Test Channel', discordUserId: '118451485221715977' },
+            { channelId: 'UC_test_channel', discordUserId: '118451485221715977' },
         ],
         lastSeenVideoIds: {},
         lastPolledAt: null,
@@ -204,6 +225,27 @@ describe('YouTubeNotificationService', () => {
             const entries = service.parseRssXml(SAMPLE_RSS_WITH_ENTITIES, 'UC_test');
             expect(entries[0].title).toBe('Tom & Jerry\'s "Adventure"');
         });
+
+        it('should filter out live streams based on published/updated gap', () => {
+            const entries = service.parseRssXml(SAMPLE_RSS_WITH_LIVE, 'UC_test');
+            expect(entries).toHaveLength(1);
+            expect(entries[0].videoId).toBe('upload_1');
+        });
+
+        it('should keep entries without updated tag (treated as uploads)', () => {
+            const rssNoUpdated = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">
+  <entry>
+    <yt:videoId>no_updated</yt:videoId>
+    <title>No Updated Tag</title>
+    <author><name>TC</name></author>
+    <published>2026-03-05T12:00:00+00:00</published>
+  </entry>
+</feed>`;
+            const entries = service.parseRssXml(rssNoUpdated, 'UC_test');
+            expect(entries).toHaveLength(1);
+            expect(entries[0].videoId).toBe('no_updated');
+        });
     });
 
     describe('fetchRssFeed', () => {
@@ -263,7 +305,7 @@ describe('YouTubeNotificationService', () => {
             expect(results[0].videos[1].videoId).toBe('video_newest');
         });
 
-        it('should seed lastSeenVideoId and return empty array on first run', async () => {
+        it('should post only the most recent video and seed on first run', async () => {
             const data = createMockS3Data({
                 lastSeenVideoIds: {}, // No prior state
             });
@@ -279,7 +321,9 @@ describe('YouTubeNotificationService', () => {
 
             const results = await service.checkForNewVideos();
 
-            expect(results).toHaveLength(0); // No videos to post
+            expect(results).toHaveLength(1);
+            expect(results[0].videos).toHaveLength(1);
+            expect(results[0].videos[0].videoId).toBe('video_newest');
             // Should have saved the seeded ID
             expect(s3Client.send).toHaveBeenCalledTimes(2); // getData + saveData
         });
@@ -287,8 +331,8 @@ describe('YouTubeNotificationService', () => {
         it('should handle multiple monitored channels independently', async () => {
             const data = createMockS3Data({
                 monitoredChannels: [
-                    { channelId: 'UC_channel1', channelName: 'Channel 1', discordUserId: '111' },
-                    { channelId: 'UC_channel2', channelName: 'Channel 2', discordUserId: '222' },
+                    { channelId: 'UC_channel1', discordUserId: '111' },
+                    { channelId: 'UC_channel2', discordUserId: '222' },
                 ],
                 lastSeenVideoIds: {
                     'UC_channel1': 'video_oldest',
@@ -421,7 +465,6 @@ describe('YouTubeNotificationService', () => {
             }] as YouTubeVideoEntry[],
             channelConfig: {
                 channelId: 'UC_test',
-                channelName: 'Test Channel',
                 discordUserId: '118451485221715977',
             } as YouTubeChannelConfig,
         }];
@@ -541,7 +584,7 @@ describe('YouTubeNotificationService', () => {
                         videoUrl: 'https://www.youtube.com/watch?v=vid2',
                     },
                 ] as YouTubeVideoEntry[],
-                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
+                channelConfig: { channelId: 'UC_test', discordUserId: '123' } as YouTubeChannelConfig,
             }];
 
             const result = await service.postNotifications(mockBot as Client, videoGroups);

--- a/src/services/tests/youtubeNotificationService.test.ts
+++ b/src/services/tests/youtubeNotificationService.test.ts
@@ -44,6 +44,7 @@ vi.mock('../../utils/util', () => ({
 
 import {
     getYouTubeNotificationService,
+    _testResetYouTubeService,
     YouTubeNotificationData,
     YouTubeChannelConfig,
     YouTubeVideoEntry,
@@ -120,12 +121,7 @@ describe('YouTubeNotificationService', () => {
     let mockBot: any;
 
     beforeEach(() => {
-        // Reset singleton
-        (getYouTubeNotificationService as any).instance = undefined;
-        // Force re-create by accessing private static
-        const ServiceClass = (getYouTubeNotificationService() as any).constructor;
-        ServiceClass.instance = undefined;
-
+        _testResetYouTubeService();
         service = getYouTubeNotificationService();
         service.clearCache();
 
@@ -153,6 +149,11 @@ describe('YouTubeNotificationService', () => {
 
         mockGuildConfigService = {
             getAllowedGuildIds: vi.fn().mockResolvedValue(['guild_123']),
+            getConfig: vi.fn().mockResolvedValue({
+                allowedGuildIds: ['guild_123'],
+                lastUpdated: new Date().toISOString(),
+                schemaVersion: 1,
+            }),
         };
 
         vi.mocked(getGachaGuildConfigService).mockReturnValue(mockGuildConfigService);
@@ -368,6 +369,28 @@ describe('YouTubeNotificationService', () => {
             expect(results).toHaveLength(0);
         });
 
+        it('should re-seed when lastSeenVideoId is not found in feed (deleted video)', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: { 'UC_test_channel': 'deleted_video_id' },
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Mock saveData
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            const results = await service.checkForNewVideos();
+
+            // Should re-seed instead of treating all 15 as new
+            expect(results).toHaveLength(0);
+            // Should still save the re-seeded ID
+            expect(s3Client.send).toHaveBeenCalledTimes(2);
+        });
+
         it('should persist seeded IDs to S3 even when no new videos to post', async () => {
             const data = createMockS3Data({
                 lastSeenVideoIds: {}, // First run
@@ -475,6 +498,30 @@ describe('YouTubeNotificationService', () => {
 
             expect(result.errors).toBe(1);
             expect(result.notified).toBe(0);
+        });
+
+        it('should skip all guilds when youtubeConfig.enabled is false', async () => {
+            mockGuildConfigService.getConfig.mockResolvedValueOnce({
+                allowedGuildIds: ['guild_123'],
+                youtubeConfig: { enabled: false },
+                lastUpdated: new Date().toISOString(),
+                schemaVersion: 1,
+            });
+
+            const videoGroups = [{
+                videos: [{
+                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
+                    publishedAt: '2026-03-05T12:00:00Z',
+                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
+                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
+                }] as YouTubeVideoEntry[],
+                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
+            }];
+
+            const result = await service.postNotifications(mockBot as Client, videoGroups);
+
+            expect(result.notified).toBe(0);
+            expect(mockChannel.send).not.toHaveBeenCalled();
         });
 
         it('should post multiple videos for a channel in order', async () => {

--- a/src/services/tests/youtubeNotificationService.test.ts
+++ b/src/services/tests/youtubeNotificationService.test.ts
@@ -1,0 +1,599 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Client, Guild, TextChannel, ChannelType } from 'discord.js';
+
+// Set environment variable before any imports
+vi.stubEnv('CDN_DOMAIN_URL', 'https://cdn.example.com');
+
+// Mock EmbedBuilder
+vi.mock('discord.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('discord.js')>();
+    return {
+        ...actual,
+        EmbedBuilder: vi.fn().mockImplementation(() => ({
+            setColor: vi.fn().mockReturnThis(),
+            setTitle: vi.fn().mockReturnThis(),
+            setURL: vi.fn().mockReturnThis(),
+            setAuthor: vi.fn().mockReturnThis(),
+            setImage: vi.fn().mockReturnThis(),
+            setTimestamp: vi.fn().mockReturnThis(),
+            setFooter: vi.fn().mockReturnThis(),
+            setThumbnail: vi.fn().mockReturnThis(),
+            setDescription: vi.fn().mockReturnThis(),
+            toJSON: vi.fn().mockReturnValue({}),
+        })),
+    };
+});
+
+// Mock S3
+vi.mock('../../utils/cdn/config', () => ({
+    s3Client: {
+        send: vi.fn(),
+    },
+    S3_BUCKET: 'test-bucket',
+}));
+
+// Mock guild config service
+vi.mock('../gachaGuildConfigService', () => ({
+    getGachaGuildConfigService: vi.fn(),
+}));
+
+// Mock util
+vi.mock('../../utils/util', () => ({
+    findChannelByName: vi.fn(),
+}));
+
+import {
+    getYouTubeNotificationService,
+    YouTubeNotificationData,
+    YouTubeChannelConfig,
+    YouTubeVideoEntry,
+} from '../youtubeNotificationService';
+import { s3Client } from '../../utils/cdn/config';
+import { getGachaGuildConfigService } from '../gachaGuildConfigService';
+import { findChannelByName } from '../../utils/util';
+
+// Sample RSS XML for testing
+const SAMPLE_RSS = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/">
+  <title>Test Channel</title>
+  <entry>
+    <yt:videoId>video_newest</yt:videoId>
+    <title>Newest Video Title</title>
+    <author><name>Test Channel</name></author>
+    <published>2026-03-05T12:00:00+00:00</published>
+  </entry>
+  <entry>
+    <yt:videoId>video_middle</yt:videoId>
+    <title>Middle Video Title</title>
+    <author><name>Test Channel</name></author>
+    <published>2026-03-04T12:00:00+00:00</published>
+  </entry>
+  <entry>
+    <yt:videoId>video_oldest</yt:videoId>
+    <title>Oldest Video Title</title>
+    <author><name>Test Channel</name></author>
+    <published>2026-03-03T12:00:00+00:00</published>
+  </entry>
+</feed>`;
+
+const SAMPLE_RSS_WITH_ENTITIES = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">
+  <entry>
+    <yt:videoId>video_entities</yt:videoId>
+    <title>Tom &amp; Jerry&#39;s &quot;Adventure&quot;</title>
+    <author><name>Test &amp; Channel</name></author>
+    <published>2026-03-05T12:00:00+00:00</published>
+  </entry>
+</feed>`;
+
+const EMPTY_RSS = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">
+  <title>Empty Channel</title>
+</feed>`;
+
+function createMockS3Data(overrides: Partial<YouTubeNotificationData> = {}): YouTubeNotificationData {
+    return {
+        monitoredChannels: [
+            { channelId: 'UC_test_channel', channelName: 'Test Channel', discordUserId: '118451485221715977' },
+        ],
+        lastSeenVideoIds: {},
+        lastPolledAt: null,
+        lastUpdated: new Date().toISOString(),
+        schemaVersion: 1,
+        ...overrides,
+    };
+}
+
+function mockS3GetResponse(data: YouTubeNotificationData) {
+    vi.mocked(s3Client.send).mockResolvedValueOnce({
+        Body: {
+            transformToString: () => Promise.resolve(JSON.stringify(data)),
+        },
+    } as any);
+}
+
+describe('YouTubeNotificationService', () => {
+    let service: ReturnType<typeof getYouTubeNotificationService>;
+    let mockGuildConfigService: any;
+    let mockChannel: any;
+    let mockGuild: any;
+    let mockBot: any;
+
+    beforeEach(() => {
+        // Reset singleton
+        (getYouTubeNotificationService as any).instance = undefined;
+        // Force re-create by accessing private static
+        const ServiceClass = (getYouTubeNotificationService() as any).constructor;
+        ServiceClass.instance = undefined;
+
+        service = getYouTubeNotificationService();
+        service.clearCache();
+
+        mockChannel = {
+            name: 'videos',
+            type: ChannelType.GuildText,
+            send: vi.fn().mockResolvedValue({}),
+        };
+
+        mockGuild = {
+            id: 'guild_123',
+            name: 'Test Guild',
+            channels: {
+                cache: {
+                    find: vi.fn().mockReturnValue(mockChannel),
+                },
+            },
+        };
+
+        mockBot = {
+            guilds: {
+                fetch: vi.fn().mockResolvedValue(mockGuild),
+            },
+        };
+
+        mockGuildConfigService = {
+            getAllowedGuildIds: vi.fn().mockResolvedValue(['guild_123']),
+        };
+
+        vi.mocked(getGachaGuildConfigService).mockReturnValue(mockGuildConfigService);
+        vi.mocked(findChannelByName).mockReturnValue(mockChannel as any);
+
+        global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('parseRssXml', () => {
+        it('should parse a valid YouTube RSS feed with multiple entries', () => {
+            const entries = service.parseRssXml(SAMPLE_RSS, 'UC_test');
+            expect(entries).toHaveLength(3);
+        });
+
+        it('should extract videoId, title, channelName, publishedAt from each entry', () => {
+            const entries = service.parseRssXml(SAMPLE_RSS, 'UC_test');
+
+            expect(entries[0].videoId).toBe('video_newest');
+            expect(entries[0].title).toBe('Newest Video Title');
+            expect(entries[0].channelName).toBe('Test Channel');
+            expect(entries[0].publishedAt).toBe('2026-03-05T12:00:00+00:00');
+        });
+
+        it('should construct correct thumbnailUrl and videoUrl from videoId', () => {
+            const entries = service.parseRssXml(SAMPLE_RSS, 'UC_test');
+
+            expect(entries[0].thumbnailUrl).toBe('https://i.ytimg.com/vi/video_newest/hqdefault.jpg');
+            expect(entries[0].videoUrl).toBe('https://www.youtube.com/watch?v=video_newest');
+        });
+
+        it('should set channelId on each entry', () => {
+            const entries = service.parseRssXml(SAMPLE_RSS, 'UC_test');
+            expect(entries[0].channelId).toBe('UC_test');
+            expect(entries[2].channelId).toBe('UC_test');
+        });
+
+        it('should return empty array for empty feed (no entries)', () => {
+            const entries = service.parseRssXml(EMPTY_RSS, 'UC_test');
+            expect(entries).toHaveLength(0);
+        });
+
+        it('should return empty array for malformed/invalid XML', () => {
+            const entries = service.parseRssXml('not xml at all', 'UC_test');
+            expect(entries).toHaveLength(0);
+        });
+
+        it('should handle HTML entities in video titles', () => {
+            const entries = service.parseRssXml(SAMPLE_RSS_WITH_ENTITIES, 'UC_test');
+            expect(entries[0].title).toBe('Tom & Jerry\'s "Adventure"');
+        });
+    });
+
+    describe('fetchRssFeed', () => {
+        it('should fetch RSS feed for a given channel ID', async () => {
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            const entries = await service.fetchRssFeed('UC_test');
+            expect(entries).toHaveLength(3);
+            expect(global.fetch).toHaveBeenCalledWith(
+                'https://www.youtube.com/feeds/videos.xml?channel_id=UC_test',
+                expect.objectContaining({ signal: expect.any(AbortSignal) })
+            );
+        });
+
+        it('should return empty array on network error', async () => {
+            vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'));
+
+            const entries = await service.fetchRssFeed('UC_test');
+            expect(entries).toHaveLength(0);
+        });
+
+        it('should return empty array on non-200 response', async () => {
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+            } as Response);
+
+            const entries = await service.fetchRssFeed('UC_test');
+            expect(entries).toHaveLength(0);
+        });
+    });
+
+    describe('checkForNewVideos', () => {
+        it('should detect new videos by walking entries until lastSeenVideoId is hit', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: { 'UC_test_channel': 'video_oldest' },
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Mock saveData S3 call
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            const results = await service.checkForNewVideos();
+
+            expect(results).toHaveLength(1);
+            expect(results[0].videos).toHaveLength(2);
+            // Should be oldest-first
+            expect(results[0].videos[0].videoId).toBe('video_middle');
+            expect(results[0].videos[1].videoId).toBe('video_newest');
+        });
+
+        it('should seed lastSeenVideoId and return empty array on first run', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: {}, // No prior state
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Mock saveData S3 call
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            const results = await service.checkForNewVideos();
+
+            expect(results).toHaveLength(0); // No videos to post
+            // Should have saved the seeded ID
+            expect(s3Client.send).toHaveBeenCalledTimes(2); // getData + saveData
+        });
+
+        it('should handle multiple monitored channels independently', async () => {
+            const data = createMockS3Data({
+                monitoredChannels: [
+                    { channelId: 'UC_channel1', channelName: 'Channel 1', discordUserId: '111' },
+                    { channelId: 'UC_channel2', channelName: 'Channel 2', discordUserId: '222' },
+                ],
+                lastSeenVideoIds: {
+                    'UC_channel1': 'video_oldest',
+                    'UC_channel2': 'video_newest', // Already up to date
+                },
+            });
+            mockS3GetResponse(data);
+
+            // Channel 1: has new videos
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Channel 2: same newest video (no new)
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Mock saveData
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            const results = await service.checkForNewVideos();
+
+            // Only channel 1 should have new videos
+            expect(results).toHaveLength(1);
+            expect(results[0].channelConfig.channelId).toBe('UC_channel1');
+        });
+
+        it('should return videos sorted oldest-first', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: { 'UC_test_channel': 'video_oldest' },
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            const results = await service.checkForNewVideos();
+            const videos = results[0].videos;
+
+            // video_middle should be before video_newest (oldest first)
+            expect(videos[0].videoId).toBe('video_middle');
+            expect(videos[1].videoId).toBe('video_newest');
+        });
+
+        it('should return empty array when newest entry matches lastSeenVideoId', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: { 'UC_test_channel': 'video_newest' },
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            const results = await service.checkForNewVideos();
+            expect(results).toHaveLength(0);
+        });
+
+        it('should return empty array when no monitored channels configured', async () => {
+            const data = createMockS3Data({
+                monitoredChannels: [],
+            });
+            mockS3GetResponse(data);
+
+            const results = await service.checkForNewVideos();
+            expect(results).toHaveLength(0);
+        });
+
+        it('should persist seeded IDs to S3 even when no new videos to post', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: {}, // First run
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Mock saveData
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            await service.checkForNewVideos();
+
+            // getData (1 call) + saveData (1 call) = 2 total
+            expect(s3Client.send).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('postNotifications', () => {
+        it('should post embed to #videos channel in each allowed guild', async () => {
+            const videoGroups = [{
+                videos: [{
+                    videoId: 'vid1',
+                    title: 'Test Video',
+                    channelName: 'Test Channel',
+                    channelId: 'UC_test',
+                    publishedAt: '2026-03-05T12:00:00+00:00',
+                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
+                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
+                }] as YouTubeVideoEntry[],
+                channelConfig: {
+                    channelId: 'UC_test',
+                    channelName: 'Test Channel',
+                    discordUserId: '118451485221715977',
+                } as YouTubeChannelConfig,
+            }];
+
+            const result = await service.postNotifications(mockBot as Client, videoGroups);
+
+            expect(result.notified).toBe(1);
+            expect(result.errors).toBe(0);
+            expect(mockChannel.send).toHaveBeenCalledTimes(1);
+
+            const sendCall = mockChannel.send.mock.calls[0][0];
+            expect(sendCall.content).toContain('@everyone');
+            expect(sendCall.content).toContain('<@118451485221715977>');
+            expect(sendCall.embeds).toHaveLength(1);
+        });
+
+        it('should skip guilds where #videos channel does not exist', async () => {
+            vi.mocked(findChannelByName).mockReturnValueOnce(undefined);
+
+            const videoGroups = [{
+                videos: [{
+                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
+                    publishedAt: '2026-03-05T12:00:00Z',
+                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
+                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
+                }] as YouTubeVideoEntry[],
+                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
+            }];
+
+            const result = await service.postNotifications(mockBot as Client, videoGroups);
+
+            expect(result.notified).toBe(0);
+            expect(mockChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('should skip guilds the bot is not a member of', async () => {
+            mockBot.guilds.fetch.mockRejectedValueOnce(new Error('Unknown Guild'));
+
+            const videoGroups = [{
+                videos: [{
+                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
+                    publishedAt: '2026-03-05T12:00:00Z',
+                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
+                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
+                }] as YouTubeVideoEntry[],
+                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
+            }];
+
+            const result = await service.postNotifications(mockBot as Client, videoGroups);
+
+            expect(result.notified).toBe(0);
+            expect(mockChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('should handle channel.send() failure gracefully', async () => {
+            mockChannel.send.mockRejectedValueOnce(new Error('Missing Permissions'));
+
+            const videoGroups = [{
+                videos: [{
+                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
+                    publishedAt: '2026-03-05T12:00:00Z',
+                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
+                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
+                }] as YouTubeVideoEntry[],
+                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
+            }];
+
+            const result = await service.postNotifications(mockBot as Client, videoGroups);
+
+            expect(result.errors).toBe(1);
+            expect(result.notified).toBe(0);
+        });
+
+        it('should post multiple videos for a channel in order', async () => {
+            const videoGroups = [{
+                videos: [
+                    {
+                        videoId: 'vid1', title: 'First', channelName: 'TC', channelId: 'UC_test',
+                        publishedAt: '2026-03-04T12:00:00Z',
+                        thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
+                        videoUrl: 'https://www.youtube.com/watch?v=vid1',
+                    },
+                    {
+                        videoId: 'vid2', title: 'Second', channelName: 'TC', channelId: 'UC_test',
+                        publishedAt: '2026-03-05T12:00:00Z',
+                        thumbnailUrl: 'https://i.ytimg.com/vi/vid2/hqdefault.jpg',
+                        videoUrl: 'https://www.youtube.com/watch?v=vid2',
+                    },
+                ] as YouTubeVideoEntry[],
+                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
+            }];
+
+            const result = await service.postNotifications(mockBot as Client, videoGroups);
+
+            expect(result.notified).toBe(2);
+            expect(mockChannel.send).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('pollAndNotify', () => {
+        it('should do nothing when no new videos found', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: { 'UC_test_channel': 'video_newest' },
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            const result = await service.pollAndNotify(mockBot as Client);
+
+            expect(result.notified).toBe(0);
+            expect(result.errors).toBe(0);
+            expect(mockChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('should fetch, detect, and post new videos end-to-end', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: { 'UC_test_channel': 'video_middle' },
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Mock saveData
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            const result = await service.pollAndNotify(mockBot as Client);
+
+            expect(result.notified).toBe(1); // 1 new video (video_newest)
+            expect(mockChannel.send).toHaveBeenCalledTimes(1);
+        });
+
+        it('should return correct notified/error counts', async () => {
+            const data = createMockS3Data({
+                lastSeenVideoIds: { 'UC_test_channel': 'video_oldest' },
+            });
+            mockS3GetResponse(data);
+
+            vi.mocked(global.fetch).mockResolvedValueOnce({
+                ok: true,
+                text: () => Promise.resolve(SAMPLE_RSS),
+            } as Response);
+
+            // Mock saveData
+            vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+
+            // First send succeeds, second fails
+            mockChannel.send
+                .mockResolvedValueOnce({})
+                .mockRejectedValueOnce(new Error('fail'));
+
+            const result = await service.pollAndNotify(mockBot as Client);
+
+            expect(result.notified).toBe(1);
+            expect(result.errors).toBe(1);
+        });
+    });
+
+    describe('S3 Data Management', () => {
+        it('should cache S3 data with TTL', async () => {
+            const data = createMockS3Data();
+            mockS3GetResponse(data);
+
+            // First call - fetches from S3
+            await service.getData();
+            // Second call - should use cache
+            await service.getData();
+
+            // Only 1 S3 call
+            expect(s3Client.send).toHaveBeenCalledTimes(1);
+        });
+
+        it('should create default data if S3 key does not exist', async () => {
+            const noSuchKeyError = new Error('NoSuchKey');
+            (noSuchKeyError as any).name = 'NoSuchKey';
+            vi.mocked(s3Client.send)
+                .mockRejectedValueOnce(noSuchKeyError)
+                .mockResolvedValueOnce({} as any); // saveData call
+
+            const data = await service.getData();
+
+            expect(data.monitoredChannels).toHaveLength(0);
+            expect(data.lastSeenVideoIds).toEqual({});
+            expect(data.schemaVersion).toBe(1);
+        });
+    });
+});

--- a/src/services/tests/youtubeNotificationService.test.ts
+++ b/src/services/tests/youtubeNotificationService.test.ts
@@ -37,11 +37,6 @@ vi.mock('../gachaGuildConfigService', () => ({
     getGachaGuildConfigService: vi.fn(),
 }));
 
-// Mock util
-vi.mock('../../utils/util', () => ({
-    findChannelByName: vi.fn(),
-}));
-
 import {
     getYouTubeNotificationService,
     _testResetYouTubeService,
@@ -51,7 +46,6 @@ import {
 } from '../youtubeNotificationService';
 import { s3Client } from '../../utils/cdn/config';
 import { getGachaGuildConfigService } from '../gachaGuildConfigService';
-import { findChannelByName } from '../../utils/util';
 
 // Sample RSS XML for testing
 const SAMPLE_RSS = `<?xml version="1.0" encoding="UTF-8"?>
@@ -128,6 +122,7 @@ describe('YouTubeNotificationService', () => {
         mockChannel = {
             name: 'videos',
             type: ChannelType.GuildText,
+            isTextBased: vi.fn().mockReturnValue(true),
             send: vi.fn().mockResolvedValue({}),
         };
 
@@ -136,7 +131,7 @@ describe('YouTubeNotificationService', () => {
             name: 'Test Guild',
             channels: {
                 cache: {
-                    find: vi.fn().mockReturnValue(mockChannel),
+                    get: vi.fn().mockReturnValue(mockChannel),
                 },
             },
         };
@@ -148,16 +143,17 @@ describe('YouTubeNotificationService', () => {
         };
 
         mockGuildConfigService = {
-            getAllowedGuildIds: vi.fn().mockResolvedValue(['guild_123']),
             getConfig: vi.fn().mockResolvedValue({
                 allowedGuildIds: ['guild_123'],
+                youtubeNotifications: [
+                    { guildId: 'guild_123', channelId: 'channel_videos_123' },
+                ],
                 lastUpdated: new Date().toISOString(),
                 schemaVersion: 1,
             }),
         };
 
         vi.mocked(getGachaGuildConfigService).mockReturnValue(mockGuildConfigService);
-        vi.mocked(findChannelByName).mockReturnValue(mockChannel as any);
 
         global.fetch = vi.fn();
     });
@@ -413,29 +409,30 @@ describe('YouTubeNotificationService', () => {
     });
 
     describe('postNotifications', () => {
-        it('should post embed to #videos channel in each allowed guild', async () => {
-            const videoGroups = [{
-                videos: [{
-                    videoId: 'vid1',
-                    title: 'Test Video',
-                    channelName: 'Test Channel',
-                    channelId: 'UC_test',
-                    publishedAt: '2026-03-05T12:00:00+00:00',
-                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
-                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
-                }] as YouTubeVideoEntry[],
-                channelConfig: {
-                    channelId: 'UC_test',
-                    channelName: 'Test Channel',
-                    discordUserId: '118451485221715977',
-                } as YouTubeChannelConfig,
-            }];
+        const sampleVideoGroups = [{
+            videos: [{
+                videoId: 'vid1',
+                title: 'Test Video',
+                channelName: 'Test Channel',
+                channelId: 'UC_test',
+                publishedAt: '2026-03-05T12:00:00+00:00',
+                thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
+                videoUrl: 'https://www.youtube.com/watch?v=vid1',
+            }] as YouTubeVideoEntry[],
+            channelConfig: {
+                channelId: 'UC_test',
+                channelName: 'Test Channel',
+                discordUserId: '118451485221715977',
+            } as YouTubeChannelConfig,
+        }];
 
-            const result = await service.postNotifications(mockBot as Client, videoGroups);
+        it('should post embed to configured channel in each target guild', async () => {
+            const result = await service.postNotifications(mockBot as Client, sampleVideoGroups);
 
             expect(result.notified).toBe(1);
             expect(result.errors).toBe(0);
             expect(mockChannel.send).toHaveBeenCalledTimes(1);
+            expect(mockGuild.channels.cache.get).toHaveBeenCalledWith('channel_videos_123');
 
             const sendCall = mockChannel.send.mock.calls[0][0];
             expect(sendCall.content).toContain('@everyone');
@@ -443,20 +440,21 @@ describe('YouTubeNotificationService', () => {
             expect(sendCall.embeds).toHaveLength(1);
         });
 
-        it('should skip guilds where #videos channel does not exist', async () => {
-            vi.mocked(findChannelByName).mockReturnValueOnce(undefined);
+        it('should skip targets where channel does not exist', async () => {
+            mockGuild.channels.cache.get.mockReturnValueOnce(undefined);
 
-            const videoGroups = [{
-                videos: [{
-                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
-                    publishedAt: '2026-03-05T12:00:00Z',
-                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
-                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
-                }] as YouTubeVideoEntry[],
-                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
-            }];
+            const result = await service.postNotifications(mockBot as Client, sampleVideoGroups);
 
-            const result = await service.postNotifications(mockBot as Client, videoGroups);
+            expect(result.notified).toBe(0);
+            expect(mockChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('should skip targets where channel is not text-based', async () => {
+            mockGuild.channels.cache.get.mockReturnValueOnce({
+                isTextBased: vi.fn().mockReturnValue(false),
+            });
+
+            const result = await service.postNotifications(mockBot as Client, sampleVideoGroups);
 
             expect(result.notified).toBe(0);
             expect(mockChannel.send).not.toHaveBeenCalled();
@@ -465,17 +463,7 @@ describe('YouTubeNotificationService', () => {
         it('should skip guilds the bot is not a member of', async () => {
             mockBot.guilds.fetch.mockRejectedValueOnce(new Error('Unknown Guild'));
 
-            const videoGroups = [{
-                videos: [{
-                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
-                    publishedAt: '2026-03-05T12:00:00Z',
-                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
-                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
-                }] as YouTubeVideoEntry[],
-                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
-            }];
-
-            const result = await service.postNotifications(mockBot as Client, videoGroups);
+            const result = await service.postNotifications(mockBot as Client, sampleVideoGroups);
 
             expect(result.notified).toBe(0);
             expect(mockChannel.send).not.toHaveBeenCalled();
@@ -484,44 +472,57 @@ describe('YouTubeNotificationService', () => {
         it('should handle channel.send() failure gracefully', async () => {
             mockChannel.send.mockRejectedValueOnce(new Error('Missing Permissions'));
 
-            const videoGroups = [{
-                videos: [{
-                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
-                    publishedAt: '2026-03-05T12:00:00Z',
-                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
-                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
-                }] as YouTubeVideoEntry[],
-                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
-            }];
-
-            const result = await service.postNotifications(mockBot as Client, videoGroups);
+            const result = await service.postNotifications(mockBot as Client, sampleVideoGroups);
 
             expect(result.errors).toBe(1);
             expect(result.notified).toBe(0);
         });
 
-        it('should skip all guilds when youtubeConfig.enabled is false', async () => {
+        it('should skip when no youtubeNotifications configured', async () => {
             mockGuildConfigService.getConfig.mockResolvedValueOnce({
                 allowedGuildIds: ['guild_123'],
-                youtubeConfig: { enabled: false },
                 lastUpdated: new Date().toISOString(),
                 schemaVersion: 1,
             });
 
-            const videoGroups = [{
-                videos: [{
-                    videoId: 'vid1', title: 'Test', channelName: 'TC', channelId: 'UC_test',
-                    publishedAt: '2026-03-05T12:00:00Z',
-                    thumbnailUrl: 'https://i.ytimg.com/vi/vid1/hqdefault.jpg',
-                    videoUrl: 'https://www.youtube.com/watch?v=vid1',
-                }] as YouTubeVideoEntry[],
-                channelConfig: { channelId: 'UC_test', channelName: 'TC', discordUserId: '123' } as YouTubeChannelConfig,
-            }];
-
-            const result = await service.postNotifications(mockBot as Client, videoGroups);
+            const result = await service.postNotifications(mockBot as Client, sampleVideoGroups);
 
             expect(result.notified).toBe(0);
+            expect(result.errors).toBe(0);
             expect(mockChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('should post to multiple target guilds', async () => {
+            const mockChannel2 = {
+                name: 'videos',
+                isTextBased: vi.fn().mockReturnValue(true),
+                send: vi.fn().mockResolvedValue({}),
+            };
+            const mockGuild2 = {
+                id: 'guild_456',
+                name: 'Test Guild 2',
+                channels: { cache: { get: vi.fn().mockReturnValue(mockChannel2) } },
+            };
+
+            mockGuildConfigService.getConfig.mockResolvedValueOnce({
+                allowedGuildIds: ['guild_123', 'guild_456'],
+                youtubeNotifications: [
+                    { guildId: 'guild_123', channelId: 'channel_videos_123' },
+                    { guildId: 'guild_456', channelId: 'channel_videos_456' },
+                ],
+                lastUpdated: new Date().toISOString(),
+                schemaVersion: 1,
+            });
+
+            mockBot.guilds.fetch
+                .mockResolvedValueOnce(mockGuild)
+                .mockResolvedValueOnce(mockGuild2);
+
+            const result = await service.postNotifications(mockBot as Client, sampleVideoGroups);
+
+            expect(result.notified).toBe(2);
+            expect(mockChannel.send).toHaveBeenCalledTimes(1);
+            expect(mockChannel2.send).toHaveBeenCalledTimes(1);
         });
 
         it('should post multiple videos for a channel in order', async () => {

--- a/src/services/youtubeNotificationScheduler.ts
+++ b/src/services/youtubeNotificationScheduler.ts
@@ -17,8 +17,21 @@ export class YouTubeNotificationScheduler {
         this.isDevelopment = process.env.NODE_ENV === 'development';
     }
 
-    public initializeSchedules(): void {
+    public async initializeSchedules(): Promise<void> {
+        await this.runPollOnce();
         this.scheduleYouTubePoll();
+    }
+
+    private async runPollOnce(): Promise<void> {
+        try {
+            const service = getYouTubeNotificationService();
+            const result = await service.pollAndNotify(this.bot);
+            if (result.notified > 0) {
+                logger.info`[YouTube] Startup poll: notified ${result.notified} new video(s), ${result.errors} error(s)`;
+            }
+        } catch (error) {
+            logger.error`[YouTube] Startup poll error: ${error}`;
+        }
     }
 
     private scheduleYouTubePoll(): void {

--- a/src/services/youtubeNotificationScheduler.ts
+++ b/src/services/youtubeNotificationScheduler.ts
@@ -1,0 +1,60 @@
+import { Client } from 'discord.js';
+import schedule from 'node-schedule';
+import { getYouTubeNotificationService } from './youtubeNotificationService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Scheduler for YouTube upload notification polling
+ */
+export class YouTubeNotificationScheduler {
+    private bot: Client;
+    private scheduledJobs: Map<string, schedule.Job> = new Map();
+    private runningTasks: Set<string> = new Set();
+    private isDevelopment: boolean;
+
+    constructor(bot: Client) {
+        this.bot = bot;
+        this.isDevelopment = process.env.NODE_ENV === 'development';
+    }
+
+    public initializeSchedules(): void {
+        this.scheduleYouTubePoll();
+    }
+
+    private scheduleYouTubePoll(): void {
+        const cronExpression = this.isDevelopment
+            ? '*/3 * * * *'     // Every 3 minutes in dev
+            : '*/20 * * * *';   // Every 20 minutes in prod
+
+        const taskName = 'youtube-poll';
+        const job = schedule.scheduleJob(cronExpression, async () => {
+            if (this.runningTasks.has(taskName)) return;
+            this.runningTasks.add(taskName);
+
+            try {
+                const service = getYouTubeNotificationService();
+                const result = await service.pollAndNotify(this.bot);
+                if (result.notified > 0) {
+                    logger.info`[YouTube] Notified ${result.notified} new video(s), ${result.errors} error(s)`;
+                }
+            } catch (error) {
+                logger.error`[YouTube] Poll error: ${error}`;
+            } finally {
+                this.runningTasks.delete(taskName);
+            }
+        });
+
+        if (job) {
+            this.scheduledJobs.set(taskName, job);
+            logger.debug`[YouTube] Scheduled polling: ${cronExpression}`;
+        }
+    }
+
+    public cancelAllSchedules(): void {
+        for (const [name, job] of this.scheduledJobs) {
+            job.cancel();
+            logger.debug`[YouTube] Cancelled scheduled job: ${name}`;
+        }
+        this.scheduledJobs.clear();
+    }
+}

--- a/src/services/youtubeNotificationService.ts
+++ b/src/services/youtubeNotificationService.ts
@@ -13,8 +13,6 @@ const CONFIG_KEY = isDevelopment
 export interface YouTubeChannelConfig {
     /** YouTube channel ID (e.g., "UCxxxxxxxx") */
     channelId: string;
-    /** Human-readable label for logging */
-    channelName: string;
     /** Discord user ID of the content creator to mention in notifications */
     discordUserId: string;
 }
@@ -141,8 +139,14 @@ class YouTubeNotificationService {
             const title = this.decodeHtmlEntities(this.extractTag(entryXml, 'title') || '');
             const channelName = this.extractTag(entryXml, 'name') || '';
             const publishedAt = this.extractTag(entryXml, 'published') || '';
+            const updatedAt = this.extractTag(entryXml, 'updated') || '';
 
             if (videoId) {
+                // Filter out live streams: they have a large gap between published and updated
+                if (this.isLikelyLiveStream(publishedAt, updatedAt)) {
+                    continue;
+                }
+
                 entries.push({
                     videoId,
                     title,
@@ -176,10 +180,11 @@ class YouTubeNotificationService {
             const lastSeenId = data.lastSeenVideoIds[channelConfig.channelId];
 
             if (!lastSeenId) {
-                // First run: seed with newest video ID, don't post anything
+                // First run: post only the most recent video, then seed
+                results.push({ videos: [entries[0]], channelConfig });
                 data.lastSeenVideoIds[channelConfig.channelId] = entries[0].videoId;
                 dataChanged = true;
-                logger.debug`[YouTube] Seeded lastSeenVideoId for ${channelConfig.channelName}: ${entries[0].videoId}`;
+                logger.debug`[YouTube] First run for ${channelConfig.channelId}, posting latest: ${entries[0].videoId}`;
                 continue;
             }
 
@@ -195,7 +200,7 @@ class YouTubeNotificationService {
                 // was likely deleted or the feed changed significantly. Re-seed to avoid
                 // flooding with up to 15 old videos.
                 if (newVideos.length === entries.length) {
-                    logger.warning`[YouTube] lastSeenVideoId not found in feed for ${channelConfig.channelName}, re-seeding`;
+                    logger.warning`[YouTube] lastSeenVideoId not found in feed for ${channelConfig.channelId}, re-seeding`;
                     data.lastSeenVideoIds[channelConfig.channelId] = entries[0].videoId;
                     dataChanged = true;
                     continue;
@@ -309,6 +314,19 @@ class YouTubeNotificationService {
         const phrases = YOUTUBE_CONFIG.ANNOUNCEMENT_PHRASES;
         const phrase = phrases[Math.floor(Math.random() * phrases.length)];
         return phrase.replace('{user}', `<@${discordUserId}>`);
+    }
+
+    /**
+     * Detect live streams by comparing published vs updated timestamps.
+     * Uploads have nearly identical timestamps; live streams diverge as the stream continues.
+     */
+    private isLikelyLiveStream(publishedAt: string, updatedAt: string): boolean {
+        if (!publishedAt || !updatedAt) return false;
+        const published = new Date(publishedAt).getTime();
+        const updated = new Date(updatedAt).getTime();
+        if (isNaN(published) || isNaN(updated)) return false;
+        const diffSeconds = Math.abs(updated - published) / 1000;
+        return diffSeconds > YOUTUBE_CONFIG.LIVE_STREAM_THRESHOLD_SECONDS;
     }
 
     private extractTag(xml: string, tagName: string): string | null {

--- a/src/services/youtubeNotificationService.ts
+++ b/src/services/youtubeNotificationService.ts
@@ -1,0 +1,330 @@
+import { Client, EmbedBuilder, TextChannel } from 'discord.js';
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { s3Client, S3_BUCKET } from '../utils/cdn/config.js';
+import { YOUTUBE_CONFIG } from '../utils/data/youtubeConfig.js';
+import { getGachaGuildConfigService } from './gachaGuildConfigService.js';
+import { findChannelByName } from '../utils/util.js';
+import { logger } from '../utils/logger.js';
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+const CONFIG_KEY = isDevelopment
+    ? `${YOUTUBE_CONFIG.DATA_PATH}/dev-config.json`
+    : `${YOUTUBE_CONFIG.DATA_PATH}/config.json`;
+
+export interface YouTubeChannelConfig {
+    /** YouTube channel ID (e.g., "UCxxxxxxxx") */
+    channelId: string;
+    /** Human-readable label for logging */
+    channelName: string;
+    /** Discord user ID of the content creator to mention in notifications */
+    discordUserId: string;
+}
+
+export interface YouTubeNotificationData {
+    monitoredChannels: YouTubeChannelConfig[];
+    /** Last seen video ID per YouTube channel */
+    lastSeenVideoIds: Record<string, string>;
+    lastPolledAt: string | null;
+    lastUpdated: string;
+    schemaVersion: number;
+}
+
+export interface YouTubeVideoEntry {
+    videoId: string;
+    title: string;
+    channelName: string;
+    channelId: string;
+    publishedAt: string;
+    thumbnailUrl: string;
+    videoUrl: string;
+}
+
+class YouTubeNotificationService {
+    private static instance: YouTubeNotificationService;
+    private cache: YouTubeNotificationData | null = null;
+    private cacheExpiry: number = 0;
+
+    private constructor() {}
+
+    public static getInstance(): YouTubeNotificationService {
+        if (!YouTubeNotificationService.instance) {
+            YouTubeNotificationService.instance = new YouTubeNotificationService();
+        }
+        return YouTubeNotificationService.instance;
+    }
+
+    /**
+     * Get notification data from S3 (with caching)
+     */
+    public async getData(): Promise<YouTubeNotificationData> {
+        if (this.cache && Date.now() < this.cacheExpiry) {
+            return this.cache;
+        }
+
+        try {
+            const response = await s3Client.send(new GetObjectCommand({
+                Bucket: S3_BUCKET,
+                Key: CONFIG_KEY,
+            }));
+
+            const bodyContents = await response.Body?.transformToString();
+            if (!bodyContents) {
+                return this.getDefaultData();
+            }
+
+            this.cache = JSON.parse(bodyContents) as YouTubeNotificationData;
+            this.cacheExpiry = Date.now() + YOUTUBE_CONFIG.CACHE_TTL;
+            return this.cache;
+        } catch (error: any) {
+            if (error.name === 'NoSuchKey' || error.Code === 'NoSuchKey') {
+                logger.warning`[YouTube] Config not found at ${CONFIG_KEY}, creating default...`;
+                const defaultData = this.getDefaultData();
+                await this.saveData(defaultData);
+                return defaultData;
+            }
+            logger.error`[YouTube] Error fetching config: ${error}`;
+            throw error;
+        }
+    }
+
+    /**
+     * Save notification data to S3
+     */
+    public async saveData(data: YouTubeNotificationData): Promise<void> {
+        data.lastUpdated = new Date().toISOString();
+
+        await s3Client.send(new PutObjectCommand({
+            Bucket: S3_BUCKET,
+            Key: CONFIG_KEY,
+            Body: JSON.stringify(data, null, 2),
+            ContentType: 'application/json',
+        }));
+
+        this.cache = data;
+        this.cacheExpiry = Date.now() + YOUTUBE_CONFIG.CACHE_TTL;
+    }
+
+    /**
+     * Fetch and parse YouTube RSS feed for a channel
+     */
+    public async fetchRssFeed(channelId: string): Promise<YouTubeVideoEntry[]> {
+        try {
+            const url = `${YOUTUBE_CONFIG.RSS_FEED_BASE_URL}${channelId}`;
+            const response = await fetch(url, {
+                signal: AbortSignal.timeout(YOUTUBE_CONFIG.FETCH_TIMEOUT_MS),
+            });
+
+            if (!response.ok) {
+                logger.warning`[YouTube] RSS feed returned ${response.status} for channel ${channelId}`;
+                return [];
+            }
+
+            const xml = await response.text();
+            return this.parseRssXml(xml, channelId);
+        } catch (error: any) {
+            logger.warning`[YouTube] Failed to fetch RSS for channel ${channelId}: ${error.message}`;
+            return [];
+        }
+    }
+
+    /**
+     * Parse YouTube RSS XML into video entries
+     */
+    public parseRssXml(xml: string, channelId: string): YouTubeVideoEntry[] {
+        const entries: YouTubeVideoEntry[] = [];
+        const entryRegex = /<entry>([\s\S]*?)<\/entry>/g;
+
+        let match;
+        while ((match = entryRegex.exec(xml)) !== null) {
+            const entryXml = match[1];
+
+            const videoId = this.extractTag(entryXml, 'yt:videoId');
+            const title = this.decodeHtmlEntities(this.extractTag(entryXml, 'title') || '');
+            const channelName = this.extractTag(entryXml, 'name') || '';
+            const publishedAt = this.extractTag(entryXml, 'published') || '';
+
+            if (videoId) {
+                entries.push({
+                    videoId,
+                    title,
+                    channelName,
+                    channelId,
+                    publishedAt,
+                    thumbnailUrl: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+                    videoUrl: `https://www.youtube.com/watch?v=${videoId}`,
+                });
+            }
+        }
+
+        return entries;
+    }
+
+    /**
+     * Check all monitored channels for new videos
+     * Returns new videos to notify about, grouped with their channel config
+     */
+    public async checkForNewVideos(): Promise<{ videos: YouTubeVideoEntry[]; channelConfig: YouTubeChannelConfig }[]> {
+        const data = await this.getData();
+        const results: { videos: YouTubeVideoEntry[]; channelConfig: YouTubeChannelConfig }[] = [];
+        let dataChanged = false;
+
+        for (const channelConfig of data.monitoredChannels) {
+            const entries = await this.fetchRssFeed(channelConfig.channelId);
+            if (entries.length === 0) continue;
+
+            const lastSeenId = data.lastSeenVideoIds[channelConfig.channelId];
+
+            if (!lastSeenId) {
+                // First run: seed with newest video ID, don't post anything
+                data.lastSeenVideoIds[channelConfig.channelId] = entries[0].videoId;
+                dataChanged = true;
+                logger.debug`[YouTube] Seeded lastSeenVideoId for ${channelConfig.channelName}: ${entries[0].videoId}`;
+                continue;
+            }
+
+            // Walk entries (newest first) until we hit the last seen ID
+            const newVideos: YouTubeVideoEntry[] = [];
+            for (const entry of entries) {
+                if (entry.videoId === lastSeenId) break;
+                newVideos.push(entry);
+            }
+
+            if (newVideos.length > 0) {
+                // Reverse to post oldest first (chronological order)
+                newVideos.reverse();
+                results.push({ videos: newVideos, channelConfig });
+
+                // Update last seen to newest
+                data.lastSeenVideoIds[channelConfig.channelId] = entries[0].videoId;
+                dataChanged = true;
+            }
+        }
+
+        // Persist seeded IDs or updated last seen IDs
+        if (dataChanged) {
+            data.lastPolledAt = new Date().toISOString();
+            await this.saveData(data);
+        }
+
+        return results;
+    }
+
+    /**
+     * Post new video notifications to #videos in all enabled guilds
+     */
+    public async postNotifications(
+        bot: Client,
+        newVideoGroups: { videos: YouTubeVideoEntry[]; channelConfig: YouTubeChannelConfig }[]
+    ): Promise<{ notified: number; errors: number }> {
+        const guildConfigService = getGachaGuildConfigService();
+        const allowedGuildIds = await guildConfigService.getAllowedGuildIds();
+
+        let notified = 0;
+        let errors = 0;
+
+        for (const guildId of allowedGuildIds) {
+            let guild;
+            try {
+                guild = await bot.guilds.fetch(guildId);
+            } catch {
+                logger.warning`[YouTube] Bot not in guild ${guildId}, skipping`;
+                continue;
+            }
+
+            const channel = findChannelByName(guild, YOUTUBE_CONFIG.VIDEOS_CHANNEL_NAME);
+            if (!channel) {
+                logger.warning`[YouTube] #${YOUTUBE_CONFIG.VIDEOS_CHANNEL_NAME} channel not found in ${guild.name}`;
+                continue;
+            }
+
+            for (const { videos, channelConfig } of newVideoGroups) {
+                for (const video of videos) {
+                    try {
+                        const embed = this.createVideoEmbed(video);
+                        const phrase = this.getRandomAnnouncementPhrase(channelConfig.discordUserId);
+                        await channel.send({ content: `@everyone\n${phrase}`, embeds: [embed] });
+                        notified++;
+                    } catch (error: any) {
+                        logger.error`[YouTube] Failed to post in ${guild.name}#${YOUTUBE_CONFIG.VIDEOS_CHANNEL_NAME}: ${error.message}`;
+                        errors++;
+                    }
+                }
+            }
+        }
+
+        return { notified, errors };
+    }
+
+    /**
+     * Main entry point: poll RSS feeds and post notifications for new videos
+     */
+    public async pollAndNotify(bot: Client): Promise<{ notified: number; errors: number }> {
+        const newVideoGroups = await this.checkForNewVideos();
+
+        if (newVideoGroups.length === 0) {
+            return { notified: 0, errors: 0 };
+        }
+
+        const totalNewVideos = newVideoGroups.reduce((sum, g) => sum + g.videos.length, 0);
+        logger.debug`[YouTube] Found ${totalNewVideos} new video(s) to notify`;
+
+        return this.postNotifications(bot, newVideoGroups);
+    }
+
+    /**
+     * Create a rich embed for a YouTube video
+     */
+    private createVideoEmbed(video: YouTubeVideoEntry): EmbedBuilder {
+        return new EmbedBuilder()
+            .setColor(YOUTUBE_CONFIG.EMBED_COLOR)
+            .setTitle(video.title)
+            .setURL(video.videoUrl)
+            .setAuthor({ name: video.channelName })
+            .setImage(video.thumbnailUrl)
+            .setTimestamp(new Date(video.publishedAt));
+    }
+
+    /**
+     * Get a random Rapi-themed announcement phrase with the user mention inserted
+     */
+    private getRandomAnnouncementPhrase(discordUserId: string): string {
+        const phrases = YOUTUBE_CONFIG.ANNOUNCEMENT_PHRASES;
+        const phrase = phrases[Math.floor(Math.random() * phrases.length)];
+        return phrase.replace('{user}', `<@${discordUserId}>`);
+    }
+
+    private extractTag(xml: string, tagName: string): string | null {
+        const regex = new RegExp(`<${tagName}>([\\s\\S]*?)</${tagName}>`);
+        const match = regex.exec(xml);
+        return match ? match[1].trim() : null;
+    }
+
+    private decodeHtmlEntities(text: string): string {
+        return text
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, "'")
+            .replace(/&#x27;/g, "'")
+            .replace(/&#x2F;/g, '/');
+    }
+
+    private getDefaultData(): YouTubeNotificationData {
+        return {
+            monitoredChannels: [],
+            lastSeenVideoIds: {},
+            lastPolledAt: null,
+            lastUpdated: new Date().toISOString(),
+            schemaVersion: 1,
+        };
+    }
+
+    public clearCache(): void {
+        this.cache = null;
+        this.cacheExpiry = 0;
+    }
+}
+
+export const getYouTubeNotificationService = (): YouTubeNotificationService =>
+    YouTubeNotificationService.getInstance();

--- a/src/services/youtubeNotificationService.ts
+++ b/src/services/youtubeNotificationService.ts
@@ -1,4 +1,4 @@
-import { Client, EmbedBuilder, TextChannel } from 'discord.js';
+import { Client, EmbedBuilder } from 'discord.js';
 import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { s3Client, S3_BUCKET } from '../utils/cdn/config.js';
 import { YOUTUBE_CONFIG } from '../utils/data/youtubeConfig.js';
@@ -164,7 +164,9 @@ class YouTubeNotificationService {
      * Returns new videos to notify about, grouped with their channel config
      */
     public async checkForNewVideos(): Promise<{ videos: YouTubeVideoEntry[]; channelConfig: YouTubeChannelConfig }[]> {
-        const data = await this.getData();
+        const cachedData = await this.getData();
+        // Deep copy to avoid mutating cached S3 data before save succeeds
+        const data: YouTubeNotificationData = JSON.parse(JSON.stringify(cachedData));
         const results: { videos: YouTubeVideoEntry[]; channelConfig: YouTubeChannelConfig }[] = [];
         let dataChanged = false;
 
@@ -190,6 +192,16 @@ class YouTubeNotificationService {
             }
 
             if (newVideos.length > 0) {
+                // If we walked the entire feed without finding lastSeenId, the tracked video
+                // was likely deleted or the feed changed significantly. Re-seed to avoid
+                // flooding with up to 15 old videos.
+                if (newVideos.length === entries.length) {
+                    logger.warning`[YouTube] lastSeenVideoId not found in feed for ${channelConfig.channelName}, re-seeding`;
+                    data.lastSeenVideoIds[channelConfig.channelId] = entries[0].videoId;
+                    dataChanged = true;
+                    continue;
+                }
+
                 // Reverse to post oldest first (chronological order)
                 newVideos.reverse();
                 results.push({ videos: newVideos, channelConfig });
@@ -217,7 +229,13 @@ class YouTubeNotificationService {
         newVideoGroups: { videos: YouTubeVideoEntry[]; channelConfig: YouTubeChannelConfig }[]
     ): Promise<{ notified: number; errors: number }> {
         const guildConfigService = getGachaGuildConfigService();
-        const allowedGuildIds = await guildConfigService.getAllowedGuildIds();
+        const config = await guildConfigService.getConfig();
+        const allowedGuildIds = config.allowedGuildIds;
+
+        // Skip if YouTube notifications are explicitly disabled
+        if (config.youtubeConfig?.enabled === false) {
+            return { notified: 0, errors: 0 };
+        }
 
         let notified = 0;
         let errors = 0;
@@ -328,3 +346,8 @@ class YouTubeNotificationService {
 
 export const getYouTubeNotificationService = (): YouTubeNotificationService =>
     YouTubeNotificationService.getInstance();
+
+/** Reset singleton for testing */
+export const _testResetYouTubeService = (): void => {
+    (YouTubeNotificationService as any).instance = undefined;
+};

--- a/src/services/youtubeNotificationService.ts
+++ b/src/services/youtubeNotificationService.ts
@@ -1,9 +1,8 @@
-import { Client, EmbedBuilder } from 'discord.js';
+import { Client, EmbedBuilder, TextChannel } from 'discord.js';
 import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { s3Client, S3_BUCKET } from '../utils/cdn/config.js';
 import { YOUTUBE_CONFIG } from '../utils/data/youtubeConfig.js';
 import { getGachaGuildConfigService } from './gachaGuildConfigService.js';
-import { findChannelByName } from '../utils/util.js';
 import { logger } from '../utils/logger.js';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -222,38 +221,39 @@ class YouTubeNotificationService {
     }
 
     /**
-     * Post new video notifications to #videos in all enabled guilds
+     * Post new video notifications only to explicitly configured guild+channel pairs
      */
     public async postNotifications(
         bot: Client,
         newVideoGroups: { videos: YouTubeVideoEntry[]; channelConfig: YouTubeChannelConfig }[]
     ): Promise<{ notified: number; errors: number }> {
         const guildConfigService = getGachaGuildConfigService();
-        const config = await guildConfigService.getConfig();
-        const allowedGuildIds = config.allowedGuildIds;
+        const guildConfig = await guildConfigService.getConfig();
+        const targets = guildConfig.youtubeNotifications || [];
 
-        // Skip if YouTube notifications are explicitly disabled
-        if (config.youtubeConfig?.enabled === false) {
+        if (targets.length === 0) {
+            logger.debug`[YouTube] No youtubeNotifications configured, skipping`;
             return { notified: 0, errors: 0 };
         }
 
         let notified = 0;
         let errors = 0;
 
-        for (const guildId of allowedGuildIds) {
+        for (const target of targets) {
             let guild;
             try {
-                guild = await bot.guilds.fetch(guildId);
+                guild = await bot.guilds.fetch(target.guildId);
             } catch {
-                logger.warning`[YouTube] Bot not in guild ${guildId}, skipping`;
+                logger.warning`[YouTube] Bot not in guild ${target.guildId}, skipping`;
                 continue;
             }
 
-            const channel = findChannelByName(guild, YOUTUBE_CONFIG.VIDEOS_CHANNEL_NAME);
-            if (!channel) {
-                logger.warning`[YouTube] #${YOUTUBE_CONFIG.VIDEOS_CHANNEL_NAME} channel not found in ${guild.name}`;
+            const fetched = guild.channels.cache.get(target.channelId);
+            if (!fetched?.isTextBased()) {
+                logger.warning`[YouTube] Channel ${target.channelId} not found in ${guild.name}`;
                 continue;
             }
+            const channel = fetched as TextChannel;
 
             for (const { videos, channelConfig } of newVideoGroups) {
                 for (const video of videos) {
@@ -263,7 +263,7 @@ class YouTubeNotificationService {
                         await channel.send({ content: `@everyone\n${phrase}`, embeds: [embed] });
                         notified++;
                     } catch (error: any) {
-                        logger.error`[YouTube] Failed to post in ${guild.name}#${YOUTUBE_CONFIG.VIDEOS_CHANNEL_NAME}: ${error.message}`;
+                        logger.error`[YouTube] Failed to post in ${guild.name}#${channel.name}: ${error.message}`;
                         errors++;
                     }
                 }

--- a/src/utils/data/youtubeConfig.ts
+++ b/src/utils/data/youtubeConfig.ts
@@ -1,0 +1,22 @@
+/**
+ * Configuration for the YouTube Upload Notification System
+ */
+
+export const YOUTUBE_CONFIG = {
+    DATA_PATH: 'data/youtube-notifications',
+    RSS_FEED_BASE_URL: 'https://www.youtube.com/feeds/videos.xml?channel_id=',
+    FETCH_TIMEOUT_MS: 10000,
+    VIDEOS_CHANNEL_NAME: 'videos',
+    EMBED_COLOR: 0xFF0000, // YouTube red
+    CACHE_TTL: 5 * 60 * 1000, // 5 minutes
+    ANNOUNCEMENT_PHRASES: [
+        'Commander, {user} just uploaded a new video! You should watch it immediately.',
+        'Attention Commander! {user} has posted new content. I recommend watching it right away.',
+        'Commander! {user} dropped a new video. I already watched it... for tactical purposes.',
+        '{user} just uploaded something new, Commander. Consider it a mandatory briefing.',
+        'New intel from {user}, Commander! A video has just been uploaded.',
+        'Commander, {user} posted a new video. I suggest we take a break and watch it together.',
+    ],
+} as const;
+
+export type YoutubeConfig = typeof YOUTUBE_CONFIG;

--- a/src/utils/data/youtubeConfig.ts
+++ b/src/utils/data/youtubeConfig.ts
@@ -9,6 +9,8 @@ export const YOUTUBE_CONFIG = {
     VIDEOS_CHANNEL_NAME: 'videos',
     EMBED_COLOR: 0xFF0000, // YouTube red
     CACHE_TTL: 5 * 60 * 1000, // 5 minutes
+    /** Max seconds between published and updated timestamps to consider a video an upload (not a live stream) */
+    LIVE_STREAM_THRESHOLD_SECONDS: 60,
     ANNOUNCEMENT_PHRASES: [
         'Commander, {user} just uploaded a new video! You should watch it immediately.',
         'Attention Commander! {user} has posted new content. I recommend watching it right away.',


### PR DESCRIPTION
## Summary
- Poll YouTube RSS feeds on a cron schedule and post notifications to configured Discord channels when new uploads are detected
- Filter out live streams using published/updated timestamp comparison — only regular uploads trigger notifications
- Run an immediate poll on bot startup, then continue with scheduled polling (3min dev / 20min prod)

## Changes
- **New service** (`youtubeNotificationService.ts`): RSS fetching, XML parsing, dedup via `lastSeenVideoIds`, live stream filtering, notification posting with Rapi-themed phrases
- **New scheduler** (`youtubeNotificationScheduler.ts`): Cron-based polling with boot-time poll and concurrency guard
- **New config** (`youtubeConfig.ts`): Centralized constants (embed color, announcement phrases, live stream threshold)
- **Guild config** (`gachaGuildConfigService.ts`): Added `youtubeNotifications` array for explicit per-guild channel targeting
- **Service initializer**: Integrated YouTube scheduler into bot startup

## Key Design Decisions
- Uses free YouTube RSS feed (no API key needed)
- Stores only 1 video ID per monitored channel in S3 (minimal state)
- Posts most recent upload on first run (instead of silent seeding)
- Live streams filtered by `published` vs `updated` timestamp gap (>60s = live)
- Notifications only go to explicitly configured `{guildId, channelId}` pairs — no implicit broadcasting

## Testing
- 33 unit tests covering RSS parsing, live stream filtering, new video detection, notification posting, S3 caching, and first-run behavior
- `bunx tsc --noEmit` passes
- `bun run test:run` — all 743 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)