### PR TITLE
feat: Rebuild giveaway system with proper patterns

### DIFF
--- a/src/commands/giveaway.ts
+++ b/src/commands/giveaway.ts
@@ -1,0 +1,481 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { getGiveawayDataService } from '../services/giveawayDataService.js';
+import { getGiveawayManagementService } from '../services/giveawayManagementService.js';
+import { getGiveawayWheelService } from '../services/giveawayWheelService.js';
+import { EndCondition } from '../utils/interfaces/Giveaway.interface.js';
+import { GIVEAWAY_CONFIG } from '../utils/data/giveawayConfig.js';
+import { getGachaGuildConfigService } from '../services/gachaGuildConfigService.js';
+import { requireModPermission } from '../utils/permissionHelpers.js';
+import { handleCommandError } from '../utils/commandErrorHandler.js';
+import { replyEphemeral, deferEphemeral, respondEphemeral } from '../utils/interactionHelpers.js';
+import { successEmbed, infoEmbed, errorEmbed, EmbedColors, customEmbed } from '../utils/embedTemplates.js';
+import { createPaginatedMessage } from './utils/paginationBuilder.js';
+
+function parseEndTime(input: string): Date | null {
+    const isoDate = new Date(input);
+    if (!isNaN(isoDate.getTime()) && isoDate > new Date()) return isoDate;
+
+    const match = input.match(/^(\d+)(m|h|d)$/i);
+    if (!match) return null;
+
+    const amount = parseInt(match[1]);
+    const unit = match[2].toLowerCase();
+    const ms = unit === 'm' ? 60_000 : unit === 'h' ? 3_600_000 : 86_400_000;
+    return new Date(Date.now() + amount * ms);
+}
+
+function toTimestamp(iso: string): string {
+    return `<t:${Math.floor(new Date(iso).getTime() / 1000)}`;
+}
+
+// ==================== User Command Handlers ====================
+
+async function handleJoin(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+
+    const giveawayId = interaction.options.getString('giveaway-id', true);
+    const dataService = getGiveawayDataService();
+
+    const giveaway = await dataService.getGiveaway(giveawayId);
+    if (!giveaway) {
+        await interaction.editReply({ content: '❌ Giveaway not found. Please check the ID and try again.' });
+        return;
+    }
+    if (giveaway.status !== 'active') {
+        await interaction.editReply({ content: '❌ This giveaway is not currently active.' });
+        return;
+    }
+
+    const result = await dataService.enterGiveaway(giveawayId, {
+        discordId: interaction.user.id,
+        enteredAt: new Date().toISOString(),
+        username: interaction.user.username,
+    });
+
+    if (!result.success) {
+        await interaction.editReply({ content: `❌ ${result.error}` });
+        return;
+    }
+
+    let message = `You've entered the giveaway for **${giveaway.prizeName}**!`;
+    if (result.previousGiveaway) {
+        message += `\n\nYou were automatically removed from "${result.previousGiveaway}" since you can only be in one active giveaway at a time.`;
+    }
+    await interaction.editReply({ embeds: [successEmbed('Giveaway Joined!', message)] });
+
+    // Check if entry limit was reached
+    const managementService = getGiveawayManagementService();
+    await managementService.checkEndConditions(interaction.client, giveawayId);
+}
+
+async function handleLeave(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+    const dataService = getGiveawayDataService();
+
+    const activeEntry = await dataService.getUserActiveEntry(interaction.user.id);
+    if (!activeEntry) {
+        await interaction.editReply({ content: '❌ You are not entered in any active giveaway.' });
+        return;
+    }
+
+    const removed = await dataService.removeEntry(activeEntry.giveawayId, interaction.user.id);
+    if (removed) {
+        await interaction.editReply({
+            embeds: [successEmbed('Left Giveaway', `You have left: **${activeEntry.giveaway.title}**`)]
+        });
+    } else {
+        await interaction.editReply({ content: '❌ Failed to leave giveaway. Please try again.' });
+    }
+}
+
+async function handleStatus(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+    const dataService = getGiveawayDataService();
+
+    const activeEntry = await dataService.getUserActiveEntry(interaction.user.id);
+    if (!activeEntry) {
+        await interaction.editReply({ content: 'You are not currently entered in any giveaway.' });
+        return;
+    }
+
+    const { giveaway } = activeEntry;
+    const userEntry = giveaway.entries.find(e => e.discordId === interaction.user.id)!;
+
+    await interaction.editReply({
+        embeds: [
+            infoEmbed('Your Giveaway Status')
+                .addFields(
+                    { name: 'Giveaway', value: giveaway.title, inline: false },
+                    { name: 'Prize', value: giveaway.prizeName, inline: false },
+                    { name: 'Entered At', value: `${toTimestamp(userEntry.enteredAt)}:F>`, inline: true },
+                    { name: 'Total Entries', value: giveaway.entries.length.toString(), inline: true },
+                    { name: 'Giveaway ID', value: `\`${giveaway.id}\``, inline: false },
+                )
+        ]
+    });
+}
+
+async function handleWinners(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+    const limit = interaction.options.getInteger('limit') || 10;
+    const dataService = getGiveawayDataService();
+
+    if (!interaction.guildId) {
+        await interaction.editReply({ content: '❌ This command can only be used in a server.' });
+        return;
+    }
+
+    const winners = await dataService.getGuildWinners(interaction.guildId, limit);
+    if (winners.length === 0) {
+        await interaction.editReply({ content: 'No winners yet in this server.' });
+        return;
+    }
+
+    const description = winners.map((w, i) =>
+        `${i + 1}. <@${w.discordId}> - **${w.prizeName}** (${toTimestamp(w.wonAt)}:R>)`
+    ).join('\n');
+
+    await interaction.editReply({
+        embeds: [customEmbed('Recent Giveaway Winners', EmbedColors.GOLD, description)]
+    });
+}
+
+// ==================== Mod Command Handlers ====================
+
+async function handleCreate(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+
+    const title = interaction.options.getString('title', true);
+    const description = interaction.options.getString('description', true);
+    const prize = interaction.options.getString('prize', true);
+    const endTimeStr = interaction.options.getString('end-time');
+    const maxEntries = interaction.options.getInteger('max-entries');
+
+    if (title.length > GIVEAWAY_CONFIG.MAX_TITLE_LENGTH) {
+        await interaction.editReply({ content: `❌ Title must be ${GIVEAWAY_CONFIG.MAX_TITLE_LENGTH} characters or less` });
+        return;
+    }
+    if (description.length > GIVEAWAY_CONFIG.MAX_DESCRIPTION_LENGTH) {
+        await interaction.editReply({ content: `❌ Description must be ${GIVEAWAY_CONFIG.MAX_DESCRIPTION_LENGTH} characters or less` });
+        return;
+    }
+    if (prize.length > GIVEAWAY_CONFIG.MAX_PRIZE_NAME_LENGTH) {
+        await interaction.editReply({ content: `❌ Prize name must be ${GIVEAWAY_CONFIG.MAX_PRIZE_NAME_LENGTH} characters or less` });
+        return;
+    }
+
+    const endConditions: EndCondition[] = [{ type: 'manual' }];
+
+    if (endTimeStr) {
+        const endTime = parseEndTime(endTimeStr);
+        if (!endTime) {
+            await interaction.editReply({
+                content: '❌ Invalid end time. Use ISO (YYYY-MM-DDTHH:MM:SS) or relative ("2h", "30m", "1d")'
+            });
+            return;
+        }
+        endConditions.push({ type: 'scheduled', scheduledEndTime: endTime.toISOString() });
+    }
+
+    if (maxEntries && maxEntries > 0) {
+        endConditions.push({ type: 'entry_count', maxEntries });
+    }
+
+    const managementService = getGiveawayManagementService();
+    const giveaway = await managementService.createGiveaway(
+        interaction.client,
+        interaction.guildId!,
+        interaction.user.id,
+        { title, description, prizeName: prize, endConditions }
+    );
+
+    await interaction.editReply({
+        embeds: [
+            successEmbed('Giveaway Created!')
+                .addFields(
+                    { name: 'Title', value: giveaway.title, inline: false },
+                    { name: 'Prize', value: giveaway.prizeName, inline: false },
+                    { name: 'Giveaway ID', value: `\`${giveaway.id}\``, inline: false },
+                    { name: 'For Users', value: `Join with: \`/giveaway join giveaway-id:${giveaway.id}\``, inline: false },
+                )
+        ]
+    });
+}
+
+async function handleList(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+    const dataService = getGiveawayDataService();
+    const giveaways = await dataService.getAllGiveaways(interaction.guildId!);
+
+    if (giveaways.length === 0) {
+        await interaction.editReply({ content: 'No giveaways found in this server.' });
+        return;
+    }
+
+    giveaways.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+    const perPage = GIVEAWAY_CONFIG.GIVEAWAYS_PER_PAGE;
+    const totalPages = Math.ceil(giveaways.length / perPage);
+    const pages = Array.from({ length: totalPages }, (_, i) => {
+        const pageItems = giveaways.slice(i * perPage, (i + 1) * perPage);
+        const statusEmojis: Record<string, string> = { active: '🟢', ended: '✅', cancelled: '❌' };
+
+        return infoEmbed('Server Giveaways')
+            .setDescription(pageItems.map(g =>
+                `${statusEmojis[g.status] || '❓'} **${g.title}**\nPrize: ${g.prizeName} | Entries: ${g.entries.length} | Status: ${g.status}\nID: \`${g.id}\``
+            ).join('\n\n'));
+    });
+
+    await createPaginatedMessage(interaction, pages, { customIdPrefix: 'giveaway_list' });
+}
+
+async function handleEntries(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+
+    const giveawayId = interaction.options.getString('giveaway-id', true);
+    const dataService = getGiveawayDataService();
+
+    const giveaway = await dataService.getGiveaway(giveawayId);
+    if (!giveaway) {
+        await interaction.editReply({ content: '❌ Giveaway not found.' });
+        return;
+    }
+    if (giveaway.entries.length === 0) {
+        await interaction.editReply({ content: 'No entries yet for this giveaway.' });
+        return;
+    }
+
+    // Paginate entries to avoid Discord's 4096 char embed limit
+    const perPage = GIVEAWAY_CONFIG.ENTRIES_PER_PAGE;
+    const totalPages = Math.ceil(giveaway.entries.length / perPage);
+    const pages = Array.from({ length: totalPages }, (_, i) => {
+        const pageEntries = giveaway.entries.slice(i * perPage, (i + 1) * perPage);
+        const startIdx = i * perPage;
+
+        return infoEmbed(`Entries for: ${giveaway.title}`)
+            .setDescription(pageEntries.map((e, j) =>
+                `${startIdx + j + 1}. <@${e.discordId}> (${e.username}) - ${toTimestamp(e.enteredAt)}:R>`
+            ).join('\n'))
+            .setFooter({ text: `Total: ${giveaway.entries.length} entries` });
+    });
+
+    await createPaginatedMessage(interaction, pages, { customIdPrefix: 'giveaway_entries' });
+}
+
+async function handleSpin(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+
+    const giveawayId = interaction.options.getString('giveaway-id', true);
+    const dataService = getGiveawayDataService();
+    const wheelService = getGiveawayWheelService();
+    const managementService = getGiveawayManagementService();
+
+    const giveaway = await dataService.getGiveaway(giveawayId);
+    if (!giveaway) { await interaction.editReply({ content: '❌ Giveaway not found.' }); return; }
+    if (giveaway.status !== 'active') { await interaction.editReply({ content: '❌ Giveaway is not active.' }); return; }
+    if (giveaway.entries.length === 0) { await interaction.editReply({ content: '❌ No entries to spin.' }); return; }
+
+    const wheelUrl = wheelService.generateWheelUrl(giveaway);
+    await dataService.updateGiveaway(giveawayId, {
+        wheelUrl,
+        wheelSpunAt: new Date().toISOString(),
+    });
+
+    const modChannel = managementService.findModChannel(interaction.client, giveaway.guildId);
+    if (modChannel) {
+        await modChannel.send({
+            embeds: [
+                successEmbed('Giveaway Ready to Spin!',
+                    `Click the link below to spin the wheel for: **${giveaway.prizeName}**`)
+                    .addFields(
+                        { name: 'Wheel URL', value: `[Click to Spin](${wheelUrl})`, inline: false },
+                        { name: 'Participants', value: `${giveaway.entries.length} entrants`, inline: true },
+                        { name: 'Giveaway ID', value: `\`${giveaway.id}\``, inline: true },
+                    )
+            ]
+        });
+    }
+
+    await interaction.editReply({
+        content: `Wheel URL generated!\n\n[Open Wheel](${wheelUrl})\n\n${wheelService.getWheelInstructions()}`
+    });
+}
+
+async function handleSelectWinner(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+
+    const giveawayId = interaction.options.getString('giveaway-id', true);
+    const winnerUser = interaction.options.getUser('winner', true);
+    const dataService = getGiveawayDataService();
+
+    const giveaway = await dataService.getGiveaway(giveawayId);
+    if (!giveaway) { await interaction.editReply({ content: '❌ Giveaway not found.' }); return; }
+
+    if (!giveaway.entries.some(e => e.discordId === winnerUser.id)) {
+        await interaction.editReply({ content: '❌ Selected user is not an entrant in this giveaway.' });
+        return;
+    }
+
+    const managementService = getGiveawayManagementService();
+    await managementService.endGiveaway(interaction.client, giveawayId, interaction.user.id, winnerUser.id);
+
+    await interaction.editReply({
+        embeds: [successEmbed('Winner Selected!',
+            `${winnerUser.toString()} has been notified via DM and announced in the moderator channel.`)]
+    });
+}
+
+async function handleCancel(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+
+    const giveawayId = interaction.options.getString('giveaway-id', true);
+    const reason = interaction.options.getString('reason') || undefined;
+    const managementService = getGiveawayManagementService();
+
+    const giveaway = await managementService.cancelGiveaway(
+        interaction.client, giveawayId, interaction.user.id, reason
+    );
+
+    let message = `Giveaway "${giveaway.title}" has been cancelled.`;
+    if (reason) message += `\n**Reason:** ${reason}`;
+
+    await interaction.editReply({ embeds: [successEmbed('Giveaway Cancelled', message)] });
+}
+
+async function handleStats(interaction: ChatInputCommandInteraction): Promise<void> {
+    await deferEphemeral(interaction);
+    const dataService = getGiveawayDataService();
+    const stats = await dataService.getGuildStats(interaction.guildId!);
+
+    await interaction.editReply({
+        embeds: [
+            infoEmbed('Giveaway Statistics')
+                .addFields(
+                    { name: 'Total Giveaways', value: stats.totalGiveaways.toString(), inline: true },
+                    { name: 'Active', value: stats.activeCount.toString(), inline: true },
+                    { name: 'Ended', value: stats.endedCount.toString(), inline: true },
+                    { name: 'Total Winners', value: stats.totalWinners.toString(), inline: true },
+                    { name: 'Total Entries', value: stats.totalEntries.toString(), inline: true },
+                    { name: 'Avg Entries', value: stats.totalGiveaways > 0
+                        ? (stats.totalEntries / stats.totalGiveaways).toFixed(1) : '0', inline: true },
+                )
+        ]
+    });
+}
+
+// ==================== Command Definition ====================
+
+const modCommands = ['create', 'list', 'entries', 'spin', 'select-winner', 'cancel', 'stats'];
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('giveaway')
+        .setDescription('Giveaway management system')
+
+        // User commands
+        .addSubcommand(sub => sub
+            .setName('join')
+            .setDescription('Join an active giveaway')
+            .addStringOption(opt => opt
+                .setName('giveaway-id')
+                .setDescription('The giveaway ID to join')
+                .setRequired(true)))
+
+        .addSubcommand(sub => sub
+            .setName('leave')
+            .setDescription('Leave your current giveaway'))
+
+        .addSubcommand(sub => sub
+            .setName('status')
+            .setDescription('Check your current giveaway entry status'))
+
+        .addSubcommand(sub => sub
+            .setName('winners')
+            .setDescription('View recent giveaway winners')
+            .addIntegerOption(opt => opt
+                .setName('limit')
+                .setDescription('Number of winners to show (default: 10, max: 50)')
+                .setMinValue(1)
+                .setMaxValue(50)))
+
+        // Mod commands
+        .addSubcommand(sub => sub
+            .setName('create')
+            .setDescription('[MOD] Create a new giveaway')
+            .addStringOption(opt => opt.setName('title').setDescription('Giveaway title').setRequired(true))
+            .addStringOption(opt => opt.setName('description').setDescription('Giveaway description').setRequired(true))
+            .addStringOption(opt => opt.setName('prize').setDescription('Prize name').setRequired(true))
+            .addStringOption(opt => opt.setName('end-time').setDescription('End time (ISO or relative: "2h", "30m", "1d")'))
+            .addIntegerOption(opt => opt.setName('max-entries').setDescription('Max entries before auto-end').setMinValue(1)))
+
+        .addSubcommand(sub => sub
+            .setName('list')
+            .setDescription('[MOD] List all giveaways'))
+
+        .addSubcommand(sub => sub
+            .setName('entries')
+            .setDescription('[MOD] View all entries for a giveaway')
+            .addStringOption(opt => opt.setName('giveaway-id').setDescription('The giveaway ID').setRequired(true)))
+
+        .addSubcommand(sub => sub
+            .setName('spin')
+            .setDescription('[MOD] Generate Wheel of Names URL')
+            .addStringOption(opt => opt.setName('giveaway-id').setDescription('The giveaway ID').setRequired(true)))
+
+        .addSubcommand(sub => sub
+            .setName('select-winner')
+            .setDescription('[MOD] Select winner after spinning the wheel')
+            .addStringOption(opt => opt.setName('giveaway-id').setDescription('The giveaway ID').setRequired(true))
+            .addUserOption(opt => opt.setName('winner').setDescription('The winner (must be an entrant)').setRequired(true)))
+
+        .addSubcommand(sub => sub
+            .setName('cancel')
+            .setDescription('[MOD] Cancel a giveaway')
+            .addStringOption(opt => opt.setName('giveaway-id').setDescription('The giveaway ID').setRequired(true))
+            .addStringOption(opt => opt.setName('reason').setDescription('Reason for cancellation')))
+
+        .addSubcommand(sub => sub
+            .setName('stats')
+            .setDescription('[MOD] View server giveaway statistics')),
+
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        const configService = getGachaGuildConfigService();
+        const isAllowed = await configService.isGuildAllowed(interaction.guildId);
+        if (!isAllowed) {
+            await replyEphemeral(interaction, '❌ This server is not authorized to use the giveaway system.');
+            return;
+        }
+
+        const subcommand = interaction.options.getSubcommand();
+
+        if (modCommands.includes(subcommand)) {
+            const hasPerm = await requireModPermission(interaction);
+            if (!hasPerm) return;
+        }
+
+        try {
+            const handlers: Record<string, (i: ChatInputCommandInteraction) => Promise<void>> = {
+                'join': handleJoin,
+                'leave': handleLeave,
+                'status': handleStatus,
+                'winners': handleWinners,
+                'create': handleCreate,
+                'list': handleList,
+                'entries': handleEntries,
+                'spin': handleSpin,
+                'select-winner': handleSelectWinner,
+                'cancel': handleCancel,
+                'stats': handleStats,
+            };
+
+            const handler = handlers[subcommand];
+            if (handler) {
+                await handler(interaction);
+            } else {
+                await replyEphemeral(interaction, '❌ Unknown subcommand.');
+            }
+        } catch (error) {
+            await handleCommandError(interaction, error, `giveaway ${subcommand}`);
+        }
+    },
+};

