### PR TITLE
fix: YouTube RSS retry logic and re-seed notification

### DIFF
--- a/src/services/tests/youtubeNotificationService.test.ts
+++ b/src/services/tests/youtubeNotificationService.test.ts
@@ -263,21 +263,71 @@ describe('YouTubeNotificationService', () => {
             );
         });
 
-        it('should return empty array on network error', async () => {
-            vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'));
+        it('should retry on transient 404 and succeed', async () => {
+            vi.useFakeTimers();
+            vi.mocked(global.fetch)
+                .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+                .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(SAMPLE_RSS) } as Response);
 
-            const entries = await service.fetchRssFeed('UC_test');
-            expect(entries).toHaveLength(0);
+            const promise = service.fetchRssFeed('UC_test');
+            await vi.advanceTimersByTimeAsync(10000);
+            const entries = await promise;
+
+            expect(entries).toHaveLength(3);
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+            vi.useRealTimers();
         });
 
-        it('should return empty array on non-200 response', async () => {
-            vi.mocked(global.fetch).mockResolvedValueOnce({
-                ok: false,
-                status: 404,
-            } as Response);
+        it('should retry on 500 and succeed', async () => {
+            vi.useFakeTimers();
+            vi.mocked(global.fetch)
+                .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+                .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(SAMPLE_RSS) } as Response);
+
+            const promise = service.fetchRssFeed('UC_test');
+            await vi.advanceTimersByTimeAsync(10000);
+            const entries = await promise;
+
+            expect(entries).toHaveLength(3);
+            vi.useRealTimers();
+        });
+
+        it('should return empty after all retries exhausted', async () => {
+            vi.useFakeTimers();
+            vi.mocked(global.fetch)
+                .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+                .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+                .mockResolvedValueOnce({ ok: false, status: 404 } as Response);
+
+            const promise = service.fetchRssFeed('UC_test');
+            await vi.advanceTimersByTimeAsync(30000);
+            const entries = await promise;
+
+            expect(entries).toHaveLength(0);
+            expect(global.fetch).toHaveBeenCalledTimes(3);
+            vi.useRealTimers();
+        });
+
+        it('should not retry on non-transient client errors', async () => {
+            vi.mocked(global.fetch).mockResolvedValueOnce({ ok: false, status: 403 } as Response);
 
             const entries = await service.fetchRssFeed('UC_test');
             expect(entries).toHaveLength(0);
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should retry on network error and succeed', async () => {
+            vi.useFakeTimers();
+            vi.mocked(global.fetch)
+                .mockRejectedValueOnce(new Error('Network error'))
+                .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(SAMPLE_RSS) } as Response);
+
+            const promise = service.fetchRssFeed('UC_test');
+            await vi.advanceTimersByTimeAsync(10000);
+            const entries = await promise;
+
+            expect(entries).toHaveLength(3);
+            vi.useRealTimers();
         });
     });
 
@@ -409,7 +459,7 @@ describe('YouTubeNotificationService', () => {
             expect(results).toHaveLength(0);
         });
 
