### PR TITLE
feat: Add BD2 Mirror Wars weekly PVP reminders

### DIFF
--- a/src/bootstrap/serviceInitializer.ts
+++ b/src/bootstrap/serviceInitializer.ts
@@ -6,6 +6,8 @@ import { getChannelMonitorService } from '../services/channelMonitorService.js';
 import { getReactionConfirmationService } from '../services/reactionConfirmationService.js';
 import { getRulesManagementService } from '../services/rulesManagementService.js';
 import { YouTubeNotificationScheduler } from '../services/youtubeNotificationScheduler.js';
+import { PvpReminderService } from '../services/pvpReminderService.js';
+import { pvpReminderServiceConfig } from '../utils/data/pvpEventsConfig.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -57,6 +59,11 @@ export async function initializeServices(bot: Client): Promise<void> {
         const youtubeScheduler = new YouTubeNotificationScheduler(bot);
         await youtubeScheduler.initializeSchedules();
         logger.info`YouTube notification scheduler initialized`;
+
+        // Initialize PVP reminder service (weekly event warnings)
+        const pvpReminderService = new PvpReminderService(bot, pvpReminderServiceConfig);
+        pvpReminderService.initializeSchedules();
+        logger.info`PVP reminder service initialized`;
 
         logger.info`All services initialized successfully`;
     } catch (error) {

--- a/src/services/pvpReminderService.ts
+++ b/src/services/pvpReminderService.ts
@@ -1,0 +1,197 @@
+import { Client, EmbedBuilder, Guild } from 'discord.js';
+import schedule from 'node-schedule';
+import { PvpEventConfig, PvpWarningConfig, PvpReminderServiceConfig } from '../utils/interfaces/PvpEventConfig.interface.js';
+import { findChannelByName, logError } from '../utils/util.js';
+import { getRandomCdnMediaUrl } from '../utils/cdn/mediaManager.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Service for scheduling weekly PVP event warnings.
+ *
+ * Separate from DailyResetService because PVP events use weekly (day-of-week)
+ * scheduling rather than daily. Follows the same node-schedule + guild iteration pattern.
+ */
+export class PvpReminderService {
+    private bot: Client;
+    private config: PvpReminderServiceConfig;
+    private scheduledJobs: Map<string, schedule.Job> = new Map();
+    private isDevelopment: boolean;
+
+    constructor(bot: Client, config: PvpReminderServiceConfig) {
+        this.bot = bot;
+        this.config = config;
+        this.isDevelopment = process.env.NODE_ENV === 'development';
+    }
+
+    /**
+     * Initialize all PVP event warning schedules
+     */
+    public initializeSchedules(): void {
+        for (const event of this.config.events) {
+            this.scheduleEventWarnings(event);
+        }
+    }
+
+    /**
+     * Schedule all warnings for a single PVP event
+     */
+    private scheduleEventWarnings(event: PvpEventConfig): void {
+        for (const warning of event.warnings) {
+            const jobId = `${event.id}-${warning.label}`;
+
+            let cron: string;
+            if (this.isDevelopment) {
+                const interval = this.config.devModeInterval || 3;
+                cron = `*/${interval} * * * *`;
+            } else {
+                cron = this.calculateWarningCron(event, warning);
+            }
+
+            const job = schedule.scheduleJob(cron, async () => {
+                await this.sendWarningToAllGuilds(event, warning);
+            });
+
+            if (job) {
+                this.scheduledJobs.set(jobId, job);
+                logger.debug`[PVP] Scheduled ${event.id} ${warning.label} warning: ${cron}`;
+            }
+        }
+    }
+
+    /**
+     * Calculate cron expression for a warning relative to the event's season end.
+     *
+     * Converts seasonEnd time to total minutes in the week, subtracts minutesBefore,
+     * and handles wraparound (e.g., warning before Monday 00:00 wraps to Sunday).
+     *
+     * @returns node-schedule cron: "minute hour * * dayOfWeek"
+     */
+    public calculateWarningCron(event: PvpEventConfig, warning: PvpWarningConfig): string {
+        const { dayOfWeek, hour, minute } = event.seasonEnd;
+
+        // Total minutes into the week (Sunday 00:00 = 0)
+        let totalMinutes = (dayOfWeek * 24 * 60) + (hour * 60) + minute;
+        totalMinutes -= warning.minutesBefore;
+
+        // Wrap around the week (7 days = 10080 minutes)
+        if (totalMinutes < 0) {
+            totalMinutes += 7 * 24 * 60;
+        }
+
+        const warningDay = Math.floor(totalMinutes / (24 * 60));
+        const remainingMinutes = totalMinutes % (24 * 60);
+        const warningHour = Math.floor(remainingMinutes / 60);
+        const warningMinute = remainingMinutes % 60;
+
+        return `${warningMinute} ${warningHour} * * ${warningDay}`;
+    }
+
+    /**
+     * Send a warning to all guilds the bot is in
+     */
+    private async sendWarningToAllGuilds(event: PvpEventConfig, warning: PvpWarningConfig): Promise<void> {
+        for (const guild of this.bot.guilds.cache.values()) {
+            try {
+                await this.sendWarningToGuild(guild, event, warning);
+            } catch (error) {
+                logError(
+                    guild.id,
+                    guild.name,
+                    error instanceof Error ? error : new Error(String(error)),
+                    `Sending ${event.id} ${warning.label} PVP warning`
+                );
+            }
+        }
+    }
+
+    /**
+     * Send a warning to a specific guild's channel
+     */
+    private async sendWarningToGuild(guild: Guild, event: PvpEventConfig, warning: PvpWarningConfig): Promise<void> {
+        const channel = findChannelByName(guild, event.channelName);
+
+        if (!channel) {
+            logger.warn`[PVP] Channel '${event.channelName}' not found in server: ${guild.name}`;
+            return;
+        }
+
+        const embed = await this.buildWarningEmbed(guild, event, warning);
+        await channel.send({ embeds: [embed] });
+    }
+
+    /**
+     * Build an embed for a PVP warning message
+     */
+    private async buildWarningEmbed(guild: Guild, event: PvpEventConfig, warning: PvpWarningConfig): Promise<EmbedBuilder> {
+        const { embedConfig } = warning;
+
+        const embed = new EmbedBuilder()
+            .setTitle(embedConfig.title)
+            .setDescription(embedConfig.description)
+            .setColor(embedConfig.color)
+            .setTimestamp()
+            .setFooter({
+                text: embedConfig.footer.text,
+                iconURL: embedConfig.footer.iconURL,
+            });
+
+        if (embedConfig.author) {
+            embed.setAuthor({
+                name: embedConfig.author.name,
+                iconURL: embedConfig.author.iconURL,
+            });
+        }
+
+        if (embedConfig.thumbnail) {
+            embed.setThumbnail(embedConfig.thumbnail);
+        }
+
+        if (embedConfig.fields) {
+            for (const field of embedConfig.fields) {
+                embed.addFields({
+                    name: field.name,
+                    value: field.value,
+                    inline: field.inline || false,
+                });
+            }
+        }
+
+        // Random media image (same pattern as daily reset)
+        if (event.mediaConfig) {
+            try {
+                const mediaUrl = await getRandomCdnMediaUrl(
+                    event.mediaConfig.cdnPath,
+                    guild.id,
+                    {
+                        extensions: event.mediaConfig.extensions,
+                        trackLast: event.mediaConfig.trackLast,
+                    }
+                );
+                if (mediaUrl && mediaUrl.startsWith('http')) {
+                    embed.setImage(mediaUrl);
+                }
+            } catch (error) {
+                logger.warn`[PVP] Failed to fetch media for ${event.id} in guild ${guild.name}: ${error}`;
+            }
+        }
+
+        return embed;
+    }
+
+    /**
+     * Cancel all scheduled jobs
+     */
+    public cancelAllSchedules(): void {
+        for (const [, job] of this.scheduledJobs) {
+            job.cancel();
+        }
+        this.scheduledJobs.clear();
+    }
+
+    /**
+     * Get all scheduled jobs (for debugging)
+     */
+    public getScheduledJobs(): Map<string, schedule.Job> {
+        return this.scheduledJobs;
+    }
+}

--- a/src/services/pvpReminderService.ts
+++ b/src/services/pvpReminderService.ts
@@ -120,14 +120,52 @@ export class PvpReminderService {
     }
 
     /**
+     * Compute the Unix timestamp (seconds) for the next occurrence of the season end.
+     * Used to generate Discord dynamic timestamps like <t:1234567890:F>.
+     */
+    public getNextSeasonEndTimestamp(event: PvpEventConfig): number {
+        const now = new Date();
+        const { dayOfWeek, hour, minute } = event.seasonEnd;
+
+        // Start from today, find next matching day of week
+        const target = new Date(Date.UTC(
+            now.getUTCFullYear(),
+            now.getUTCMonth(),
+            now.getUTCDate(),
+            hour,
+            minute,
+            0
+        ));
+
+        // Adjust to the correct day of week
+        const currentDay = target.getUTCDay();
+        let daysUntil = dayOfWeek - currentDay;
+        if (daysUntil < 0) daysUntil += 7;
+        if (daysUntil === 0 && target.getTime() <= now.getTime()) daysUntil = 7;
+        target.setUTCDate(target.getUTCDate() + daysUntil);
+
+        return Math.floor(target.getTime() / 1000);
+    }
+
+    /**
      * Build an embed for a PVP warning message
      */
     private async buildWarningEmbed(guild: Guild, event: PvpEventConfig, warning: PvpWarningConfig): Promise<EmbedBuilder> {
         const { embedConfig } = warning;
+        const seasonEndTs = this.getNextSeasonEndTimestamp(event);
+
+        // Resolve dynamic description and fields
+        const description = typeof embedConfig.description === 'function'
+            ? embedConfig.description(seasonEndTs)
+            : embedConfig.description;
+
+        const fields = typeof embedConfig.fields === 'function'
+            ? embedConfig.fields(seasonEndTs)
+            : embedConfig.fields;
 
         const embed = new EmbedBuilder()
             .setTitle(embedConfig.title)
-            .setDescription(embedConfig.description)
+            .setDescription(description)
             .setColor(embedConfig.color)
             .setTimestamp()
             .setFooter({
@@ -146,8 +184,8 @@ export class PvpReminderService {
             embed.setThumbnail(embedConfig.thumbnail);
         }
 
-        if (embedConfig.fields) {
-            for (const field of embedConfig.fields) {
+        if (fields) {
+            for (const field of fields) {
                 embed.addFields({
                     name: field.name,
                     value: field.value,

--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -386,6 +386,90 @@ describe('PvpReminderService', () => {
         });
     });
 
+    describe('Dynamic Descriptions and Discord Timestamps', () => {
+        it('should resolve function-based description with season end timestamp', async () => {
+            const dynamicEvent: PvpEventConfig = {
+                ...testEvent,
+                warnings: [{
+                    ...testEvent.warnings[0],
+                    embedConfig: {
+                        ...testEvent.warnings[0].embedConfig,
+                        description: (ts) => `Season ends <t:${ts}:F>`,
+                    }
+                }]
+            };
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, dynamicEvent, dynamicEvent.warnings[0]);
+
+            expect(embed.data.description).toMatch(/Season ends <t:\d+:F>/);
+        });
+
+        it('should resolve function-based fields with season end timestamp', async () => {
+            const dynamicEvent: PvpEventConfig = {
+                ...testEvent,
+                warnings: [{
+                    ...testEvent.warnings[0],
+                    embedConfig: {
+                        ...testEvent.warnings[0].embedConfig,
+                        fields: (ts) => [
+                            { name: 'Ends', value: `<t:${ts}:R>`, inline: true }
+                        ],
+                    }
+                }]
+            };
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, dynamicEvent, dynamicEvent.warnings[0]);
+
+            expect(embed.data.fields).toHaveLength(1);
+            expect(embed.data.fields?.[0].value).toMatch(/<t:\d+:R>/);
+        });
+
+        it('should still support static description strings', async () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, testEvent, testEvent.warnings[0]);
+
+            expect(embed.data.description).toBe('Season ends tomorrow.');
+        });
+    });
+
+    describe('getNextSeasonEndTimestamp', () => {
+        it('should return a Unix timestamp in the future', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const ts = service.getNextSeasonEndTimestamp(testEvent);
+
+            const now = Math.floor(Date.now() / 1000);
+            expect(ts).toBeGreaterThan(now);
+        });
+
+        it('should return a timestamp on the correct day of week', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const ts = service.getNextSeasonEndTimestamp(testEvent);
+
+            const date = new Date(ts * 1000);
+            expect(date.getUTCDay()).toBe(0); // Sunday
+            expect(date.getUTCHours()).toBe(14);
+            expect(date.getUTCMinutes()).toBe(59);
+        });
+
+        it('should be within the next 7 days', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const ts = service.getNextSeasonEndTimestamp(testEvent);
+
+            const now = Math.floor(Date.now() / 1000);
+            const sevenDays = 7 * 24 * 60 * 60;
+            expect(ts - now).toBeLessThanOrEqual(sevenDays);
+            expect(ts - now).toBeGreaterThan(0);
+        });
+    });
+
     describe('Config Validation', () => {
         it('should use actual BD2 Mirror Wars config values', async () => {
             // Import the real config to validate it

--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { PvpReminderService } from '../pvpReminderService';
+import { PvpEventConfig, PvpReminderServiceConfig, PvpWarningConfig } from '../../utils/interfaces/PvpEventConfig.interface';
+import { Client, Guild, TextChannel } from 'discord.js';
+import * as util from '../../utils/util';
+import * as mediaManager from '../../utils/cdn/mediaManager';
+
+vi.mock('node-schedule', () => ({
+    default: {
+        scheduleJob: vi.fn((cronTime, callback) => ({
+            cancel: vi.fn()
+        }))
+    }
+}));
+
+vi.mock('../../utils/util', () => ({
+    findChannelByName: vi.fn(),
+    findRoleByName: vi.fn(),
+    logError: vi.fn(),
+    cdnDomainUrl: 'https://cdn.example.com'
+}));
+
+vi.mock('../../utils/cdn/mediaManager', () => ({
+    getRandomCdnMediaUrl: vi.fn().mockResolvedValue('https://cdn.example.com/test-image.png')
+}));
+
+describe('PvpReminderService', () => {
+    let mockBot: Client;
+    let mockGuild: Guild;
+    let mockChannel: TextChannel;
+    let testEvent: PvpEventConfig;
+    let testConfig: PvpReminderServiceConfig;
+
+    beforeEach(() => {
+        mockBot = {
+            guilds: {
+                cache: new Map()
+            }
+        } as any;
+
+        mockGuild = {
+            id: 'test-guild-id',
+            name: 'Test Guild',
+            channels: { cache: new Map() }
+        } as any;
+
+        mockChannel = {
+            id: 'test-channel-id',
+            name: 'brown-dust-2',
+            send: vi.fn().mockResolvedValue({
+                id: 'test-message-id',
+                channel: mockChannel,
+                guild: mockGuild
+            })
+        } as any;
+
+        (mockBot.guilds.cache as any).set('test-guild-id', mockGuild);
+
+        testEvent = {
+            id: 'bd2-mirror-wars',
+            game: 'Brown Dust 2',
+            eventName: 'Mirror Wars',
+            channelName: 'brown-dust-2',
+            seasonEnd: { dayOfWeek: 0, hour: 14, minute: 59 },
+            warnings: [
+                {
+                    label: '1 day',
+                    minutesBefore: 24 * 60,
+                    embedConfig: {
+                        title: 'Mirror Wars Ending Tomorrow!',
+                        description: 'Season ends tomorrow.',
+                        color: 0xFFA500,
+                        footer: { text: 'Test footer' },
+                        fields: [
+                            { name: 'Time', value: '~24 hours', inline: true }
+                        ]
+                    }
+                },
+                {
+                    label: '1 hour',
+                    minutesBefore: 60,
+                    embedConfig: {
+                        title: 'Mirror Wars Ending in 1 Hour!',
+                        description: 'Final hour!',
+                        color: 0xFF0000,
+                        footer: { text: 'Urgent footer' }
+                    }
+                }
+            ],
+            mediaConfig: {
+                cdnPath: 'dailies/bd2/',
+                extensions: ['.png', '.jpg'],
+                trackLast: 10
+            }
+        };
+
+        testConfig = { events: [testEvent], devModeInterval: 3 };
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('Constructor', () => {
+        it('should create an instance with bot and config', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            expect(service).toBeInstanceOf(PvpReminderService);
+        });
+    });
+
+    describe('calculateWarningCron', () => {
+        it('should calculate 1-day warning: Sunday 14:59 - 1440min = Saturday 14:59', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const cron = service.calculateWarningCron(testEvent, testEvent.warnings[0]);
+            expect(cron).toBe('59 14 * * 6'); // Saturday 14:59
+        });
+
+        it('should calculate 1-hour warning: Sunday 14:59 - 60min = Sunday 13:59', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const cron = service.calculateWarningCron(testEvent, testEvent.warnings[1]);
+            expect(cron).toBe('59 13 * * 0'); // Sunday 13:59
+        });
+
+        it('should handle week wraparound (before Monday 00:00 wraps to Sunday)', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const mondayEvent: PvpEventConfig = {
+                ...testEvent,
+                seasonEnd: { dayOfWeek: 1, hour: 0, minute: 30 } // Monday 00:30
+            };
+            const warning: PvpWarningConfig = {
+                label: '2 hours',
+                minutesBefore: 120,
+                embedConfig: testEvent.warnings[0].embedConfig
+            };
+
+            const cron = service.calculateWarningCron(mondayEvent, warning);
+            expect(cron).toBe('30 22 * * 0'); // Sunday 22:30
+        });
+
+        it('should handle Saturday event with 2-day warning wrapping to Thursday', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const saturdayEvent: PvpEventConfig = {
+                ...testEvent,
+                seasonEnd: { dayOfWeek: 6, hour: 12, minute: 0 } // Saturday 12:00
+            };
+            const warning: PvpWarningConfig = {
+                label: '2 days',
+                minutesBefore: 48 * 60,
+                embedConfig: testEvent.warnings[0].embedConfig
+            };
+
+            const cron = service.calculateWarningCron(saturdayEvent, warning);
+            expect(cron).toBe('0 12 * * 4'); // Thursday 12:00
+        });
+
+        it('should handle Sunday 00:00 event with 1-day warning = Saturday 00:00', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const sundayMidnightEvent: PvpEventConfig = {
+                ...testEvent,
+                seasonEnd: { dayOfWeek: 0, hour: 0, minute: 0 }
+            };
+            const warning: PvpWarningConfig = {
+                label: '1 day',
+                minutesBefore: 24 * 60,
+                embedConfig: testEvent.warnings[0].embedConfig
+            };
+
+            const cron = service.calculateWarningCron(sundayMidnightEvent, warning);
+            expect(cron).toBe('0 0 * * 6'); // Saturday 00:00
+        });
+    });
+
+    describe('initializeSchedules', () => {
+        it('should create one job per warning per event', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            service.initializeSchedules();
+
+            const jobs = service.getScheduledJobs();
+            expect(jobs.size).toBe(2); // 2 warnings for Mirror Wars
+            expect(jobs.has('bd2-mirror-wars-1 day')).toBe(true);
+            expect(jobs.has('bd2-mirror-wars-1 hour')).toBe(true);
+        });
+
+        it('should handle multiple events', () => {
+            const secondEvent: PvpEventConfig = {
+                ...testEvent,
+                id: 'bd2-arena',
+                eventName: 'Arena',
+                warnings: [testEvent.warnings[0]] // 1 warning
+            };
+
+            const multiConfig: PvpReminderServiceConfig = {
+                events: [testEvent, secondEvent],
+                devModeInterval: 3
+            };
+
+            const service = new PvpReminderService(mockBot, multiConfig);
+            service.initializeSchedules();
+
+            const jobs = service.getScheduledJobs();
+            expect(jobs.size).toBe(3); // 2 from Mirror Wars + 1 from Arena
+        });
+    });
+
+    describe('cancelAllSchedules', () => {
+        it('should cancel all jobs and clear the map', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            service.initializeSchedules();
+
+            expect(service.getScheduledJobs().size).toBe(2);
+
+            service.cancelAllSchedules();
+
+            expect(service.getScheduledJobs().size).toBe(0);
+        });
+    });
+
+    describe('Warning Sending', () => {
+        it('should skip guilds without the target channel', async () => {
+            vi.mocked(util.findChannelByName).mockReturnValue(undefined);
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const sendWarningToGuild = (service as any).sendWarningToGuild;
+
+            await sendWarningToGuild.call(service, mockGuild, testEvent, testEvent.warnings[0]);
+
+            expect(mockChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('should send embed to the correct channel', async () => {
+            vi.mocked(util.findChannelByName).mockReturnValue(mockChannel);
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const sendWarningToGuild = (service as any).sendWarningToGuild;
+
+            await sendWarningToGuild.call(service, mockGuild, testEvent, testEvent.warnings[0]);
+
+            expect(mockChannel.send).toHaveBeenCalledTimes(1);
+            expect(mockChannel.send).toHaveBeenCalledWith({ embeds: expect.any(Array) });
+        });
+
+        it('should handle errors gracefully when sending to all guilds', async () => {
+            vi.mocked(util.findChannelByName).mockReturnValue({
+                ...mockChannel,
+                send: vi.fn(() => Promise.reject(new Error('Send failed')))
+            } as any);
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const sendWarningToAllGuilds = (service as any).sendWarningToAllGuilds;
+
+            await expect(
+                sendWarningToAllGuilds.call(service, testEvent, testEvent.warnings[0])
+            ).resolves.not.toThrow();
+
+            expect(util.logError).toHaveBeenCalled();
+        });
+    });
+
+    describe('Embed Building', () => {
+        it('should build embed with correct title and color for 1-day warning', async () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, testEvent, testEvent.warnings[0]);
+
+            expect(embed.data.title).toBe('Mirror Wars Ending Tomorrow!');
+            expect(embed.data.color).toBe(0xFFA500);
+            expect(embed.data.footer?.text).toBe('Test footer');
+        });
+
+        it('should build embed with correct title and color for 1-hour warning', async () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, testEvent, testEvent.warnings[1]);
+
+            expect(embed.data.title).toBe('Mirror Wars Ending in 1 Hour!');
+            expect(embed.data.color).toBe(0xFF0000);
+        });
+
+        it('should include fields when configured', async () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, testEvent, testEvent.warnings[0]);
+
+            expect(embed.data.fields?.length).toBe(1);
+            expect(embed.data.fields?.[0].name).toBe('Time');
+        });
+
+        it('should set thumbnail when configured', async () => {
+            const eventWithThumbnail: PvpEventConfig = {
+                ...testEvent,
+                warnings: [{
+                    ...testEvent.warnings[0],
+                    embedConfig: {
+                        ...testEvent.warnings[0].embedConfig,
+                        thumbnail: 'https://cdn.example.com/logo.png'
+                    }
+                }]
+            };
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, eventWithThumbnail, eventWithThumbnail.warnings[0]);
+
+            expect(embed.data.thumbnail?.url).toBe('https://cdn.example.com/logo.png');
+        });
+
+        it('should set author when configured', async () => {
+            const eventWithAuthor: PvpEventConfig = {
+                ...testEvent,
+                warnings: [{
+                    ...testEvent.warnings[0],
+                    embedConfig: {
+                        ...testEvent.warnings[0].embedConfig,
+                        author: { name: 'Rapi BOT', iconURL: 'https://cdn.example.com/icon.png' }
+                    }
+                }]
+            };
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, eventWithAuthor, eventWithAuthor.warnings[0]);
+
+            expect(embed.data.author?.name).toBe('Rapi BOT');
+        });
+
+        it('should include CDN media image', async () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, testEvent, testEvent.warnings[0]);
+
+            expect(mediaManager.getRandomCdnMediaUrl).toHaveBeenCalledWith(
+                'dailies/bd2/',
+                'test-guild-id',
+                { extensions: ['.png', '.jpg'], trackLast: 10 }
+            );
+            expect(embed.data.image?.url).toBe('https://cdn.example.com/test-image.png');
+        });
+
+        it('should handle media fetch failure gracefully', async () => {
+            vi.mocked(mediaManager.getRandomCdnMediaUrl).mockRejectedValueOnce(new Error('CDN error'));
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, testEvent, testEvent.warnings[0]);
+
+            // Should still build the embed without the image
+            expect(embed.data.title).toBe('Mirror Wars Ending Tomorrow!');
+            expect(embed.data.image).toBeUndefined();
+        });
+
+        it('should not set image when event has no mediaConfig', async () => {
+            const eventWithoutMedia: PvpEventConfig = {
+                ...testEvent,
+                mediaConfig: undefined
+            };
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, eventWithoutMedia, eventWithoutMedia.warnings[0]);
+
+            expect(mediaManager.getRandomCdnMediaUrl).not.toHaveBeenCalled();
+            expect(embed.data.image).toBeUndefined();
+        });
+    });
+
+    describe('Dev Mode', () => {
+        it('should use dev interval instead of weekly crons', () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'development';
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            service.initializeSchedules();
+
+            const jobs = service.getScheduledJobs();
+            expect(jobs.size).toBe(2);
+
+            process.env.NODE_ENV = originalEnv;
+        });
+    });
+
+    describe('Config Validation', () => {
+        it('should use actual BD2 Mirror Wars config values', async () => {
+            // Import the real config to validate it
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const mirrorWars = pvpReminderServiceConfig.events[0];
+
+            expect(mirrorWars.id).toBe('bd2-mirror-wars');
+            expect(mirrorWars.channelName).toBe('brown-dust-2');
+            expect(mirrorWars.seasonEnd).toEqual({ dayOfWeek: 0, hour: 14, minute: 59 });
+            expect(mirrorWars.warnings).toHaveLength(2);
+            expect(mirrorWars.warnings[0].minutesBefore).toBe(24 * 60);
+            expect(mirrorWars.warnings[1].minutesBefore).toBe(60);
+        });
+
+        it('should produce correct crons for actual BD2 config', async () => {
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const mirrorWars = pvpReminderServiceConfig.events[0];
+
+            const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
+
+            // 1-day warning: Saturday 14:59
+            const dayWarningCron = service.calculateWarningCron(mirrorWars, mirrorWars.warnings[0]);
+            expect(dayWarningCron).toBe('59 14 * * 6');
+
+            // 1-hour warning: Sunday 13:59
+            const hourWarningCron = service.calculateWarningCron(mirrorWars, mirrorWars.warnings[1]);
+            expect(hourWarningCron).toBe('59 13 * * 0');
+        });
+    });
+});

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -1,0 +1,100 @@
+import { PvpEventConfig, PvpReminderServiceConfig } from '../interfaces/PvpEventConfig.interface.js';
+import { cdnDomainUrl } from '../util.js';
+
+// Asset URLs (shared with gamesResetConfig.ts)
+const RAPI_BOT_THUMBNAIL_URL = `${cdnDomainUrl}/assets/rapi-bot-thumbnail.jpg`;
+const BROWN_DUST_2_LOGO_URL = `${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`;
+
+const DEFAULT_IMAGE_EXTENSIONS = ['.gif', '.png', '.jpg', '.webp'];
+
+/**
+ * Brown Dust 2 — Mirror Wars (Weekly PVP)
+ *
+ * Season ends every Sunday ~2:59 PM UTC.
+ * Players get 40 async auto-battles per day and need to push rank before reset.
+ * Rewards (Diamonds) are based on peak rank achieved during the season.
+ */
+const bd2MirrorWarsConfig: PvpEventConfig = {
+    id: 'bd2-mirror-wars',
+    game: 'Brown Dust 2',
+    eventName: 'Mirror Wars',
+    channelName: 'brown-dust-2',
+    seasonEnd: {
+        dayOfWeek: 0,  // Sunday
+        hour: 14,
+        minute: 59,
+    },
+    warnings: [
+        {
+            label: '1 day',
+            minutesBefore: 24 * 60, // Saturday ~2:59 PM UTC
+            embedConfig: {
+                title: '\u2694\uFE0F Mirror Wars Season Ending Tomorrow!',
+                description:
+                    `Adventurers, the rift between mirrors grows unstable...\n\n` +
+                    `**Mirror Wars season ends tomorrow (Sunday) at ~2:59 PM UTC.**\n\n` +
+                    `Complete your remaining **40 async auto-battles** and climb the ranks before the mirrors shatter!`,
+                color: 0xFFA500, // Orange — advance warning
+                footer: {
+                    text: 'May the Blood Imprint guide your path, Adventurer!',
+                    iconURL: RAPI_BOT_THUMBNAIL_URL,
+                },
+                thumbnail: BROWN_DUST_2_LOGO_URL,
+                author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
+                fields: [
+                    {
+                        name: '\u23F0 Time Remaining',
+                        value: '**~24 hours** until season ends',
+                        inline: true,
+                    },
+                    {
+                        name: '\uD83C\uDFAF What to Do',
+                        value: '\u2022 Use all **40 daily async battles**\n\u2022 Push for a higher rank\n\u2022 Review your defense team composition',
+                        inline: true,
+                    },
+                ],
+            },
+        },
+        {
+            label: '1 hour',
+            minutesBefore: 60, // Sunday ~1:59 PM UTC
+            embedConfig: {
+                title: '\uD83D\uDEA8 Mirror Wars Season Ending in 1 Hour!',
+                description:
+                    `The mirrors are cracking, Adventurer! Time is almost up!\n\n` +
+                    `**Mirror Wars season ends at ~2:59 PM UTC \u2014 less than 1 hour remains!**\n\n` +
+                    `This is your **final chance** to complete battles and secure your rank. ` +
+                    `The Cocytus waits for no one.`,
+                color: 0xFF0000, // Red — urgent
+                footer: {
+                    text: 'The mirrors shatter soon... | May the Blood Imprint guide your path!',
+                    iconURL: RAPI_BOT_THUMBNAIL_URL,
+                },
+                thumbnail: BROWN_DUST_2_LOGO_URL,
+                author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
+                fields: [
+                    {
+                        name: '\u23F0 Time Remaining',
+                        value: '**~1 hour** until season ends!',
+                        inline: true,
+                    },
+                    {
+                        name: '\uD83D\uDEA8 Last Call',
+                        value: '\u2022 Burn remaining **async battles NOW**\n\u2022 Final rank adjustments\n\u2022 Season rewards lock after reset',
+                        inline: true,
+                    },
+                ],
+            },
+        },
+    ],
+    mediaConfig: {
+        cdnPath: 'dailies/bd2/',
+        extensions: [...DEFAULT_IMAGE_EXTENSIONS],
+        trackLast: 10,
+    },
+};
+
+export const pvpReminderServiceConfig: PvpReminderServiceConfig = {
+    events: [bd2MirrorWarsConfig],
+    devModeInterval: 3,
+};

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -11,7 +11,7 @@ const DEFAULT_IMAGE_EXTENSIONS = ['.gif', '.png', '.jpg', '.webp'];
  * Brown Dust 2 — Mirror Wars (Weekly PVP)
  *
  * Season ends every Sunday ~2:59 PM UTC.