--- a/src/services/giveawayDataService.ts
+++ b/src/services/giveawayDataService.ts
@@ -1,0 +1,304 @@
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { s3Client, S3_BUCKET } from "../utils/cdn/config.js";
+import {
+    GiveawayData,
+    Giveaway,
+    GiveawayEntry,
+    GiveawayWinner,
+    GiveawayStatus,
+    UserGiveawayStats,
+} from "../utils/interfaces/Giveaway.interface.js";
+import { GIVEAWAY_CONFIG } from "../utils/data/giveawayConfig.js";
+import { logger } from "../utils/logger.js";
+import { randomUUID } from "crypto";
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+const DATA_KEY = isDevelopment
+    ? `${GIVEAWAY_CONFIG.DATA_PATH}/dev-giveaways.json`
+    : `${GIVEAWAY_CONFIG.DATA_PATH}/giveaways.json`;
+const CURRENT_SCHEMA_VERSION = 1;
+
+export class GiveawayDataService {
+    private static instance: GiveawayDataService;
+    private cache: GiveawayData | null = null;
+    private cacheExpiry: number = 0;
+
+    private constructor() {}
+
+    public static getInstance(): GiveawayDataService {
+        if (!GiveawayDataService.instance) {
+            GiveawayDataService.instance = new GiveawayDataService();
+        }
+        return GiveawayDataService.instance;
+    }
+
+    public async getData(): Promise<GiveawayData> {
+        if (this.cache && Date.now() < this.cacheExpiry) {
+            return this.cache;
+        }
+
+        try {
+            const response = await s3Client.send(new GetObjectCommand({
+                Bucket: S3_BUCKET,
+                Key: DATA_KEY,
+            }));
+
+            const body = await response.Body?.transformToString();
+            if (!body) return this.getDefaultData();
+
+            this.cache = JSON.parse(body) as GiveawayData;
+            this.cacheExpiry = Date.now() + GIVEAWAY_CONFIG.CACHE_TTL;
+            return this.cache;
+        } catch (error: any) {
+            if (error.name === 'NoSuchKey' || error.Code === 'NoSuchKey') {
+                logger.debug`[Giveaway] Data file not found, creating default`;
+                const defaultData = this.getDefaultData();
+                await this.saveData(defaultData);
+                return defaultData;
+            }
+            throw error;
+        }
+    }
+
+    public async saveData(data: GiveawayData): Promise<void> {
+        data.lastUpdated = new Date().toISOString();
+
+        await s3Client.send(new PutObjectCommand({
+            Bucket: S3_BUCKET,
+            Key: DATA_KEY,
+            Body: JSON.stringify(data, null, 2),
+            ContentType: 'application/json',
+        }));
+
+        this.cache = data;
+        this.cacheExpiry = Date.now() + GIVEAWAY_CONFIG.CACHE_TTL;
+    }
+
+    private getDefaultData(): GiveawayData {
+        return {
+            giveaways: [],
+            winners: [],
+            userStats: [],
+            lastUpdated: new Date().toISOString(),
+            schemaVersion: CURRENT_SCHEMA_VERSION,
+        };
+    }
+
+    public invalidateCache(): void {
+        this.cache = null;
+        this.cacheExpiry = 0;
+    }
+
+    // ==================== Giveaway Operations ====================
+
+    public async createGiveaway(giveaway: Omit<Giveaway, 'id' | 'createdAt'>): Promise<Giveaway> {
+        const data = await this.getData();
+        const newGiveaway: Giveaway = {
+            ...giveaway,
+            id: randomUUID(),
+            createdAt: new Date().toISOString(),
+        };
+        data.giveaways.push(newGiveaway);
+        await this.saveData(data);
+        return newGiveaway;
+    }
+
+    public async getGiveaway(id: string): Promise<Giveaway | null> {
+        const data = await this.getData();
+        return data.giveaways.find(g => g.id === id) || null;
+    }
+
+    public async getActiveGiveaways(guildId: string): Promise<Giveaway[]> {
+        const data = await this.getData();
+        return data.giveaways.filter(g => g.guildId === guildId && g.status === 'active');
+    }
+
+    public async getAllGiveaways(guildId: string): Promise<Giveaway[]> {
+        const data = await this.getData();
+        return data.giveaways.filter(g => g.guildId === guildId);
+    }
+
+    public async updateGiveaway(id: string, updates: Partial<Giveaway>): Promise<void> {
+        const data = await this.getData();
+        const giveaway = data.giveaways.find(g => g.id === id);
+        if (!giveaway) throw new Error(`Giveaway ${id} not found`);
+        Object.assign(giveaway, updates);
+        await this.saveData(data);
+    }
+
+    // ==================== Entry Operations ====================
+
+    public async enterGiveaway(
+        giveawayId: string,
+        entry: GiveawayEntry
+    ): Promise<{ success: boolean; error?: string; previousGiveaway?: string }> {
+        const data = await this.getData();
+        const giveaway = data.giveaways.find(g => g.id === giveawayId);
+
+        if (!giveaway) return { success: false, error: 'Giveaway not found' };
+        if (giveaway.status !== 'active') return { success: false, error: 'Giveaway is not active' };
+        if (giveaway.entries.some(e => e.discordId === entry.discordId)) {
+            return { success: false, error: 'You have already entered this giveaway' };
+        }
+
+        const maxEntriesCondition = giveaway.endConditions.find(c => c.type === 'entry_count');
+        if (maxEntriesCondition?.maxEntries && giveaway.entries.length >= maxEntriesCondition.maxEntries) {
+            return { success: false, error: 'Giveaway is full' };
+        }
+
+        // Auto-remove from other active giveaway (one-entry-at-a-time rule)
+        let previousGiveaway: string | undefined;
+        for (const g of data.giveaways) {
+            if (g.status === 'active' && g.id !== giveawayId) {
+                const idx = g.entries.findIndex(e => e.discordId === entry.discordId);
+                if (idx !== -1) {
+                    previousGiveaway = g.title;
+                    g.entries.splice(idx, 1);
+                    break;
+                }
+            }
+        }
+
+        // Add entry and update stats in a single save
+        giveaway.entries.push(entry);
+
+        let userStats = data.userStats.find(s => s.discordId === entry.discordId);
+        if (!userStats) {
+            userStats = { discordId: entry.discordId, totalEntered: 0, totalWon: 0, wins: [] };
+            data.userStats.push(userStats);
+        }
+        userStats.totalEntered++;
+        userStats.lastEnteredAt = new Date().toISOString();
+
+        await this.saveData(data);
+        return { success: true, previousGiveaway };
+    }
+
+    public async removeEntry(giveawayId: string, discordId: string): Promise<boolean> {
+        const data = await this.getData();
+        const giveaway = data.giveaways.find(g => g.id === giveawayId);
+        if (!giveaway) return false;
+
+        const index = giveaway.entries.findIndex(e => e.discordId === discordId);
+        if (index === -1) return false;
+
+        giveaway.entries.splice(index, 1);
+        await this.saveData(data);
+        return true;
+    }
+
+    public async getUserActiveEntry(discordId: string): Promise<{ giveawayId: string; giveaway: Giveaway } | null> {
+        const data = await this.getData();
+        for (const giveaway of data.giveaways) {
+            if (giveaway.status === 'active' && giveaway.entries.some(e => e.discordId === discordId)) {
+                return { giveawayId: giveaway.id, giveaway };
+            }
+        }
+        return null;
+    }
+
+    // ==================== Winner Operations ====================
+
+    public async setWinner(giveawayId: string, winnerId: string, endedBy: string): Promise<void> {
+        const data = await this.getData();
+        const giveaway = data.giveaways.find(g => g.id === giveawayId);
+        if (!giveaway) throw new Error(`Giveaway ${giveawayId} not found`);
+        if (!giveaway.entries.some(e => e.discordId === winnerId)) {
+            throw new Error('Winner is not an entrant in this giveaway');
+        }
+
+        const now = new Date().toISOString();
+        giveaway.winnerId = winnerId;
+        giveaway.status = 'ended';
+        giveaway.endedAt = now;
+        giveaway.endedBy = endedBy;
+
+        data.winners.push({
+            discordId: winnerId,
+            giveawayId,
+            wonAt: now,
+            prizeName: giveaway.prizeName,
+            notified: false,
+        });
+
+        let userStats = data.userStats.find(s => s.discordId === winnerId);
+        if (!userStats) {
+            userStats = { discordId: winnerId, totalEntered: 0, totalWon: 0, wins: [] };
+            data.userStats.push(userStats);
+        }
+        userStats.totalWon++;
+        userStats.wins.push({ giveawayId, prizeName: giveaway.prizeName, wonAt: now });
+
+        await this.saveData(data);
+    }
+
+    public async markWinnerNotified(giveawayId: string): Promise<void> {
+        const data = await this.getData();
+        const winner = data.winners.find(w => w.giveawayId === giveawayId);
+        if (winner) {
+            winner.notified = true;
+            winner.notifiedAt = new Date().toISOString();
+            await this.saveData(data);
+        }
+    }
+
+    public async getGuildWinners(guildId: string, limit?: number): Promise<GiveawayWinner[]> {
+        const data = await this.getData();
+        const guildGiveawayIds = new Set(
+            data.giveaways.filter(g => g.guildId === guildId).map(g => g.id)
+        );
+
+        const winners = data.winners
+            .filter(w => guildGiveawayIds.has(w.giveawayId))
+            .sort((a, b) => new Date(b.wonAt).getTime() - new Date(a.wonAt).getTime());
+
+        return limit ? winners.slice(0, limit) : winners;
+    }
+
+    // ==================== Statistics ====================
+
+    public async getUserStats(discordId: string): Promise<UserGiveawayStats> {
+        const data = await this.getData();
+        return data.userStats.find(s => s.discordId === discordId) || {
+            discordId, totalEntered: 0, totalWon: 0, wins: [],
+        };
+    }
+
+    public async getGuildStats(guildId: string): Promise<{
+        totalGiveaways: number;
+        activeCount: number;
+        endedCount: number;
+        totalWinners: number;
+        totalEntries: number;
+    }> {
+        const data = await this.getData();
+        const guildGiveaways = data.giveaways.filter(g => g.guildId === guildId);
+        const guildGiveawayIds = new Set(guildGiveaways.map(g => g.id));
+
+        return {
+            totalGiveaways: guildGiveaways.length,
+            activeCount: guildGiveaways.filter(g => g.status === 'active').length,
+            endedCount: guildGiveaways.filter(g => g.status === 'ended').length,
+            totalWinners: data.winners.filter(w => guildGiveawayIds.has(w.giveawayId)).length,
+            totalEntries: guildGiveaways.reduce((sum, g) => sum + g.entries.length, 0),
+        };
+    }
+
+    public async getExpiredScheduledGiveaways(): Promise<Giveaway[]> {
+        const data = await this.getData();
+        const now = new Date();
+
+        return data.giveaways.filter(g => {
+            if (g.status !== 'active') return false;
+            const scheduled = g.endConditions.find(c => c.type === 'scheduled');
+            return scheduled?.scheduledEndTime && new Date(scheduled.scheduledEndTime) <= now;
+        });
+    }
+
+    /** @internal Test helper */
+    public static _testResetInstance(): void {
+        GiveawayDataService.instance = undefined as any;
+    }
+}
+
+export const getGiveawayDataService = (): GiveawayDataService => GiveawayDataService.getInstance();