-        it('should re-seed when lastSeenVideoId is not found in feed (deleted video)', async () => {
+        it('should post newest video and re-seed when lastSeenVideoId is not found in feed', async () => {
             const data = createMockS3Data({
                 lastSeenVideoIds: { 'UC_test_channel': 'deleted_video_id' },
             });
@@ -425,8 +475,10 @@ describe('YouTubeNotificationService', () => {
 
             const results = await service.checkForNewVideos();
 
-            // Should re-seed instead of treating all 15 as new
-            expect(results).toHaveLength(0);
+            // Should post newest video instead of silently re-seeding
+            expect(results).toHaveLength(1);
+            expect(results[0].videos).toHaveLength(1);
+            expect(results[0].videos[0].videoId).toBe('video_newest');
             // Should still save the re-seeded ID
             expect(s3Client.send).toHaveBeenCalledTimes(2);
         });

--- a/src/services/youtubeNotificationService.ts
+++ b/src/services/youtubeNotificationService.ts
@@ -105,23 +105,37 @@ class YouTubeNotificationService {
      * Fetch and parse YouTube RSS feed for a channel
      */
     public async fetchRssFeed(channelId: string): Promise<YouTubeVideoEntry[]> {
-        try {
-            const url = `${YOUTUBE_CONFIG.RSS_FEED_BASE_URL}${channelId}`;
-            const response = await fetch(url, {
-                signal: AbortSignal.timeout(YOUTUBE_CONFIG.FETCH_TIMEOUT_MS),
-            });
+        const url = `${YOUTUBE_CONFIG.RSS_FEED_BASE_URL}${channelId}`;
 
-            if (!response.ok) {
-                logger.warning`[YouTube] RSS feed returned ${response.status} for channel ${channelId}`;
-                return [];
+        for (let attempt = 1; attempt <= YOUTUBE_CONFIG.FETCH_MAX_RETRIES; attempt++) {
+            try {
+                const response = await fetch(url, {
+                    signal: AbortSignal.timeout(YOUTUBE_CONFIG.FETCH_TIMEOUT_MS),
+                });
+
+                if (response.ok) {
+                    const xml = await response.text();
+                    return this.parseRssXml(xml, channelId);
+                }
+
+                // Don't retry client errors other than 404 (which YouTube returns transiently)
+                if (response.status >= 400 && response.status < 500 && response.status !== 404) {
+                    logger.warning`[YouTube] RSS feed returned ${response.status} for channel ${channelId}`;
+                    return [];
+                }
+
+                logger.debug`[YouTube] RSS feed returned ${response.status} for channel ${channelId} (attempt ${attempt}/${YOUTUBE_CONFIG.FETCH_MAX_RETRIES})`;
+            } catch (error: any) {
+                logger.debug`[YouTube] Fetch error for ${channelId} (attempt ${attempt}/${YOUTUBE_CONFIG.FETCH_MAX_RETRIES}): ${error.message}`;
             }
 
-            const xml = await response.text();
-            return this.parseRssXml(xml, channelId);
-        } catch (error: any) {
-            logger.warning`[YouTube] Failed to fetch RSS for channel ${channelId}: ${error.message}`;
-            return [];
+            if (attempt < YOUTUBE_CONFIG.FETCH_MAX_RETRIES) {
+                await new Promise(resolve => setTimeout(resolve, YOUTUBE_CONFIG.FETCH_RETRY_DELAY_MS * attempt));
+            }
         }
+
+        logger.warning`[YouTube] RSS feed failed after ${YOUTUBE_CONFIG.FETCH_MAX_RETRIES} retries for channel ${channelId}`;
+        return [];
     }
 
     /**
@@ -197,10 +211,11 @@ class YouTubeNotificationService {
 
             if (newVideos.length > 0) {
                 // If we walked the entire feed without finding lastSeenId, the tracked video
-                // was likely deleted or the feed changed significantly. Re-seed to avoid
-                // flooding with up to 15 old videos.
+                // was likely deleted or fell off the feed during an outage.
+                // Post only the newest video to avoid flooding, but don't silently skip.
                 if (newVideos.length === entries.length) {
-                    logger.warning`[YouTube] lastSeenVideoId not found in feed for ${channelConfig.channelId}, re-seeding`;
+                    logger.warning`[YouTube] lastSeenVideoId not found in feed for ${channelConfig.channelId}, posting latest and re-seeding`;
+                    results.push({ videos: [entries[0]], channelConfig });
                     data.lastSeenVideoIds[channelConfig.channelId] = entries[0].videoId;
                     dataChanged = true;
                     continue;

--- a/src/utils/data/youtubeConfig.ts
+++ b/src/utils/data/youtubeConfig.ts
@@ -6,6 +6,8 @@ export const YOUTUBE_CONFIG = {
     DATA_PATH: 'data/youtube-notifications',
     RSS_FEED_BASE_URL: 'https://www.youtube.com/feeds/videos.xml?channel_id=',
     FETCH_TIMEOUT_MS: 10000,
+    FETCH_MAX_RETRIES: 3,
+    FETCH_RETRY_DELAY_MS: 2000,
     VIDEOS_CHANNEL_NAME: 'videos',
     EMBED_COLOR: 0xFF0000, // YouTube red
     CACHE_TTL: 5 * 60 * 1000, // 5 minutes


### PR DESCRIPTION
## Summary
- Add retry with backoff for transient YouTube RSS 404/500 errors
- Post newest video on re-seed instead of silently skipping missed uploads

## Problem
YouTube RSS feeds intermittently return 404/500 errors (observed for hours at a time). After recovery, if a new video was uploaded during the outage, the `lastSeenVideoId` falls off the feed, triggering a silent re-seed that misses the upload notification entirely.

## Changes
- **Retry logic**: Up to 3 attempts with exponential backoff (2s, 4s) for 404, 500, and network errors. Non-transient client errors (403, etc.) fail immediately.
- **Re-seed behavior**: When `lastSeenVideoId` is not found in feed, post the newest video instead of silently re-seeding — prevents missed notifications after outages.
- **Config**: Added `FETCH_MAX_RETRIES` (3) and `FETCH_RETRY_DELAY_MS` (2000) to `youtubeConfig.ts`

## Testing
- 36 YouTube tests pass (5 new retry tests + updated re-seed test)
- `bunx tsc --noEmit` clean
- Note: `dateHelpers.test.ts` has a pre-existing time-sensitive flake unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)