- * Players get 40 async auto-battles per day and need to push rank before reset.
+ * Players get 40 auto-battles per day and need to push rank before reset.
  * Rewards (Diamonds) are based on peak rank achieved during the season.
  */
 const bd2MirrorWarsConfig: PvpEventConfig = {
@@ -30,10 +30,10 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
             minutesBefore: 24 * 60, // Saturday ~2:59 PM UTC
             embedConfig: {
                 title: '\u2694\uFE0F Mirror Wars Season Ending Tomorrow!',
-                description:
+                description: (ts) =>
                     `Adventurers, the rift between mirrors grows unstable...\n\n` +
-                    `**Mirror Wars season ends tomorrow (Sunday) at ~2:59 PM UTC.**\n\n` +
-                    `Complete your remaining **40 async auto-battles** and climb the ranks before the mirrors shatter!`,
+                    `**Mirror Wars season ends <t:${ts}:F> (<t:${ts}:R>).**\n\n` +
+                    `Complete your remaining **40 daily battles** and climb the ranks before the mirrors shatter!`,
                 color: 0xFFA500, // Orange — advance warning
                 footer: {
                     text: 'May the Blood Imprint guide your path, Adventurer!',
@@ -41,15 +41,15 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
                 },
                 thumbnail: BROWN_DUST_2_LOGO_URL,
                 author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
-                fields: [
+                fields: (ts) => [
                     {
-                        name: '\u23F0 Time Remaining',
-                        value: '**~24 hours** until season ends',
+                        name: '\u23F0 Season Ends',
+                        value: `<t:${ts}:F>\n<t:${ts}:R>`,
                         inline: true,
                     },
                     {
                         name: '\uD83C\uDFAF What to Do',
-                        value: '\u2022 Use all **40 daily async battles**\n\u2022 Push for a higher rank\n\u2022 Review your defense team composition',
+                        value: '\u2022 Use all **40 daily battles**\n\u2022 Push for a higher rank\n\u2022 Review your defense team composition',
                         inline: true,
                     },
                 ],
@@ -60,9 +60,9 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
             minutesBefore: 60, // Sunday ~1:59 PM UTC
             embedConfig: {
                 title: '\uD83D\uDEA8 Mirror Wars Season Ending in 1 Hour!',
-                description:
+                description: (ts) =>
                     `The mirrors are cracking, Adventurer! Time is almost up!\n\n` +
-                    `**Mirror Wars season ends at ~2:59 PM UTC \u2014 less than 1 hour remains!**\n\n` +
+                    `**Mirror Wars season ends <t:${ts}:R> (<t:${ts}:t>)!**\n\n` +
                     `This is your **final chance** to complete battles and secure your rank. ` +
                     `The Cocytus waits for no one.`,
                 color: 0xFF0000, // Red — urgent
@@ -72,15 +72,15 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
                 },
                 thumbnail: BROWN_DUST_2_LOGO_URL,
                 author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
-                fields: [
+                fields: (ts) => [
                     {
-                        name: '\u23F0 Time Remaining',
-                        value: '**~1 hour** until season ends!',
+                        name: '\u23F0 Season Ends',
+                        value: `<t:${ts}:t> (<t:${ts}:R>)`,
                         inline: true,
                     },
                     {
                         name: '\uD83D\uDEA8 Last Call',
-                        value: '\u2022 Burn remaining **async battles NOW**\n\u2022 Final rank adjustments\n\u2022 Season rewards lock after reset',
+                        value: '\u2022 Burn remaining **battles NOW**\n\u2022 Final rank adjustments\n\u2022 Season rewards lock after reset',
                         inline: true,
                     },
                 ],

--- a/src/utils/interfaces/PvpEventConfig.interface.ts
+++ b/src/utils/interfaces/PvpEventConfig.interface.ts
@@ -1,0 +1,84 @@
+/**
+ * Day of week (0 = Sunday, 6 = Saturday) — matches JS Date.getDay()
+ */
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/**
+ * A specific weekly time in UTC (day + hour + minute)
+ */
+export interface WeeklyTime {
+    dayOfWeek: DayOfWeek;
+    hour: number;   // 0-23 UTC
+    minute: number; // 0-59
+}
+
+/**
+ * Embed appearance configuration for PVP warnings
+ */
+export interface PvpEmbedConfig {
+    title: string;
+    description: string;
+    color: number;
+    footer: {
+        text: string;
+        iconURL?: string;
+    };
+    thumbnail?: string;
+    author?: {
+        name: string;
+        iconURL?: string;
+    };
+    fields?: Array<{ name: string; value: string; inline?: boolean }>;
+}
+
+/**
+ * Configuration for a warning sent before a PVP event ends
+ */
+export interface PvpWarningConfig {
+    /** Human-readable label, e.g. "1 day", "1 hour" — used for logging and job IDs */
+    label: string;
+    /** Minutes before event end to send this warning */
+    minutesBefore: number;
+    /** Embed configuration for this warning */
+    embedConfig: PvpEmbedConfig;
+}
+
+/**
+ * Media configuration for random CDN images (same shape as daily reset)
+ */
+export interface PvpMediaConfig {
+    cdnPath: string;
+    extensions?: string[];
+    trackLast?: number;
+}
+
+/**
+ * Configuration for a recurring weekly PVP event
+ */
+export interface PvpEventConfig {
+    /** Unique identifier, e.g. "bd2-mirror-wars" */
+    id: string;
+    /** Human-readable game name */
+    game: string;
+    /** Human-readable event name */
+    eventName: string;
+    /** Discord channel name to post in */
+    channelName: string;
+    /** Optional role name to ping */
+    roleName?: string;
+    /** When the event season ends each week (UTC) */
+    seasonEnd: WeeklyTime;
+    /** Warning configurations — supports multiple warnings at different intervals */
+    warnings: PvpWarningConfig[];
+    /** Optional CDN media config for random images */
+    mediaConfig?: PvpMediaConfig;
+}
+
+/**
+ * Top-level config for the PVP reminder service
+ */
+export interface PvpReminderServiceConfig {
+    events: PvpEventConfig[];
+    /** Dev mode interval in minutes (overrides weekly schedule) */
+    devModeInterval?: number;
+}

--- a/src/utils/interfaces/PvpEventConfig.interface.ts
+++ b/src/utils/interfaces/PvpEventConfig.interface.ts
@@ -17,7 +17,8 @@ export interface WeeklyTime {
  */
 export interface PvpEmbedConfig {
     title: string;
-    description: string;
+    /** Static string or function that receives the season end Unix timestamp (seconds) */
+    description: string | ((seasonEndTimestamp: number) => string);
     color: number;
     footer: {
         text: string;
@@ -28,7 +29,8 @@ export interface PvpEmbedConfig {
         name: string;
         iconURL?: string;
     };
-    fields?: Array<{ name: string; value: string; inline?: boolean }>;
+    /** Static fields or function that receives the season end Unix timestamp (seconds) */
+    fields?: Array<{ name: string; value: string; inline?: boolean }> | ((seasonEndTimestamp: number) => Array<{ name: string; value: string; inline?: boolean }>);
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds scheduled channel warnings for Brown Dust 2 **Mirror Wars** (weekly PVP) season end. Posts to `#brown-dust-2` channel with **1-day** and **1-hour** advance notices before season closes every Sunday ~2:59 PM UTC.

## Changes
- **New `PvpReminderService`** — weekly event scheduler using `node-schedule` with day-of-week cron expressions. Separate from `DailyResetService` since PVP events are weekly, not daily.
- **New `PvpEventConfig` interfaces** — `WeeklyTime`, `PvpWarningConfig`, `PvpEventConfig` supporting multiple warnings per event at configurable intervals.
- **BD2 Mirror Wars config** — two themed warnings:
  - 🟠 **1-day warning** (Saturday 2:59 PM UTC) — orange embed, "Season ending tomorrow"
  - 🔴 **1-hour warning** (Sunday 1:59 PM UTC) — red embed, "Final hour!"
- **Wired into `serviceInitializer.ts`** for automatic startup
- **23 unit tests** covering cron calculation, embed building, error handling, and config validation

## How to add new PVP events
Add a new `PvpEventConfig` object to `pvpEventsConfig.ts` — no service code changes needed.

## Testing
- [x] `bunx tsc --noEmit` passes
- [x] 23 new tests pass (`bun run test:run -- pvpReminderService`)
- [x] Full suite: 774 tests, 0 failures
- [ ] Manual: dev mode posts every 3 min to verify embeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)