--- a/src/services/giveawayManagementService.ts
+++ b/src/services/giveawayManagementService.ts
@@ -1,0 +1,270 @@
+import { Client, TextChannel, User } from 'discord.js';
+import { getGiveawayDataService } from './giveawayDataService.js';
+import { Giveaway, EndCondition } from '../utils/interfaces/Giveaway.interface.js';
+import { GIVEAWAY_CONFIG } from '../utils/data/giveawayConfig.js';
+import { logger } from '../utils/logger.js';
+import { successEmbed, warningEmbed, errorEmbed, infoEmbed, EmbedColors, customEmbed } from '../utils/embedTemplates.js';
+import { getAssetUrls } from '../config/assets.js';
+
+export class GiveawayManagementService {
+    private static instance: GiveawayManagementService;
+
+    private constructor() {}
+
+    public static getInstance(): GiveawayManagementService {
+        if (!GiveawayManagementService.instance) {
+            GiveawayManagementService.instance = new GiveawayManagementService();
+        }
+        return GiveawayManagementService.instance;
+    }
+
+    // ==================== Lifecycle ====================
+
+    public async createGiveaway(
+        bot: Client,
+        guildId: string,
+        createdBy: string,
+        config: {
+            title: string;
+            description: string;
+            prizeName: string;
+            endConditions: EndCondition[];
+        }
+    ): Promise<Giveaway> {
+        const dataService = getGiveawayDataService();
+
+        const activeGiveaways = await dataService.getActiveGiveaways(guildId);
+        if (activeGiveaways.length >= GIVEAWAY_CONFIG.MAX_ACTIVE_GIVEAWAYS_PER_GUILD) {
+            throw new Error(`Maximum of ${GIVEAWAY_CONFIG.MAX_ACTIVE_GIVEAWAYS_PER_GUILD} active giveaways reached`);
+        }
+
+        const modChannel = this.findModChannel(bot, guildId);
+        if (!modChannel) {
+            throw new Error(`Moderator channel "${GIVEAWAY_CONFIG.MOD_CHANNEL_NAME}" not found`);
+        }
+
+        const giveaway = await dataService.createGiveaway({
+            guildId,
+            createdBy,
+            title: config.title,
+            description: config.description,
+            prizeName: config.prizeName,
+            status: 'active',
+            entries: [],
+            endConditions: config.endConditions,
+            modChannelId: modChannel.id,
+        });
+
+        await this.announceToModChannel(bot, guildId,
+            infoEmbed('New Giveaway Created!', config.description)
+                .addFields(
+                    { name: 'Title', value: giveaway.title, inline: false },
+                    { name: 'Prize', value: giveaway.prizeName, inline: false },
+                    { name: 'Giveaway ID', value: `\`${giveaway.id}\``, inline: false },
+                    { name: 'End Conditions', value: this.formatEndConditions(giveaway.endConditions), inline: false }
+                )
+        );
+
+        return giveaway;
+    }
+
+    public async endGiveaway(
+        bot: Client,
+        giveawayId: string,
+        endedBy: string,
+        winnerId: string
+    ): Promise<void> {
+        const dataService = getGiveawayDataService();
+        const giveaway = await dataService.getGiveaway(giveawayId);
+
+        if (!giveaway) throw new Error('Giveaway not found');
+        if (giveaway.status !== 'active') throw new Error('Giveaway is not active');
+        if (giveaway.entries.length === 0) throw new Error('Cannot end giveaway with no entries');
+
+        await dataService.setWinner(giveawayId, winnerId, endedBy);
+
+        try {
+            const winner = await bot.users.fetch(winnerId);
+            const notified = await this.notifyWinner(winner, giveaway);
+            if (notified) await dataService.markWinnerNotified(giveawayId);
+
+            await this.announceToModChannel(bot, giveaway.guildId,
+                successEmbed('Giveaway Winner Selected!', `**${giveaway.title}** has ended.`)
+                    .addFields(
+                        { name: 'Winner', value: `<@${winner.id}> (${winner.username})`, inline: true },
+                        { name: 'Prize', value: giveaway.prizeName, inline: true },
+                        { name: 'Total Entries', value: giveaway.entries.length.toString(), inline: true },
+                    )
+            );
+        } catch (error) {
+            logger.error`[Giveaway] Error notifying winner for ${giveawayId}: ${error}`;
+            await this.announceToModChannel(bot, giveaway.guildId,
+                warningEmbed('Winner Notification Failed',
+                    `Giveaway ended but failed to notify <@${winnerId}>. Please notify them manually.`)
+            );
+        }
+    }
+
+    public async cancelGiveaway(
+        bot: Client,
+        giveawayId: string,
+        cancelledBy: string,
+        reason?: string
+    ): Promise<Giveaway> {
+        const dataService = getGiveawayDataService();
+        const giveaway = await dataService.getGiveaway(giveawayId);
+
+        if (!giveaway) throw new Error('Giveaway not found');
+        if (giveaway.status !== 'active') throw new Error('Giveaway is not active');
+
+        await dataService.updateGiveaway(giveawayId, {
+            status: 'cancelled',
+            endedAt: new Date().toISOString(),
+            endedBy: cancelledBy,
+        });
+
+        const embed = errorEmbed('Giveaway Cancelled',
+            `**${giveaway.title}** has been cancelled by <@${cancelledBy}>`)
+            .addFields(
+                { name: 'Prize', value: giveaway.prizeName, inline: true },
+                { name: 'Entries', value: giveaway.entries.length.toString(), inline: true },
+            );
+        if (reason) embed.addFields({ name: 'Reason', value: reason, inline: false });
+
+        await this.announceToModChannel(bot, giveaway.guildId, embed);
+        return giveaway;
+    }
+
+    // ==================== End Condition Checking ====================
+
+    public async checkEndConditions(bot: Client, giveawayId: string): Promise<boolean> {
+        const dataService = getGiveawayDataService();
+        const giveaway = await dataService.getGiveaway(giveawayId);
+        if (!giveaway || giveaway.status !== 'active') return false;
+
+        const entryCondition = giveaway.endConditions.find(c => c.type === 'entry_count');
+        if (entryCondition?.maxEntries && giveaway.entries.length >= entryCondition.maxEntries) {
+            logger.debug`[Giveaway] Entry limit reached for ${giveaway.id}`;
+            await this.announceToModChannel(bot, giveaway.guildId,
+                warningEmbed('Giveaway Entry Limit Reached!',
+                    `**${giveaway.title}** reached its entry limit of ${entryCondition.maxEntries}.`)
+                    .addFields(
+                        { name: 'Giveaway ID', value: `\`${giveaway.id}\``, inline: false },
+                        { name: 'Next Step', value: 'Use `/giveaway spin` then `/giveaway select-winner`', inline: false },
+                    )
+            );
+            return true;
+        }
+
+        const scheduledCondition = giveaway.endConditions.find(c => c.type === 'scheduled');
+        if (scheduledCondition?.scheduledEndTime && new Date() >= new Date(scheduledCondition.scheduledEndTime)) {
+            logger.debug`[Giveaway] Scheduled end time reached for ${giveaway.id}`;
+            await this.announceToModChannel(bot, giveaway.guildId,
+                warningEmbed('Giveaway Time Limit Reached!',
+                    `**${giveaway.title}** reached its scheduled end time.`)
+                    .addFields(
+                        { name: 'Giveaway ID', value: `\`${giveaway.id}\``, inline: false },
+                        { name: 'Total Entries', value: giveaway.entries.length.toString(), inline: true },
+                        { name: 'Next Step', value: 'Use `/giveaway spin` then `/giveaway select-winner`', inline: false },
+                    )
+            );
+            return true;
+        }
+
+        return false;
+    }
+
+    public async checkAndEndExpiredGiveaways(bot: Client): Promise<number> {
+        const dataService = getGiveawayDataService();
+        const expired = await dataService.getExpiredScheduledGiveaways();
+
+        for (const giveaway of expired) {
+            logger.debug`[Giveaway] Found expired giveaway ${giveaway.id}`;
+            await this.announceToModChannel(bot, giveaway.guildId,
+                errorEmbed('Expired Giveaway Detected!',
+                    `**${giveaway.title}** passed its scheduled end time while the bot was offline.`)
+                    .addFields(
+                        { name: 'Giveaway ID', value: `\`${giveaway.id}\``, inline: false },
+                        { name: 'Total Entries', value: giveaway.entries.length.toString(), inline: true },
+                        { name: 'Next Step', value: 'Use `/giveaway spin` then `/giveaway select-winner`', inline: false },
+                    )
+            );
+        }
+
+        return expired.length;
+    }
+
+    // ==================== Notifications ====================
+
+    private async notifyWinner(user: User, giveaway: Giveaway): Promise<boolean> {
+        const assetUrls = getAssetUrls();
+
+        const embed = customEmbed('Congratulations! You Won!', EmbedColors.GOLD,
+            `You've won the giveaway for:\n**${giveaway.prizeName}**`)
+            .addFields(
+                { name: 'Prize', value: giveaway.prizeName, inline: false },
+                { name: 'Giveaway', value: giveaway.title, inline: false },
+                { name: 'Next Steps', value: 'Please contact a moderator in the server to claim your prize.', inline: false },
+            )
+            .setFooter({ text: 'Giveaway System', iconURL: assetUrls.rapiBot.thumbnail });
+
+        for (let attempt = 0; attempt < GIVEAWAY_CONFIG.DM_RETRY_ATTEMPTS; attempt++) {
+            try {
+                await user.send({ embeds: [embed] });
+                logger.debug`[Giveaway] Winner ${user.username} notified`;
+                return true;
+            } catch (error) {
+                logger.warning`[Giveaway] DM attempt ${attempt + 1} failed for ${user.username}: ${error}`;
+                if (attempt < GIVEAWAY_CONFIG.DM_RETRY_ATTEMPTS - 1) {
+                    await new Promise(resolve => setTimeout(resolve, GIVEAWAY_CONFIG.DM_RETRY_DELAY));
+                }
+            }
+        }
+
+        logger.error`[Giveaway] Failed to DM winner ${user.username} after ${GIVEAWAY_CONFIG.DM_RETRY_ATTEMPTS} attempts`;
+        return false;
+    }
+
+    // ==================== Helpers ====================
+
+    public findModChannel(bot: Client, guildId: string): TextChannel | null {
+        const guild = bot.guilds.cache.get(guildId);
+        if (!guild) return null;
+
+        return guild.channels.cache.find(
+            ch => ch.name === GIVEAWAY_CONFIG.MOD_CHANNEL_NAME && ch.isTextBased()
+        ) as TextChannel | null;
+    }
+
+    private async announceToModChannel(
+        bot: Client,
+        guildId: string,
+        embed: ReturnType<typeof infoEmbed>
+    ): Promise<void> {
+        const modChannel = this.findModChannel(bot, guildId);
+        if (!modChannel) return;
+
+        try {
+            await modChannel.send({ embeds: [embed] });
+        } catch (error) {
+            logger.error`[Giveaway] Failed to send to mod channel: ${error}`;
+        }
+    }
+
+    private formatEndConditions(conditions: EndCondition[]): string {
+        return conditions.map(c => {
+            if (c.type === 'manual') return 'Manual end';
+            if (c.type === 'scheduled') return `Ends at <t:${Math.floor(new Date(c.scheduledEndTime!).getTime() / 1000)}:F>`;
+            if (c.type === 'entry_count') return `Max ${c.maxEntries} entries`;
+            return 'Unknown';
+        }).join('\n');
+    }
+
+    /** @internal Test helper */
+    public static _testResetInstance(): void {
+        GiveawayManagementService.instance = undefined as any;
+    }
+}
+
+export const getGiveawayManagementService = (): GiveawayManagementService =>
+    GiveawayManagementService.getInstance();

