### PR TITLE
fix: Detect Cyrillic homoglyph bypass in sensitive terms filter

### DIFF
--- a/src/utils/sensitiveTermsChecker.ts
+++ b/src/utils/sensitiveTermsChecker.ts
@@ -53,10 +53,11 @@ const HOMOGLYPH_MAP: Record<string, string> = {
     '\u041D': 'h', '\u0406': 'i', '\u041A': 'k', '\u041C': 'm',
     '\u041E': 'o', '\u0420': 'p', '\u0422': 't', '\u0425': 'x',
     '\u0423': 'y',
-    // Cyrillic lowercase
-    '\u0430': 'a', '\u0435': 'e', '\u043E': 'o', '\u0440': 'p',
-    '\u0441': 'c', '\u0443': 'y', '\u0445': 'x', '\u0456': 'i',
-    '\u043A': 'k',
+    // Cyrillic lowercase (critical — preprocessMessage lowercases first)
+    '\u0430': 'a', '\u0432': 'b', '\u0441': 'c', '\u0435': 'e',
+    '\u043D': 'h', '\u0456': 'i', '\u043A': 'k', '\u043C': 'm',
+    '\u043E': 'o', '\u0440': 'p', '\u0442': 't', '\u0445': 'x',
+    '\u0443': 'y',
 };
 
 const HOMOGLYPH_REGEX = new RegExp(`[${Object.keys(HOMOGLYPH_MAP).join('')}]`, 'g');

--- a/src/utils/sensitiveTermsChecker.ts
+++ b/src/utils/sensitiveTermsChecker.ts
@@ -44,6 +44,24 @@ const SENSITIVE_TERMS: SensitiveTerm[] = [
 ];
 
 /**
+ * Cyrillic/Greek homoglyphs that visually mimic Latin characters.
+ * Maps Unicode codepoints to their Latin equivalents for normalization.
+ */
+const HOMOGLYPH_MAP: Record<string, string> = {
+    // Cyrillic uppercase
+    '\u0410': 'a', '\u0412': 'b', '\u0421': 'c', '\u0415': 'e',
+    '\u041D': 'h', '\u0406': 'i', '\u041A': 'k', '\u041C': 'm',
+    '\u041E': 'o', '\u0420': 'p', '\u0422': 't', '\u0425': 'x',
+    '\u0423': 'y',
+    // Cyrillic lowercase
+    '\u0430': 'a', '\u0435': 'e', '\u043E': 'o', '\u0440': 'p',
+    '\u0441': 'c', '\u0443': 'y', '\u0445': 'x', '\u0456': 'i',
+    '\u043A': 'k',
+};
+
+const HOMOGLYPH_REGEX = new RegExp(`[${Object.keys(HOMOGLYPH_MAP).join('')}]`, 'g');
+
+/**
  * Message preprocessing options
  */
 const MESSAGE_CLEANUP_PATTERNS = [
@@ -105,6 +123,9 @@ export async function checkSensitiveTerms(message: Message): Promise<void> {
  */
 function preprocessMessage(content: string): string {
     let processed = content.toLowerCase();
+
+    // Normalize Cyrillic/Greek homoglyphs to Latin equivalents
+    processed = processed.replace(HOMOGLYPH_REGEX, char => HOMOGLYPH_MAP[char] || char);
 
     MESSAGE_CLEANUP_PATTERNS.forEach(({ pattern, replacement }) => {
         processed = processed.replace(pattern, replacement);


### PR DESCRIPTION
## Summary
- Fix filter bypass using Cyrillic characters that visually mimic Latin letters (e.g., `ТАIWАN` using Cyrillic `Т` and `А`)

## Problem
Users could bypass the sensitive terms filter by substituting Latin characters with visually identical Cyrillic Unicode codepoints. The filter only checked for exact Latin matches.

## Solution
Add a homoglyph normalization step in `preprocessMessage()` that maps common Cyrillic lookalikes to their Latin equivalents before checking against sensitive terms. Covers uppercase and lowercase Cyrillic characters that have Latin doppelgängers (А→a, В→b, С→c, Е→e, Н→h, etc.).

## Testing
- [x] Type check passes
- [x] Full suite: 748 pass / 1 pre-existing flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)