--- a/src/services/giveawayWheelService.ts
+++ b/src/services/giveawayWheelService.ts
@@ -1,0 +1,42 @@
+import { Giveaway } from '../utils/interfaces/Giveaway.interface.js';
+import { GIVEAWAY_CONFIG } from '../utils/data/giveawayConfig.js';
+
+export class GiveawayWheelService {
+    private static instance: GiveawayWheelService;
+
+    private constructor() {}
+
+    public static getInstance(): GiveawayWheelService {
+        if (!GiveawayWheelService.instance) {
+            GiveawayWheelService.instance = new GiveawayWheelService();
+        }
+        return GiveawayWheelService.instance;
+    }
+
+    public generateWheelUrl(giveaway: Giveaway): string {
+        if (giveaway.entries.length === 0) {
+            throw new Error('Cannot generate wheel URL with no entries');
+        }
+
+        const entriesParam = giveaway.entries.map(e => e.username).join(',');
+        return `${GIVEAWAY_CONFIG.WHEEL_BASE_URL}?entries=${encodeURIComponent(entriesParam)}`;
+    }
+
+    public getWheelInstructions(): string {
+        return [
+            '**How to use Wheel of Names:**',
+            '1. Click the wheel URL to open it in your browser',
+            '2. Click "Spin" on the website to select a random winner',
+            '3. Once you have the winner, use `/giveaway select-winner` to officially select them',
+            '4. The bot will notify the winner via DM and announce in the moderator channel',
+        ].join('\n');
+    }
+
+    /** @internal Test helper */
+    public static _testResetInstance(): void {
+        GiveawayWheelService.instance = undefined as any;
+    }
+}
+
+export const getGiveawayWheelService = (): GiveawayWheelService =>
+    GiveawayWheelService.getInstance();

--- a/src/utils/data/giveawayConfig.ts
+++ b/src/utils/data/giveawayConfig.ts
@@ -1,0 +1,14 @@
+export const GIVEAWAY_CONFIG = {
+    DATA_PATH: 'data/giveaways',
+    CACHE_TTL: 5 * 60 * 1000,
+    MAX_ACTIVE_GIVEAWAYS_PER_GUILD: 5,
+    MAX_TITLE_LENGTH: 100,
+    MAX_DESCRIPTION_LENGTH: 500,
+    MAX_PRIZE_NAME_LENGTH: 200,
+    DM_RETRY_ATTEMPTS: 3,
+    DM_RETRY_DELAY: 2000,
+    WHEEL_BASE_URL: 'https://wheelofnames.com',
+    MOD_CHANNEL_NAME: 'moderator-only',
+    GIVEAWAYS_PER_PAGE: 10,
+    ENTRIES_PER_PAGE: 20,
+} as const;

--- a/src/utils/interfaces/Giveaway.interface.ts
+++ b/src/utils/interfaces/Giveaway.interface.ts
@@ -1,0 +1,63 @@
+export type GiveawayStatus = 'active' | 'ended' | 'cancelled';
+
+export type EndConditionType = 'manual' | 'scheduled' | 'entry_count';
+
+export interface GiveawayEntry {
+    discordId: string;
+    enteredAt: string;
+    username: string;
+}
+
+export interface GiveawayWinner {
+    discordId: string;
+    giveawayId: string;
+    wonAt: string;
+    prizeName: string;
+    notified: boolean;
+    notifiedAt?: string;
+}
+
+export interface EndCondition {
+    type: EndConditionType;
+    scheduledEndTime?: string;
+    maxEntries?: number;
+}
+
+export interface Giveaway {
+    id: string;
+    guildId: string;
+    createdBy: string;
+    createdAt: string;
+    title: string;
+    description: string;
+    prizeName: string;
+    status: GiveawayStatus;
+    entries: GiveawayEntry[];
+    winnerId?: string;
+    endConditions: EndCondition[];
+    endedAt?: string;
+    endedBy?: string;
+    wheelUrl?: string;
+    wheelSpunAt?: string;
+    modChannelId?: string;
+}
+
+export interface UserGiveawayStats {
+    discordId: string;
+    totalEntered: number;
+    totalWon: number;
+    wins: Array<{
+        giveawayId: string;
+        prizeName: string;
+        wonAt: string;
+    }>;
+    lastEnteredAt?: string;
+}
+
+export interface GiveawayData {
+    giveaways: Giveaway[];
+    winners: GiveawayWinner[];
+    userStats: UserGiveawayStats[];
+    lastUpdated: string;
+    schemaVersion: number;
+}


### PR DESCRIPTION
## Summary
Complete rebuild of the giveaway system from scratch on a fresh branch from master, using proper codebase patterns and utilities.

## Changes
- **Single S3 save per entry** -- entering a giveaway now does auto-removal, entry add, and stats update in one save (was 3 separate saves)
- **Removed backup-on-every-save** -- eliminated unbounded S3 backup growth on every write
- **Paginated entries list** -- prevents Discord 4096 char embed overflow with large entry counts
- **Proper utility usage** -- `requireModPermission`, `handleCommandError`, `deferEphemeral`, `embedTemplates`, `paginationBuilder`, `getAssetUrls()`, LogTape `logger`
- **Removed dead code** -- `validateWinnerExists`, `findDiscordIdByUsername`, unused config constants
- **Test reset helpers** -- `_testResetInstance()` on all singleton services
- **41% code reduction** -- 1,972 → 1,174 lines across 6 files

## Files
| File | Lines | Description |
|------|-------|-------------|
| `Giveaway.interface.ts` | 63 | Streamlined type definitions (removed NoSQL migration comments) |
| `giveawayConfig.ts` | 14 | Config constants (removed unused WHEEL_SPIN_TIMEOUT, WINNERS_PER_PAGE, BACKUP_PATH) |
| `giveawayDataService.ts` | 304 | S3 CRUD with batched operations |
| `giveawayManagementService.ts` | 270 | Lifecycle, notifications, end condition checking |
| `giveawayWheelService.ts` | 42 | Wheel of Names URL generation |
| `giveaway.ts` | 481 | Slash command with 11 subcommands |

## Testing
- [x] `bunx tsc --noEmit` passes
- [x] `bun run test:run` -- all tests pass (1 pre-existing flaky date test unrelated)
- [ ] Manual testing with Discord bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)