### PR TITLE
feat: Add DM notification subscription framework

### DIFF
--- a/src/bootstrap/serviceInitializer.ts
+++ b/src/bootstrap/serviceInitializer.ts
@@ -8,6 +8,7 @@ import { getRulesManagementService } from '../services/rulesManagementService.js
 import { YouTubeNotificationScheduler } from '../services/youtubeNotificationScheduler.js';
 import { PvpReminderService } from '../services/pvpReminderService.js';
 import { pvpReminderServiceConfig } from '../utils/data/pvpEventsConfig.js';
+import { getNotificationSubscriptionService } from '../services/notificationSubscriptionService.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -59,6 +60,17 @@ export async function initializeServices(bot: Client): Promise<void> {
         const youtubeScheduler = new YouTubeNotificationScheduler(bot);
         await youtubeScheduler.initializeSchedules();
         logger.info`YouTube notification scheduler initialized`;
+
+        // Initialize notification subscription service (DM opt-in via reactions)
+        const notificationService = getNotificationSubscriptionService();
+        notificationService.registerNotificationType({
+            type: 'pvp-warning:bd2-mirror-wars',
+            displayName: 'BD2 Mirror Wars PVP',
+            description: 'Weekly PVP season end reminders for Brown Dust 2',
+            embedColor: 0x8B4513,
+        });
+        notificationService.startListening(bot);
+        logger.info`Notification subscription service initialized`;
 
         // Initialize PVP reminder service (weekly event warnings)
         const pvpReminderService = new PvpReminderService(bot, pvpReminderServiceConfig);

--- a/src/services/gachaRedemptionService.ts
+++ b/src/services/gachaRedemptionService.ts
@@ -14,6 +14,7 @@ import {
 import { getGameConfig, getAutoRedeemGames } from '../utils/data/gachaGamesConfig';
 import { GACHA_CONFIG } from '../utils/data/gachaConfig';
 import { logger } from '../utils/logger.js';
+import { sendDMSafe } from '../utils/dmSender.js';
 import { getAssetUrls } from '../config/assets.js';
 
 const RERUN_EMOJI = '🔁';
@@ -335,29 +336,17 @@ export class GachaRedemptionService {
         content: { embeds: EmbedBuilder[] },
         gameId?: GachaGameId
     ): Promise<Message | null> {
-        try {
-            const message = await user.send(content);
-            await new Promise(resolve => setTimeout(resolve, GACHA_CONFIG.DM_RATE_LIMIT_DELAY));
-
-            // Clear DM disabled status if previously marked
-            if (gameId) {
+        return sendDMSafe(user, content, {
+            rateLimitDelay: GACHA_CONFIG.DM_RATE_LIMIT_DELAY,
+            onDMDisabled: gameId ? async (userId) => {
                 const dataService = getGachaDataService();
-                await dataService.clearDMDisabled(user.id, gameId);
-            }
-            return message;
-        } catch (error: any) {
-            // Check if this is a "Cannot send messages to this user" error
-            if (error.code === 50007) {
-                logger.warning`Cannot send DM to ${user.id} - user has DMs disabled`;
-                if (gameId) {
-                    const dataService = getGachaDataService();
-                    await dataService.markDMDisabled(user.id, gameId);
-                }
-            } else {
-                logger.error`Failed to send DM to ${user.id}: ${error.message}`;
-            }
-            return null;
-        }
+                await dataService.markDMDisabled(userId, gameId);
+            } : undefined,
+            onDMSuccess: gameId ? async (userId) => {
+                const dataService = getGachaDataService();
+                await dataService.clearDMDisabled(userId, gameId);
+            } : undefined,
+        });
     }
 
     /**

--- a/src/services/notificationSubscriptionDataService.ts
+++ b/src/services/notificationSubscriptionDataService.ts
@@ -1,0 +1,231 @@
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { s3Client, S3_BUCKET } from '../utils/cdn/config.js';
+import {
+    NotificationType,
+    NotificationUserSubscription,
+    NotificationSubscriptionData,
+} from '../utils/interfaces/NotificationSubscription.interface.js';
+import { NOTIFICATION_CONFIG } from '../utils/data/notificationConfig.js';
+import { logger } from '../utils/logger.js';
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+const DATA_KEY = isDevelopment
+    ? `${NOTIFICATION_CONFIG.S3_DATA_PATH}/dev-subscriptions.json`
+    : `${NOTIFICATION_CONFIG.S3_DATA_PATH}/subscriptions.json`;
+const CURRENT_SCHEMA_VERSION = 1;
+
+/**
+ * S3-backed data service for notification subscriptions.
+ * Follows the same singleton + cache pattern as GachaDataService.
+ */
+export class NotificationSubscriptionDataService {
+    private static instance: NotificationSubscriptionDataService;
+    private cache: NotificationSubscriptionData | null = null;
+    private cacheExpiry: number = 0;
+    private readonly CACHE_TTL = NOTIFICATION_CONFIG.CACHE_TTL;
+
+    private constructor() {}
+
+    public static getInstance(): NotificationSubscriptionDataService {
+        if (!NotificationSubscriptionDataService.instance) {
+            NotificationSubscriptionDataService.instance = new NotificationSubscriptionDataService();
+        }
+        return NotificationSubscriptionDataService.instance;
+    }
+
+    /**
+     * Fetch data from S3 with caching
+     */
+    public async getData(): Promise<NotificationSubscriptionData> {
+        if (this.cache && Date.now() < this.cacheExpiry) {
+            return this.cache;
+        }
+
+        try {
+            const response = await s3Client.send(new GetObjectCommand({
+                Bucket: S3_BUCKET,
+                Key: DATA_KEY,
+            }));
+
+            const body = await response.Body?.transformToString();
+            if (!body) {
+                return this.getDefaultData();
+            }
+
+            this.cache = JSON.parse(body) as NotificationSubscriptionData;
+            this.cacheExpiry = Date.now() + this.CACHE_TTL;
+            return this.cache;
+        } catch (error: any) {
+            if (error.name === 'NoSuchKey' || error.Code === 'NoSuchKey') {
+                logger.warn`Notification subscription data not found at ${DATA_KEY}, creating default...`;
+                const defaultData = this.getDefaultData();
+                await this.saveData(defaultData);
+                return defaultData;
+            }
+            logger.error`Error fetching notification subscription data: ${error}`;
+            throw error;
+        }
+    }
+
+    /**
+     * Save data to S3 and update cache
+     */
+    public async saveData(data: NotificationSubscriptionData): Promise<void> {
+        data.lastUpdated = new Date().toISOString();
+
+        await s3Client.send(new PutObjectCommand({
+            Bucket: S3_BUCKET,
+            Key: DATA_KEY,
+            Body: JSON.stringify(data, null, 2),
+            ContentType: 'application/json',
+        }));
+
+        this.cache = data;
+        this.cacheExpiry = Date.now() + this.CACHE_TTL;
+    }
+
+    /**
+     * Get all subscribers for a notification type
+     */
+    public async getSubscribers(notificationType: NotificationType): Promise<NotificationUserSubscription[]> {
+        const data = await this.getData();
+        return data.subscriptions[notificationType] || [];
+    }
+
+    /**
+     * Add a subscription. Returns false if already subscribed.
+     */
+    public async addSubscription(
+        discordId: string,
+        guildId: string,
+        notificationType: NotificationType
+    ): Promise<boolean> {
+        const data = await this.getData();
+
+        if (!data.subscriptions[notificationType]) {
+            data.subscriptions[notificationType] = [];
+        }
+
+        const existing = data.subscriptions[notificationType].find(
+            sub => sub.discordId === discordId
+        );
+        if (existing) {
+            return false;
+        }
+
+        data.subscriptions[notificationType].push({
+            discordId,
+            guildId,
+            notificationType,
+            subscribedAt: new Date().toISOString(),
+        });
+
+        await this.saveData(data);
+        return true;
+    }
+
+    /**
+     * Remove a subscription. Returns false if not found.
+     */
+    public async removeSubscription(
+        discordId: string,
+        notificationType: NotificationType
+    ): Promise<boolean> {
+        const data = await this.getData();
+
+        const subs = data.subscriptions[notificationType];
+        if (!subs) return false;
+
+        const index = subs.findIndex(sub => sub.discordId === discordId);
+        if (index === -1) return false;
+
+        subs.splice(index, 1);
+        await this.saveData(data);
+        return true;
+    }
+
+    /**
+     * Check if a user is subscribed to a notification type
+     */
+    public async isSubscribed(
+        discordId: string,
+        notificationType: NotificationType
+    ): Promise<boolean> {
+        const subs = await this.getSubscribers(notificationType);
+        return subs.some(sub => sub.discordId === discordId);
+    }
+
+    /**
+     * Mark a user's DM as disabled for a notification type
+     */
+    public async markDMDisabled(
+        discordId: string,
+        notificationType: NotificationType
+    ): Promise<void> {
+        const data = await this.getData();
+        const subs = data.subscriptions[notificationType];
+        if (!subs) return;
+
+        const sub = subs.find(s => s.discordId === discordId);
+        if (sub) {
+            sub.dmDisabled = true;
+            sub.dmDisabledAt = new Date().toISOString();
+            await this.saveData(data);
+        }
+    }
+
+    /**
+     * Clear DM disabled status for a user
+     */
+    public async clearDMDisabled(
+        discordId: string,
+        notificationType: NotificationType
+    ): Promise<void> {
+        const data = await this.getData();
+        const subs = data.subscriptions[notificationType];
+        if (!subs) return;
+
+        const sub = subs.find(s => s.discordId === discordId);
+        if (sub && sub.dmDisabled) {
+            sub.dmDisabled = undefined;
+            sub.dmDisabledAt = undefined;
+            await this.saveData(data);
+        }
+    }
+
+    /**
+     * Get all subscriptions for a specific user
+     */
+    public async getSubscriptionsForUser(discordId: string): Promise<NotificationUserSubscription[]> {
+        const data = await this.getData();
+        const results: NotificationUserSubscription[] = [];
+
+        for (const subs of Object.values(data.subscriptions)) {
+            const userSub = subs.find(s => s.discordId === discordId);
+            if (userSub) {
+                results.push(userSub);
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Invalidate cache (useful for testing)
+     */
+    public invalidateCache(): void {
+        this.cache = null;
+        this.cacheExpiry = 0;
+    }
+
+    private getDefaultData(): NotificationSubscriptionData {
+        return {
+            subscriptions: {},
+            lastUpdated: new Date().toISOString(),
+            schemaVersion: CURRENT_SCHEMA_VERSION,
+        };
+    }
+}
+
+export const getNotificationSubscriptionDataService = (): NotificationSubscriptionDataService =>
+    NotificationSubscriptionDataService.getInstance();

--- a/src/services/notificationSubscriptionService.ts
+++ b/src/services/notificationSubscriptionService.ts
@@ -1,0 +1,374 @@
+import {
+    Client,
+    EmbedBuilder,
+    Message,
+    MessageReaction,
+    PartialMessageReaction,
+    PartialUser,
+    User,
+} from 'discord.js';
+import {
+    NotificationType,
+    NotificationTypeConfig,
+} from '../utils/interfaces/NotificationSubscription.interface.js';
+import { getNotificationSubscriptionDataService } from './notificationSubscriptionDataService.js';
+import { sendDMSafe } from '../utils/dmSender.js';
+import { NOTIFICATION_CONFIG, NOTIFICATION_TYPE_FOOTER_REGEX } from '../utils/data/notificationConfig.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Result of sending notifications to subscribers
+ */
+export interface NotificationSendResult {
+    sent: number;
+    failed: number;
+    dmDisabled: number;
+}
+
+/**
+ * Central notification subscription service.
+ *
+ * Manages notification type registry, subscribe/unsubscribe via reactions,
+ * and DM delivery to subscribers. Completely independent from the gacha
+ * coupon subscription system.
+ */
+export class NotificationSubscriptionService {
+    private static instance: NotificationSubscriptionService;
+
+    /** Registry of notification types */
+    private typeRegistry: Map<NotificationType, NotificationTypeConfig> = new Map();
+
+    /** In-memory map: messageId → notificationType (for fast reaction lookup) */
+    private messageTypeMap: Map<string, NotificationType> = new Map();
+
+    /** Dedup set to prevent double-subscribe race conditions */
+    private processingSet: Set<string> = new Set();
+
+    private constructor() {}
+
+    public static getInstance(): NotificationSubscriptionService {
+        if (!NotificationSubscriptionService.instance) {
+            NotificationSubscriptionService.instance = new NotificationSubscriptionService();
+        }
+        return NotificationSubscriptionService.instance;
+    }
+
+    // ──── Type Registry ────
+
+    /**
+     * Register a notification type. Call during service initialization.
+     */
+    public registerNotificationType(config: NotificationTypeConfig): void {
+        this.typeRegistry.set(config.type, config);
+        logger.debug`[Notifications] Registered type: ${config.type} (${config.displayName})`;
+    }
+
+    /**
+     * Get a registered notification type config
+     */
+    public getNotificationType(type: NotificationType): NotificationTypeConfig | undefined {
+        return this.typeRegistry.get(type);
+    }
+
+    /**
+     * Get all registered notification types
+     */
+    public getAllNotificationTypes(): NotificationTypeConfig[] {
+        return [...this.typeRegistry.values()];
+    }
+
+    // ──── Subscription ────
+
+    /**
+     * Subscribe a user to a notification type
+     */
+    public async subscribe(
+        discordId: string,
+        guildId: string,
+        notificationType: NotificationType
+    ): Promise<{ success: boolean; message: string }> {
+        const typeConfig = this.typeRegistry.get(notificationType);
+        if (!typeConfig) {
+            return { success: false, message: 'Unknown notification type.' };
+        }
+
+        const dataService = getNotificationSubscriptionDataService();
+        const added = await dataService.addSubscription(discordId, guildId, notificationType);
+
+        if (!added) {
+            return { success: false, message: `You are already subscribed to **${typeConfig.displayName}** notifications.` };
+        }
+
+        return { success: true, message: `Subscribed to **${typeConfig.displayName}** DM notifications!` };
+    }
+
+    /**
+     * Unsubscribe a user from a notification type
+     */
+    public async unsubscribe(
+        discordId: string,
+        notificationType: NotificationType
+    ): Promise<{ success: boolean; message: string }> {
+        const typeConfig = this.typeRegistry.get(notificationType);
+        const displayName = typeConfig?.displayName || notificationType;
+
+        const dataService = getNotificationSubscriptionDataService();
+        const removed = await dataService.removeSubscription(discordId, notificationType);
+
+        if (!removed) {
+            return { success: false, message: `You are not subscribed to **${displayName}** notifications.` };
+        }
+
+        return { success: true, message: `Unsubscribed from **${displayName}** DM notifications.` };
+    }
+
+    // ──── Notification Sending ────
+
+    /**
+     * Send a notification DM to all subscribers of a given type.
+     * Adds unsubscribe reaction and footer tag to each DM.
+     */
+    public async sendNotification(
+        bot: Client,
+        notificationType: NotificationType,
+        embed: EmbedBuilder
+    ): Promise<NotificationSendResult> {
+        const dataService = getNotificationSubscriptionDataService();
+        const subscribers = await dataService.getSubscribers(notificationType);
+        const typeConfig = this.typeRegistry.get(notificationType);
+
+        const result: NotificationSendResult = { sent: 0, failed: 0, dmDisabled: 0 };
+
+        if (subscribers.length === 0) return result;
+
+        // Append footer tag for unsubscribe parsing
+        const footerText = embed.data.footer?.text || '';
+        const taggedFooter = footerText
+            ? `${footerText} | [type:${notificationType}]`
+            : `[type:${notificationType}]`;
+        embed.setFooter({
+            text: taggedFooter,
+            iconURL: embed.data.footer?.icon_url,
+        });
+
+        // Add unsubscribe instruction as last field
+        embed.addFields({
+            name: '\u200B', // zero-width space separator
+            value: `_React ${NOTIFICATION_CONFIG.UNSUBSCRIBE_EMOJI} to unsubscribe from ${typeConfig?.displayName || notificationType} DM notifications._`,
+            inline: false,
+        });
+
+        for (const sub of subscribers) {
+            if (sub.dmDisabled) {
+                result.dmDisabled++;
+                continue;
+            }
+
+            try {
+                const user = await bot.users.fetch(sub.discordId);
+                const sentMessage = await sendDMSafe(user, { embeds: [EmbedBuilder.from(embed.data)] }, {
+                    onDMDisabled: async (userId) => {
+                        await dataService.markDMDisabled(userId, notificationType);
+                    },
+                    onDMSuccess: async (userId) => {
+                        await dataService.clearDMDisabled(userId, notificationType);
+                    },
+                });
+
+                if (sentMessage) {
+                    // Seed unsubscribe reaction
+                    try {
+                        await sentMessage.react(NOTIFICATION_CONFIG.UNSUBSCRIBE_EMOJI);
+                    } catch {
+                        // Non-critical — DM was still sent
+                    }
+                    result.sent++;
+                } else {
+                    result.failed++;
+                }
+            } catch (error) {
+                logger.error`[Notifications] Failed to send DM to ${sub.discordId}: ${error}`;
+                result.failed++;
+            }
+        }
+
+        return result;
+    }
+
+    // ──── Reaction Seeding ────
+
+    /**
+     * Add subscribe reaction to a channel message and track the mapping.
+     */
+    public async seedSubscribeReaction(
+        message: Message,
+        notificationType: NotificationType
+    ): Promise<void> {
+        try {
+            await message.react(NOTIFICATION_CONFIG.SUBSCRIBE_EMOJI);
+
+            // Track messageId → type for fast lookup on reaction
+            this.messageTypeMap.set(message.id, notificationType);
+
+            // Cleanup if map grows too large
+            if (this.messageTypeMap.size > NOTIFICATION_CONFIG.MESSAGE_TYPE_MAP_MAX_SIZE) {
+                const entries = [...this.messageTypeMap.entries()];
+                const toDelete = entries.slice(0, Math.floor(entries.length / 2));
+                for (const [key] of toDelete) {
+                    this.messageTypeMap.delete(key);
+                }
+            }
+        } catch (error) {
+            logger.warn`[Notifications] Failed to seed subscribe reaction: ${error}`;
+        }
+    }
+
+    // ──── Reaction Event Handling ────
+
+    /**
+     * Start listening for reaction events. Call once during initialization.
+     */
+    public startListening(bot: Client): void {
+        bot.on('messageReactionAdd', async (reaction, user) => {
+            try {
+                await this.handleReaction(reaction, user, bot);
+            } catch (error) {
+                logger.error`[Notifications] Error in reaction handler: ${error}`;
+            }
+        });
+    }
+
+    /**
+     * Route a reaction to the appropriate handler
+     */
+    private async handleReaction(
+        reaction: MessageReaction | PartialMessageReaction,
+        user: User | PartialUser,
+        bot: Client
+    ): Promise<void> {
+        if (user.bot) return;
+
+        // Fetch partials
+        if (reaction.partial) {
+            try { await reaction.fetch(); } catch { return; }
+        }
+        let message = reaction.message;
+        if (message.partial) {
+            try { message = await message.fetch(); } catch { return; }
+        }
+
+        // Only handle bot's messages
+        if (message.author?.id !== bot.user?.id) return;
+
+        const emoji = reaction.emoji.name;
+        if (!emoji) return;
+
+        if (!message.channel.isDMBased() && emoji === NOTIFICATION_CONFIG.SUBSCRIBE_EMOJI) {
+            await this.handleSubscribeReaction(message as Message, user, bot);
+        } else if (message.channel.isDMBased() && emoji === NOTIFICATION_CONFIG.UNSUBSCRIBE_EMOJI) {
+            await this.handleUnsubscribeReaction(message as Message, user);
+        }
+    }
+
+    /**
+     * Handle ✉️ reaction on a channel message → subscribe user
+     */
+    private async handleSubscribeReaction(
+        message: Message,
+        user: User | PartialUser,
+        bot: Client
+    ): Promise<void> {
+        // Determine notification type from memory map or footer
+        let notificationType = this.messageTypeMap.get(message.id);
+
+        if (!notificationType) {
+            notificationType = this.parseNotificationTypeFromEmbed(message);
+            if (!notificationType) return;
+        }
+
+        const guildId = message.guildId;
+        if (!guildId) return;
+
+        // Dedup concurrent reactions
+        const dedupKey = `${user.id}:${notificationType}`;
+        if (this.processingSet.has(dedupKey)) return;
+        this.processingSet.add(dedupKey);
+
+        try {
+            const result = await this.subscribe(user.id, guildId, notificationType);
+            const typeConfig = this.typeRegistry.get(notificationType);
+
+            // Send confirmation DM
+            const fullUser = user.partial ? await bot.users.fetch(user.id) : user;
+            const confirmEmbed = new EmbedBuilder()
+                .setTitle(result.success ? 'Subscribed!' : 'Already Subscribed')
+                .setDescription(result.message)
+                .setColor(result.success ? 0x00FF00 : 0xFFA500)
+                .setTimestamp();
+
+            if (typeConfig?.thumbnailUrl) {
+                confirmEmbed.setThumbnail(typeConfig.thumbnailUrl);
+            }
+
+            await sendDMSafe(fullUser, { embeds: [confirmEmbed] });
+        } catch (error) {
+            logger.error`[Notifications] Subscribe reaction error for ${user.id}: ${error}`;
+        } finally {
+            this.processingSet.delete(dedupKey);
+        }
+    }
+
+    /**
+     * Handle ❌ reaction on a DM message → unsubscribe user
+     */
+    private async handleUnsubscribeReaction(
+        message: Message,
+        user: User | PartialUser
+    ): Promise<void> {
+        const notificationType = this.parseNotificationTypeFromEmbed(message);
+        if (!notificationType) return; // Not a notification DM — let gacha service handle it
+
+        const dedupKey = `${user.id}:${notificationType}`;
+        if (this.processingSet.has(dedupKey)) return;
+        this.processingSet.add(dedupKey);
+
+        try {
+            const result = await this.unsubscribe(user.id, notificationType);
+            const typeConfig = this.typeRegistry.get(notificationType);
+
+            // Edit the original DM to show unsubscribed status
+            try {
+                const updatedEmbed = EmbedBuilder.from(message.embeds[0])
+                    .setColor(0x808080) // Gray
+                    .setFooter({ text: `Unsubscribed from ${typeConfig?.displayName || notificationType}` });
+                await message.edit({ embeds: [updatedEmbed] });
+            } catch {
+                // Message may be too old to edit — non-critical
+            }
+
+            logger.debug`[Notifications] ${user.id} unsubscribed from ${notificationType}: ${result.message}`;
+        } catch (error) {
+            logger.error`[Notifications] Unsubscribe reaction error for ${user.id}: ${error}`;
+        } finally {
+            this.processingSet.delete(dedupKey);
+        }
+    }
+
+    /**
+     * Parse notification type from message embed footer tag [type:...]
+     */
+    private parseNotificationTypeFromEmbed(message: Message): NotificationType | undefined {
+        const embed = message.embeds[0];
+        if (!embed?.footer?.text) return undefined;
+
+        const match = embed.footer.text.match(NOTIFICATION_TYPE_FOOTER_REGEX);
+        if (!match) return undefined;
+
+        const type = match[1];
+        // Only handle types we know about
+        return this.typeRegistry.has(type) ? type : undefined;
+    }
+}
+
+export const getNotificationSubscriptionService = (): NotificationSubscriptionService =>
+    NotificationSubscriptionService.getInstance();

--- a/src/services/notificationSubscriptionService.ts
+++ b/src/services/notificationSubscriptionService.ts
@@ -144,8 +144,8 @@ export class NotificationSubscriptionService {
         // Append footer tag for unsubscribe parsing
         const footerText = embed.data.footer?.text || '';
         const taggedFooter = footerText
-            ? `${footerText} | [type:${notificationType}]`
-            : `[type:${notificationType}]`;
+            ? `${footerText} | [n:${notificationType}]`
+            : `[n:${notificationType}]`;
         embed.setFooter({
             text: taggedFooter,
             iconURL: embed.data.footer?.icon_url,
@@ -298,19 +298,37 @@ export class NotificationSubscriptionService {
             const result = await this.subscribe(user.id, guildId, notificationType);
             const typeConfig = this.typeRegistry.get(notificationType);
 
-            // Send confirmation DM
+            // Send confirmation DM with unsubscribe option
             const fullUser = user.partial ? await bot.users.fetch(user.id) : user;
             const confirmEmbed = new EmbedBuilder()
                 .setTitle(result.success ? 'Subscribed!' : 'Already Subscribed')
                 .setDescription(result.message)
                 .setColor(result.success ? 0x00FF00 : 0xFFA500)
+                .setFooter({ text: `[n:${notificationType}]` })
                 .setTimestamp();
 
             if (typeConfig?.thumbnailUrl) {
                 confirmEmbed.setThumbnail(typeConfig.thumbnailUrl);
             }
 
-            await sendDMSafe(fullUser, { embeds: [confirmEmbed] });
+            if (result.success) {
+                confirmEmbed.addFields({
+                    name: '\u200B',
+                    value: `_React ${NOTIFICATION_CONFIG.UNSUBSCRIBE_EMOJI} to unsubscribe from ${typeConfig?.displayName || notificationType} DM notifications._`,
+                    inline: false,
+                });
+            }
+
+            const confirmMessage = await sendDMSafe(fullUser, { embeds: [confirmEmbed] });
+
+            // Add unsubscribe reaction so user can immediately unsubscribe
+            if (confirmMessage && result.success) {
+                try {
+                    await confirmMessage.react(NOTIFICATION_CONFIG.UNSUBSCRIBE_EMOJI);
+                } catch {
+                    // Non-critical — DM was still sent
+                }
+            }
         } catch (error) {
             logger.error`[Notifications] Subscribe reaction error for ${user.id}: ${error}`;
         } finally {

--- a/src/services/pvpReminderService.ts
+++ b/src/services/pvpReminderService.ts
@@ -3,6 +3,7 @@ import schedule from 'node-schedule';
 import { PvpEventConfig, PvpWarningConfig, PvpReminderServiceConfig } from '../utils/interfaces/PvpEventConfig.interface.js';
 import { findChannelByName, logError } from '../utils/util.js';
 import { getRandomCdnMediaUrl } from '../utils/cdn/mediaManager.js';
+import { getNotificationSubscriptionService } from './notificationSubscriptionService.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -116,7 +117,13 @@ export class PvpReminderService {
         }
 
         const embed = await this.buildWarningEmbed(guild, event, warning);
-        await channel.send({ embeds: [embed] });
+        const sentMessage = await channel.send({ embeds: [embed] });
+
+        // Seed subscribe reaction and send DM notifications
+        const notificationService = getNotificationSubscriptionService();
+        const notificationType = `pvp-warning:${event.id}`;
+        await notificationService.seedSubscribeReaction(sentMessage, notificationType);
+        await notificationService.sendNotification(this.bot, notificationType, EmbedBuilder.from(embed.data));
     }
 
     /**

--- a/src/services/pvpReminderService.ts
+++ b/src/services/pvpReminderService.ts
@@ -103,6 +103,21 @@ export class PvpReminderService {
                 );
             }
         }
+
+        // Send DM notifications once (not per-guild) for warnings that opt in
+        if (warning.sendDM) {
+            try {
+                const firstGuild = this.bot.guilds.cache.values().next().value;
+                if (firstGuild) {
+                    const notificationService = getNotificationSubscriptionService();
+                    const notificationType = `pvp-warning:${event.id}`;
+                    const dmEmbed = await this.buildWarningEmbed(firstGuild, event, warning);
+                    await notificationService.sendNotification(this.bot, notificationType, dmEmbed);
+                }
+            } catch (error) {
+                logger.error`[PVP] Failed to send DM notifications for ${event.id} ${warning.label}: ${error}`;
+            }
+        }
     }
 
     /**
@@ -119,11 +134,10 @@ export class PvpReminderService {
         const embed = await this.buildWarningEmbed(guild, event, warning);
         const sentMessage = await channel.send({ embeds: [embed] });
 
-        // Seed subscribe reaction and send DM notifications
+        // Seed subscribe reaction on channel messages
         const notificationService = getNotificationSubscriptionService();
         const notificationType = `pvp-warning:${event.id}`;
         await notificationService.seedSubscribeReaction(sentMessage, notificationType);
-        await notificationService.sendNotification(this.bot, notificationType, EmbedBuilder.from(embed.data));
     }
 
     /**

--- a/src/services/tests/notificationSubscriptionDataService.test.ts
+++ b/src/services/tests/notificationSubscriptionDataService.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { NotificationSubscriptionDataService, getNotificationSubscriptionDataService } from '../notificationSubscriptionDataService';
+import { NotificationSubscriptionData } from '../../utils/interfaces/NotificationSubscription.interface';
+
+// Mock S3
+vi.mock('../../utils/cdn/config', () => ({
+    s3Client: { send: vi.fn() },
+    S3_BUCKET: 'test-bucket',
+}));
+
+import { s3Client } from '../../utils/cdn/config';
+
+function mockS3Get(data: NotificationSubscriptionData) {
+    vi.mocked(s3Client.send).mockResolvedValueOnce({
+        Body: {
+            transformToString: () => Promise.resolve(JSON.stringify(data)),
+        },
+    } as any);
+}
+
+function mockS3Put() {
+    vi.mocked(s3Client.send).mockResolvedValueOnce({} as any);
+}
+
+function createMockData(overrides: Partial<NotificationSubscriptionData> = {}): NotificationSubscriptionData {
+    return {
+        subscriptions: {},
+        lastUpdated: new Date().toISOString(),
+        schemaVersion: 1,
+        ...overrides,
+    };
+}
+
+describe('NotificationSubscriptionDataService', () => {
+    let service: NotificationSubscriptionDataService;
+
+    beforeEach(() => {
+        // Reset singleton
+        (NotificationSubscriptionDataService as any).instance = null;
+        service = getNotificationSubscriptionDataService();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('getData', () => {
+        it('should fetch from S3 and cache', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+
+            const data = await service.getData();
+            expect(data.schemaVersion).toBe(1);
+            expect(s3Client.send).toHaveBeenCalledTimes(1);
+
+            // Second call should use cache
+            const data2 = await service.getData();
+            expect(data2).toBe(data);
+            expect(s3Client.send).toHaveBeenCalledTimes(1);
+        });
+
+        it('should create default data when S3 key not found', async () => {
+            vi.mocked(s3Client.send)
+                .mockRejectedValueOnce({ name: 'NoSuchKey' })
+                .mockResolvedValueOnce({} as any); // For saveData
+
+            const data = await service.getData();
+            expect(data.subscriptions).toEqual({});
+            expect(data.schemaVersion).toBe(1);
+        });
+    });
+
+    describe('addSubscription', () => {
+        it('should add a new subscription', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+            mockS3Put();
+
+            const result = await service.addSubscription('user1', 'guild1', 'pvp-warning:bd2');
+            expect(result).toBe(true);
+        });
+
+        it('should return false if already subscribed', async () => {
+            const mockData = createMockData({
+                subscriptions: {
+                    'pvp-warning:bd2': [{
+                        discordId: 'user1',
+                        guildId: 'guild1',
+                        notificationType: 'pvp-warning:bd2',
+                        subscribedAt: new Date().toISOString(),
+                    }],
+                },
+            });
+            mockS3Get(mockData);
+
+            const result = await service.addSubscription('user1', 'guild1', 'pvp-warning:bd2');
+            expect(result).toBe(false);
+        });
+
+        it('should create type array if it does not exist', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+            mockS3Put();
+
+            await service.addSubscription('user1', 'guild1', 'new-type');
+
+            // Verify the data was saved with the new type
+            const saveCall = vi.mocked(s3Client.send).mock.calls[1];
+            const savedBody = JSON.parse((saveCall[0] as any).input.Body);
+            expect(savedBody.subscriptions['new-type']).toHaveLength(1);
+            expect(savedBody.subscriptions['new-type'][0].discordId).toBe('user1');
+        });
+    });
+
+    describe('removeSubscription', () => {
+        it('should remove an existing subscription', async () => {
+            const mockData = createMockData({
+                subscriptions: {
+                    'pvp-warning:bd2': [{
+                        discordId: 'user1',
+                        guildId: 'guild1',
+                        notificationType: 'pvp-warning:bd2',
+                        subscribedAt: new Date().toISOString(),
+                    }],
+                },
+            });
+            mockS3Get(mockData);
+            mockS3Put();
+
+            const result = await service.removeSubscription('user1', 'pvp-warning:bd2');
+            expect(result).toBe(true);
+        });
+
+        it('should return false if not subscribed', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+
+            const result = await service.removeSubscription('user1', 'pvp-warning:bd2');
+            expect(result).toBe(false);
+        });
+
+        it('should return false if type has no subscribers', async () => {
+            const mockData = createMockData({
+                subscriptions: { 'pvp-warning:bd2': [] },
+            });
+            mockS3Get(mockData);
+
+            const result = await service.removeSubscription('user1', 'pvp-warning:bd2');
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('isSubscribed', () => {
+        it('should return true when subscribed', async () => {
+            const mockData = createMockData({
+                subscriptions: {
+                    'pvp-warning:bd2': [{
+                        discordId: 'user1',
+                        guildId: 'guild1',
+                        notificationType: 'pvp-warning:bd2',
+                        subscribedAt: new Date().toISOString(),
+                    }],
+                },
+            });
+            mockS3Get(mockData);
+
+            expect(await service.isSubscribed('user1', 'pvp-warning:bd2')).toBe(true);
+        });
+
+        it('should return false when not subscribed', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+
+            expect(await service.isSubscribed('user1', 'pvp-warning:bd2')).toBe(false);
+        });
+    });
+
+    describe('markDMDisabled', () => {
+        it('should mark DM as disabled', async () => {
+            const mockData = createMockData({
+                subscriptions: {
+                    'pvp-warning:bd2': [{
+                        discordId: 'user1',
+                        guildId: 'guild1',
+                        notificationType: 'pvp-warning:bd2',
+                        subscribedAt: new Date().toISOString(),
+                    }],
+                },
+            });
+            mockS3Get(mockData);
+            mockS3Put();
+
+            await service.markDMDisabled('user1', 'pvp-warning:bd2');
+
+            const saveCall = vi.mocked(s3Client.send).mock.calls[1];
+            const savedBody = JSON.parse((saveCall[0] as any).input.Body);
+            expect(savedBody.subscriptions['pvp-warning:bd2'][0].dmDisabled).toBe(true);
+            expect(savedBody.subscriptions['pvp-warning:bd2'][0].dmDisabledAt).toBeDefined();
+        });
+
+        it('should no-op if user not found', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+
+            // Should not throw
+            await service.markDMDisabled('unknown', 'pvp-warning:bd2');
+            // Only 1 S3 call (getData), no saveData
+            expect(s3Client.send).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('clearDMDisabled', () => {
+        it('should clear DM disabled status', async () => {
+            const mockData = createMockData({
+                subscriptions: {
+                    'pvp-warning:bd2': [{
+                        discordId: 'user1',
+                        guildId: 'guild1',
+                        notificationType: 'pvp-warning:bd2',
+                        subscribedAt: new Date().toISOString(),
+                        dmDisabled: true,
+                        dmDisabledAt: new Date().toISOString(),
+                    }],
+                },
+            });
+            mockS3Get(mockData);
+            mockS3Put();
+
+            await service.clearDMDisabled('user1', 'pvp-warning:bd2');
+
+            const saveCall = vi.mocked(s3Client.send).mock.calls[1];
+            const savedBody = JSON.parse((saveCall[0] as any).input.Body);
+            expect(savedBody.subscriptions['pvp-warning:bd2'][0].dmDisabled).toBeUndefined();
+        });
+    });
+
+    describe('getSubscriptionsForUser', () => {
+        it('should return all subscriptions for a user across types', async () => {
+            const mockData = createMockData({
+                subscriptions: {
+                    'pvp-warning:bd2': [{
+                        discordId: 'user1',
+                        guildId: 'guild1',
+                        notificationType: 'pvp-warning:bd2',
+                        subscribedAt: new Date().toISOString(),
+                    }],
+                    'daily-reset:nikke': [{
+                        discordId: 'user1',
+                        guildId: 'guild1',
+                        notificationType: 'daily-reset:nikke',
+                        subscribedAt: new Date().toISOString(),
+                    }],
+                    'other-type': [{
+                        discordId: 'user2',
+                        guildId: 'guild1',
+                        notificationType: 'other-type',
+                        subscribedAt: new Date().toISOString(),
+                    }],
+                },
+            });
+            mockS3Get(mockData);
+
+            const subs = await service.getSubscriptionsForUser('user1');
+            expect(subs).toHaveLength(2);
+            expect(subs.map(s => s.notificationType)).toContain('pvp-warning:bd2');
+            expect(subs.map(s => s.notificationType)).toContain('daily-reset:nikke');
+        });
+
+        it('should return empty array for user with no subscriptions', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+
+            const subs = await service.getSubscriptionsForUser('nobody');
+            expect(subs).toEqual([]);
+        });
+    });
+
+    describe('getSubscribers', () => {
+        it('should return subscribers for a type', async () => {
+            const mockData = createMockData({
+                subscriptions: {
+                    'pvp-warning:bd2': [
+                        { discordId: 'user1', guildId: 'g1', notificationType: 'pvp-warning:bd2', subscribedAt: '' },
+                        { discordId: 'user2', guildId: 'g1', notificationType: 'pvp-warning:bd2', subscribedAt: '' },
+                    ],
+                },
+            });
+            mockS3Get(mockData);
+
+            const subs = await service.getSubscribers('pvp-warning:bd2');
+            expect(subs).toHaveLength(2);
+        });
+
+        it('should return empty array for unknown type', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+
+            const subs = await service.getSubscribers('unknown');
+            expect(subs).toEqual([]);
+        });
+    });
+
+    describe('invalidateCache', () => {
+        it('should force re-fetch from S3', async () => {
+            const mockData = createMockData();
+            mockS3Get(mockData);
+
+            await service.getData();
+            expect(s3Client.send).toHaveBeenCalledTimes(1);
+
+            service.invalidateCache();
+            mockS3Get(mockData);
+
+            await service.getData();
+            expect(s3Client.send).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/src/services/tests/notificationSubscriptionService.test.ts
+++ b/src/services/tests/notificationSubscriptionService.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { NotificationSubscriptionService, getNotificationSubscriptionService } from '../notificationSubscriptionService';
+import { NotificationSubscriptionDataService } from '../notificationSubscriptionDataService';
+import { Client, EmbedBuilder, Message } from 'discord.js';
+
+// Mock dependencies
+vi.mock('../../utils/cdn/config', () => ({
+    s3Client: { send: vi.fn() },
+    S3_BUCKET: 'test-bucket',
+}));
+
+vi.mock('../notificationSubscriptionDataService', () => {
+    const mockDataService = {
+        getSubscribers: vi.fn().mockResolvedValue([]),
+        addSubscription: vi.fn().mockResolvedValue(true),
+        removeSubscription: vi.fn().mockResolvedValue(true),
+        isSubscribed: vi.fn().mockResolvedValue(false),
+        markDMDisabled: vi.fn().mockResolvedValue(undefined),
+        clearDMDisabled: vi.fn().mockResolvedValue(undefined),
+        getSubscriptionsForUser: vi.fn().mockResolvedValue([]),
+        getData: vi.fn().mockResolvedValue({ subscriptions: {}, lastUpdated: '', schemaVersion: 1 }),
+    };
+    return {
+        NotificationSubscriptionDataService: {
+            getInstance: () => mockDataService,
+        },
+        getNotificationSubscriptionDataService: () => mockDataService,
+    };
+});
+
+vi.mock('../../utils/dmSender', () => ({
+    sendDMSafe: vi.fn().mockResolvedValue({
+        id: 'dm-msg-id',
+        react: vi.fn().mockResolvedValue(undefined),
+    }),
+}));
+
+import { getNotificationSubscriptionDataService } from '../notificationSubscriptionDataService';
+import { sendDMSafe } from '../../utils/dmSender';
+
+describe('NotificationSubscriptionService', () => {
+    let service: NotificationSubscriptionService;
+    let mockDataService: ReturnType<typeof getNotificationSubscriptionDataService>;
+
+    beforeEach(() => {
+        (NotificationSubscriptionService as any).instance = null;
+        service = getNotificationSubscriptionService();
+        mockDataService = getNotificationSubscriptionDataService();
+        vi.clearAllMocks();
+
+        // Register a test notification type
+        service.registerNotificationType({
+            type: 'pvp-warning:bd2-mirror-wars',
+            displayName: 'BD2 Mirror Wars PVP',
+            description: 'Weekly PVP reminders',
+            embedColor: 0x8B4513,
+            thumbnailUrl: 'https://cdn.example.com/bd2-logo.png',
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('Type Registry', () => {
+        it('should register and retrieve a notification type', () => {
+            const config = service.getNotificationType('pvp-warning:bd2-mirror-wars');
+            expect(config).toBeDefined();
+            expect(config?.displayName).toBe('BD2 Mirror Wars PVP');
+        });
+
+        it('should return undefined for unregistered type', () => {
+            expect(service.getNotificationType('unknown')).toBeUndefined();
+        });
+
+        it('should return all registered types', () => {
+            service.registerNotificationType({
+                type: 'daily-reset:nikke',
+                displayName: 'NIKKE Daily Reset',
+                description: 'Daily reset reminders',
+                embedColor: 0x3498DB,
+            });
+
+            const types = service.getAllNotificationTypes();
+            expect(types).toHaveLength(2);
+        });
+    });
+
+    describe('Subscribe', () => {
+        it('should subscribe a user successfully', async () => {
+            const result = await service.subscribe('user1', 'guild1', 'pvp-warning:bd2-mirror-wars');
+            expect(result.success).toBe(true);
+            expect(result.message).toContain('BD2 Mirror Wars PVP');
+            expect(mockDataService.addSubscription).toHaveBeenCalledWith('user1', 'guild1', 'pvp-warning:bd2-mirror-wars');
+        });
+
+        it('should return error for unknown notification type', async () => {
+            const result = await service.subscribe('user1', 'guild1', 'unknown-type');
+            expect(result.success).toBe(false);
+            expect(result.message).toBe('Unknown notification type.');
+        });
+
+        it('should return already-subscribed message', async () => {
+            vi.mocked(mockDataService.addSubscription).mockResolvedValueOnce(false);
+
+            const result = await service.subscribe('user1', 'guild1', 'pvp-warning:bd2-mirror-wars');
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('already subscribed');
+        });
+    });
+
+    describe('Unsubscribe', () => {
+        it('should unsubscribe a user successfully', async () => {
+            const result = await service.unsubscribe('user1', 'pvp-warning:bd2-mirror-wars');
+            expect(result.success).toBe(true);
+            expect(result.message).toContain('Unsubscribed');
+        });
+
+        it('should return not-subscribed message', async () => {
+            vi.mocked(mockDataService.removeSubscription).mockResolvedValueOnce(false);
+
+            const result = await service.unsubscribe('user1', 'pvp-warning:bd2-mirror-wars');
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('not subscribed');
+        });
+    });
+
+    describe('sendNotification', () => {
+        it('should return zero counts when no subscribers', async () => {
+            vi.mocked(mockDataService.getSubscribers).mockResolvedValueOnce([]);
+
+            const mockBot = {} as Client;
+            const embed = new EmbedBuilder().setTitle('Test').setDescription('Test');
+
+            const result = await service.sendNotification(mockBot, 'pvp-warning:bd2-mirror-wars', embed);
+            expect(result.sent).toBe(0);
+            expect(result.failed).toBe(0);
+            expect(result.dmDisabled).toBe(0);
+        });
+
+        it('should send DMs to subscribers and count results', async () => {
+            vi.mocked(mockDataService.getSubscribers).mockResolvedValueOnce([
+                { discordId: 'user1', guildId: 'g1', notificationType: 'pvp-warning:bd2-mirror-wars', subscribedAt: '' },
+                { discordId: 'user2', guildId: 'g1', notificationType: 'pvp-warning:bd2-mirror-wars', subscribedAt: '' },
+            ]);
+
+            const mockUser = { id: 'user1', send: vi.fn() };
+            const mockBot = {
+                users: { fetch: vi.fn().mockResolvedValue(mockUser) },
+            } as any;
+
+            const embed = new EmbedBuilder().setTitle('Test').setDescription('Test');
+
+            const result = await service.sendNotification(mockBot, 'pvp-warning:bd2-mirror-wars', embed);
+            expect(result.sent).toBe(2);
+            expect(sendDMSafe).toHaveBeenCalledTimes(2);
+        });
+
+        it('should skip users with dmDisabled', async () => {
+            vi.mocked(mockDataService.getSubscribers).mockResolvedValueOnce([
+                { discordId: 'user1', guildId: 'g1', notificationType: 'pvp-warning:bd2-mirror-wars', subscribedAt: '', dmDisabled: true },
+            ]);
+
+            const mockBot = { users: { fetch: vi.fn() } } as any;
+            const embed = new EmbedBuilder().setTitle('Test').setDescription('Test');
+
+            const result = await service.sendNotification(mockBot, 'pvp-warning:bd2-mirror-wars', embed);
+            expect(result.dmDisabled).toBe(1);
+            expect(result.sent).toBe(0);
+            expect(sendDMSafe).not.toHaveBeenCalled();
+        });
+
+        it('should append footer tag with notification type', async () => {
+            vi.mocked(mockDataService.getSubscribers).mockResolvedValueOnce([
+                { discordId: 'user1', guildId: 'g1', notificationType: 'pvp-warning:bd2-mirror-wars', subscribedAt: '' },
+            ]);
+
+            const mockUser = { id: 'user1' };
+            const mockBot = {
+                users: { fetch: vi.fn().mockResolvedValue(mockUser) },
+            } as any;
+
+            const embed = new EmbedBuilder()
+                .setTitle('Test')
+                .setDescription('Test')
+                .setFooter({ text: 'Original footer' });
+
+            await service.sendNotification(mockBot, 'pvp-warning:bd2-mirror-wars', embed);
+
+            // Check the embed passed to sendDMSafe has the footer tag
+            const call = vi.mocked(sendDMSafe).mock.calls[0];
+            const sentEmbed = call[1].embeds[0];
+            expect(sentEmbed.data.footer?.text).toContain('[type:pvp-warning:bd2-mirror-wars]');
+            expect(sentEmbed.data.footer?.text).toContain('Original footer');
+        });
+
+        it('should count failures when sendDMSafe returns null', async () => {
+            vi.mocked(mockDataService.getSubscribers).mockResolvedValueOnce([
+                { discordId: 'user1', guildId: 'g1', notificationType: 'pvp-warning:bd2-mirror-wars', subscribedAt: '' },
+            ]);
+
+            vi.mocked(sendDMSafe).mockResolvedValueOnce(null);
+
+            const mockBot = {
+                users: { fetch: vi.fn().mockResolvedValue({ id: 'user1' }) },
+            } as any;
+
+            const embed = new EmbedBuilder().setTitle('Test').setDescription('Test');
+
+            const result = await service.sendNotification(mockBot, 'pvp-warning:bd2-mirror-wars', embed);
+            expect(result.failed).toBe(1);
+            expect(result.sent).toBe(0);
+        });
+    });
+
+    describe('seedSubscribeReaction', () => {
+        it('should add subscribe emoji to message', async () => {
+            const mockMessage = {
+                id: 'msg-123',
+                react: vi.fn().mockResolvedValue(undefined),
+            } as any;
+
+            await service.seedSubscribeReaction(mockMessage, 'pvp-warning:bd2-mirror-wars');
+
+            expect(mockMessage.react).toHaveBeenCalledWith('✉️');
+        });
+
+        it('should handle reaction failure gracefully', async () => {
+            const mockMessage = {
+                id: 'msg-123',
+                react: vi.fn().mockRejectedValue(new Error('Missing permissions')),
+            } as any;
+
+            // Should not throw
+            await expect(
+                service.seedSubscribeReaction(mockMessage, 'pvp-warning:bd2-mirror-wars')
+            ).resolves.not.toThrow();
+        });
+    });
+
+    describe('Footer Tag Parsing', () => {
+        it('should parse notification type from embed footer', () => {
+            const parseMethod = (service as any).parseNotificationTypeFromEmbed.bind(service);
+
+            const message = {
+                embeds: [{
+                    footer: { text: 'Some text | [type:pvp-warning:bd2-mirror-wars]' },
+                }],
+            } as any;
+
+            expect(parseMethod(message)).toBe('pvp-warning:bd2-mirror-wars');
+        });
+
+        it('should return undefined for missing footer', () => {
+            const parseMethod = (service as any).parseNotificationTypeFromEmbed.bind(service);
+
+            const message = { embeds: [{}] } as any;
+            expect(parseMethod(message)).toBeUndefined();
+        });
+
+        it('should return undefined for footer without type tag', () => {
+            const parseMethod = (service as any).parseNotificationTypeFromEmbed.bind(service);
+
+            const message = {
+                embeds: [{ footer: { text: 'Just a normal footer' } }],
+            } as any;
+
+            expect(parseMethod(message)).toBeUndefined();
+        });
+
+        it('should return undefined for unregistered type in footer', () => {
+            const parseMethod = (service as any).parseNotificationTypeFromEmbed.bind(service);
+
+            const message = {
+                embeds: [{ footer: { text: '[type:unknown-type]' } }],
+            } as any;
+
+            expect(parseMethod(message)).toBeUndefined();
+        });
+
+        it('should return undefined for message with no embeds', () => {
+            const parseMethod = (service as any).parseNotificationTypeFromEmbed.bind(service);
+
+            const message = { embeds: [] } as any;
+            expect(parseMethod(message)).toBeUndefined();
+        });
+    });
+
+    describe('Reaction Routing', () => {
+        it('should start listening on messageReactionAdd', () => {
+            const mockBot = { on: vi.fn() } as any;
+            service.startListening(mockBot);
+            expect(mockBot.on).toHaveBeenCalledWith('messageReactionAdd', expect.any(Function));
+        });
+    });
+});

--- a/src/services/tests/notificationSubscriptionService.test.ts
+++ b/src/services/tests/notificationSubscriptionService.test.ts
@@ -190,7 +190,7 @@ describe('NotificationSubscriptionService', () => {
             // Check the embed passed to sendDMSafe has the footer tag
             const call = vi.mocked(sendDMSafe).mock.calls[0];
             const sentEmbed = call[1].embeds[0];
-            expect(sentEmbed.data.footer?.text).toContain('[type:pvp-warning:bd2-mirror-wars]');
+            expect(sentEmbed.data.footer?.text).toContain('[n:pvp-warning:bd2-mirror-wars]');
             expect(sentEmbed.data.footer?.text).toContain('Original footer');
         });
 
@@ -244,7 +244,7 @@ describe('NotificationSubscriptionService', () => {
 
             const message = {
                 embeds: [{
-                    footer: { text: 'Some text | [type:pvp-warning:bd2-mirror-wars]' },
+                    footer: { text: 'Some text | [n:pvp-warning:bd2-mirror-wars]' },
                 }],
             } as any;
 

--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -24,6 +24,13 @@ vi.mock('../../utils/cdn/mediaManager', () => ({
     getRandomCdnMediaUrl: vi.fn().mockResolvedValue('https://cdn.example.com/test-image.png')
 }));
 
+vi.mock('../notificationSubscriptionService', () => ({
+    getNotificationSubscriptionService: () => ({
+        seedSubscribeReaction: vi.fn().mockResolvedValue(undefined),
+        sendNotification: vi.fn().mockResolvedValue({ sent: 0, failed: 0, dmDisabled: 0 }),
+    }),
+}));
+
 describe('PvpReminderService', () => {
     let mockBot: Client;
     let mockGuild: Guild;

--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -24,11 +24,13 @@ vi.mock('../../utils/cdn/mediaManager', () => ({
     getRandomCdnMediaUrl: vi.fn().mockResolvedValue('https://cdn.example.com/test-image.png')
 }));
 
+const mockNotificationService = {
+    seedSubscribeReaction: vi.fn().mockResolvedValue(undefined),
+    sendNotification: vi.fn().mockResolvedValue({ sent: 0, failed: 0, dmDisabled: 0 }),
+};
+
 vi.mock('../notificationSubscriptionService', () => ({
-    getNotificationSubscriptionService: () => ({
-        seedSubscribeReaction: vi.fn().mockResolvedValue(undefined),
-        sendNotification: vi.fn().mockResolvedValue({ sent: 0, failed: 0, dmDisabled: 0 }),
-    }),
+    getNotificationSubscriptionService: () => mockNotificationService,
 }));
 
 describe('PvpReminderService', () => {
@@ -86,6 +88,7 @@ describe('PvpReminderService', () => {
                 {
                     label: '1 hour',
                     minutesBefore: 60,
+                    sendDM: true,
                     embedConfig: {
                         title: 'Mirror Wars Ending in 1 Hour!',
                         description: 'Final hour!',
@@ -260,6 +263,40 @@ describe('PvpReminderService', () => {
             ).resolves.not.toThrow();
 
             expect(util.logError).toHaveBeenCalled();
+        });
+    });
+
+    describe('DM Notification Sending', () => {
+        it('should send DM notifications once for warnings with sendDM: true', async () => {
+            vi.mocked(util.findChannelByName).mockReturnValue(mockChannel);
+
+            // Add a second guild to verify DMs aren't duplicated
+            const secondGuild = { ...mockGuild, id: 'guild-2', name: 'Guild 2' };
+            (mockBot.guilds.cache as any).set('guild-2', secondGuild);
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const sendWarningToAllGuilds = (service as any).sendWarningToAllGuilds;
+
+            // Use the 1-hour warning which has sendDM: true
+            await sendWarningToAllGuilds.call(service, testEvent, testEvent.warnings[1]);
+
+            // Channel messages sent to both guilds
+            expect(mockChannel.send).toHaveBeenCalledTimes(2);
+            // DM notification sent only once (not per-guild)
+            expect(mockNotificationService.sendNotification).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not send DM notifications for warnings without sendDM', async () => {
+            vi.mocked(util.findChannelByName).mockReturnValue(mockChannel);
+
+            const service = new PvpReminderService(mockBot, testConfig);
+            const sendWarningToAllGuilds = (service as any).sendWarningToAllGuilds;
+
+            // Use the 1-day warning which does NOT have sendDM
+            await sendWarningToAllGuilds.call(service, testEvent, testEvent.warnings[0]);
+
+            expect(mockChannel.send).toHaveBeenCalledTimes(1);
+            expect(mockNotificationService.sendNotification).not.toHaveBeenCalled();
         });
     });
 
@@ -488,7 +525,9 @@ describe('PvpReminderService', () => {
             expect(mirrorWars.seasonEnd).toEqual({ dayOfWeek: 0, hour: 14, minute: 59 });
             expect(mirrorWars.warnings).toHaveLength(2);
             expect(mirrorWars.warnings[0].minutesBefore).toBe(24 * 60);
+            expect(mirrorWars.warnings[0].sendDM).toBeUndefined();
             expect(mirrorWars.warnings[1].minutesBefore).toBe(60);
+            expect(mirrorWars.warnings[1].sendDM).toBe(true);
         });
 
         it('should produce correct crons for actual BD2 config', async () => {

--- a/src/utils/data/notificationConfig.ts
+++ b/src/utils/data/notificationConfig.ts
@@ -1,0 +1,31 @@
+/**
+ * Configuration constants for the notification subscription system
+ */
+export const NOTIFICATION_CONFIG = {
+    /** Delay between DM sends to avoid Discord rate limits (ms) */
+    DM_RATE_LIMIT_DELAY: 100,
+
+    /** Max concurrent DM sends */
+    CONCURRENT_DM_LIMIT: 5,
+
+    /** S3 data path prefix */
+    S3_DATA_PATH: 'data/notification-subscriptions',
+
+    /** Emoji used on channel messages — react to subscribe */
+    SUBSCRIBE_EMOJI: '✉️',
+
+    /** Emoji used on DM messages — react to unsubscribe */
+    UNSUBSCRIBE_EMOJI: '❌',
+
+    /** Max entries in messageId → notificationType memory map before cleanup */
+    MESSAGE_TYPE_MAP_MAX_SIZE: 500,
+
+    /** Cache TTL for S3 data (ms) */
+    CACHE_TTL: 5 * 60 * 1000, // 5 minutes
+} as const;
+
+/**
+ * Regex to parse notification type from embed footer.
+ * Format: "[type:some-notification-type]"
+ */
+export const NOTIFICATION_TYPE_FOOTER_REGEX = /\[type:([^\]]+)\]/;

--- a/src/utils/data/notificationConfig.ts
+++ b/src/utils/data/notificationConfig.ts
@@ -5,9 +5,6 @@ export const NOTIFICATION_CONFIG = {
     /** Delay between DM sends to avoid Discord rate limits (ms) */
     DM_RATE_LIMIT_DELAY: 100,
 
-    /** Max concurrent DM sends */
-    CONCURRENT_DM_LIMIT: 5,
-
     /** S3 data path prefix */
     S3_DATA_PATH: 'data/notification-subscriptions',
 
@@ -26,6 +23,6 @@ export const NOTIFICATION_CONFIG = {
 
 /**
  * Regex to parse notification type from embed footer.
- * Format: "[type:some-notification-type]"
+ * Format: "[n:some-notification-type]" — short prefix to minimize footer clutter
  */
-export const NOTIFICATION_TYPE_FOOTER_REGEX = /\[type:([^\]]+)\]/;
+export const NOTIFICATION_TYPE_FOOTER_REGEX = /\[n:([^\]]+)\]/;

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -59,6 +59,7 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
         {
             label: '1 hour',
             minutesBefore: 60, // Sunday ~1:59 PM UTC
+            sendDM: true, // Only the 1-hour warning sends DM notifications to subscribers
             embedConfig: {
                 title: '\uD83D\uDEA8 Mirror Wars Season Ending in 1 Hour!',
                 description: (ts) =>

--- a/src/utils/dmSender.ts
+++ b/src/utils/dmSender.ts
@@ -1,0 +1,46 @@
+import { EmbedBuilder, Message, User } from 'discord.js';
+import { logger } from './logger.js';
+import { NOTIFICATION_CONFIG } from './data/notificationConfig.js';
+
+/**
+ * Send a DM safely with rate limiting and error handling.
+ *
+ * Handles Discord error 50007 (user has DMs disabled) via callbacks,
+ * allowing each caller to track DM failures in their own data store.
+ *
+ * @returns The sent Message if successful, null if failed
+ */
+export async function sendDMSafe(
+    user: User,
+    content: { embeds: EmbedBuilder[] },
+    options?: {
+        /** Called when DM sending fails with error 50007 */
+        onDMDisabled?: (userId: string) => Promise<void>;
+        /** Called on successful send (useful for clearing previous DM-disabled flags) */
+        onDMSuccess?: (userId: string) => Promise<void>;
+        /** Rate limit delay in ms (defaults to NOTIFICATION_CONFIG.DM_RATE_LIMIT_DELAY) */
+        rateLimitDelay?: number;
+    }
+): Promise<Message | null> {
+    try {
+        const message = await user.send(content);
+        const delay = options?.rateLimitDelay ?? NOTIFICATION_CONFIG.DM_RATE_LIMIT_DELAY;
+        await new Promise(resolve => setTimeout(resolve, delay));
+
+        if (options?.onDMSuccess) {
+            await options.onDMSuccess(user.id);
+        }
+
+        return message;
+    } catch (error: any) {
+        if (error.code === 50007) {
+            logger.warning`Cannot send DM to ${user.id} - user has DMs disabled`;
+            if (options?.onDMDisabled) {
+                await options.onDMDisabled(user.id);
+            }
+        } else {
+            logger.error`Failed to send DM to ${user.id}: ${error.message}`;
+        }
+        return null;
+    }
+}

--- a/src/utils/interfaces/NotificationSubscription.interface.ts
+++ b/src/utils/interfaces/NotificationSubscription.interface.ts
@@ -1,0 +1,51 @@
+/**
+ * Notification type identifier.
+ * Convention: "{category}:{specificId}" e.g., "pvp-warning:bd2-mirror-wars"
+ */
+export type NotificationType = string;
+
+/**
+ * Metadata for a registered notification type
+ */
+export interface NotificationTypeConfig {
+    /** Unique type identifier */
+    type: NotificationType;
+    /** Human-readable display name, e.g. "BD2 Mirror Wars PVP" */
+    displayName: string;
+    /** Short description */
+    description: string;
+    /** Embed color for DM notifications */
+    embedColor: number;
+    /** Thumbnail URL for DM embeds */
+    thumbnailUrl?: string;
+}
+
+/**
+ * A user's subscription to a specific notification type
+ */
+export interface NotificationUserSubscription {
+    /** Discord user ID */
+    discordId: string;
+    /** Guild ID where subscription was created */
+    guildId: string;
+    /** Notification type subscribed to */
+    notificationType: NotificationType;
+    /** ISO timestamp of subscription */
+    subscribedAt: string;
+    /** Whether DMs failed to send (error 50007) */
+    dmDisabled?: boolean;
+    /** ISO timestamp when DM failure was detected */
+    dmDisabledAt?: string;
+}
+
+/**
+ * Root data structure stored in S3
+ */
+export interface NotificationSubscriptionData {
+    /** Subscriptions keyed by notification type for O(1) lookup */
+    subscriptions: Record<NotificationType, NotificationUserSubscription[]>;
+    /** ISO timestamp of last update */
+    lastUpdated: string;
+    /** Schema version for future migrations */
+    schemaVersion: number;
+}

--- a/src/utils/interfaces/PvpEventConfig.interface.ts
+++ b/src/utils/interfaces/PvpEventConfig.interface.ts
@@ -43,6 +43,8 @@ export interface PvpWarningConfig {
     minutesBefore: number;
     /** Embed configuration for this warning */
     embedConfig: PvpEmbedConfig;
+    /** Whether to send DM notifications to subscribers for this warning (default: false) */
+    sendDM?: boolean;
 }
 
 /**

--- a/src/utils/tests/dmSender.test.ts
+++ b/src/utils/tests/dmSender.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { sendDMSafe } from '../dmSender';
+import { EmbedBuilder, User } from 'discord.js';
+
+describe('sendDMSafe', () => {
+    let mockUser: User;
+    let testContent: { embeds: EmbedBuilder[] };
+
+    beforeEach(() => {
+        mockUser = {
+            id: 'test-user-id',
+            send: vi.fn().mockResolvedValue({ id: 'dm-msg-id' }),
+        } as any;
+
+        testContent = { embeds: [new EmbedBuilder().setTitle('Test')] };
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should send DM and return message', async () => {
+        const result = await sendDMSafe(mockUser, testContent);
+        expect(result).toBeDefined();
+        expect(result?.id).toBe('dm-msg-id');
+        expect(mockUser.send).toHaveBeenCalledWith(testContent);
+    });
+
+    it('should call onDMSuccess callback on successful send', async () => {
+        const onSuccess = vi.fn();
+        await sendDMSafe(mockUser, testContent, { onDMSuccess: onSuccess });
+        expect(onSuccess).toHaveBeenCalledWith('test-user-id');
+    });
+
+    it('should return null and call onDMDisabled on error 50007', async () => {
+        (mockUser.send as any).mockRejectedValueOnce({ code: 50007, message: 'DMs disabled' });
+
+        const onDisabled = vi.fn();
+        const result = await sendDMSafe(mockUser, testContent, { onDMDisabled: onDisabled });
+
+        expect(result).toBeNull();
+        expect(onDisabled).toHaveBeenCalledWith('test-user-id');
+    });
+
+    it('should return null on non-50007 error without calling onDMDisabled', async () => {
+        (mockUser.send as any).mockRejectedValueOnce({ code: 50001, message: 'Other error' });
+
+        const onDisabled = vi.fn();
+        const result = await sendDMSafe(mockUser, testContent, { onDMDisabled: onDisabled });
+
+        expect(result).toBeNull();
+        expect(onDisabled).not.toHaveBeenCalled();
+    });
+
+    it('should use custom rate limit delay', async () => {
+        const start = Date.now();
+        await sendDMSafe(mockUser, testContent, { rateLimitDelay: 50 });
+        const elapsed = Date.now() - start;
+
+        // Should wait at least 50ms (with some tolerance)
+        expect(elapsed).toBeGreaterThanOrEqual(40);
+    });
+
+    it('should work without options', async () => {
+        const result = await sendDMSafe(mockUser, testContent);
+        expect(result).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary
Adds a reaction-based DM notification subscription framework. Users react ✉️ on channel messages to subscribe to DM copies of notifications, and react ❌ on any DM to unsubscribe. Fully integrated with PVP warnings from #215.

## Changes
- **`NotificationSubscriptionService`** — central framework with type registry, reaction handling (subscribe via ✉️, unsubscribe via ❌), and DM delivery with rate limiting
- **`NotificationSubscriptionDataService`** — S3 CRUD for subscriptions (`data/notification-subscriptions/subscriptions.json`), separate from gacha data
- **`sendDMSafe` utility** (`src/utils/dmSender.ts`) — extracted from `gachaRedemptionService` for reuse. Handles error 50007 (DMs disabled) via callbacks
- **Gacha refactor** — `sendDMWithDelay` now delegates to `sendDMSafe` (behavioral parity, non-breaking)
- **PVP integration** — channel warnings auto-seed ✉️ reaction and DM subscribers
- **Footer tag system** — `[n:notification-type]` in embed footer enables stateless reaction routing (survives bot restart)

## How it works
1. PVP warning posts to `#brown-dust-2` with ✉️ reaction seeded
2. User reacts ✉️ → subscribed, receives confirmation DM with ❌ reaction for immediate unsubscribe
3. Next 1-hour PVP warning → subscribers get DM copy with ❌ reaction
4. User reacts ❌ on DM → unsubscribed, embed grayed out

## Fixes included (review feedback)
- **Fixed duplicate DMs bug** — `sendNotification()` was called per-guild, causing N duplicate DMs. Now called once after guild iteration
- **DM frequency** — Only the 1-hour warning sends DMs (via `sendDM` flag on `PvpWarningConfig`), not all 3 warnings
- **Immediate unsubscribe** — Confirmation DM includes ❌ reaction + footer tag so users can unsubscribe without waiting for a notification
- **Shortened footer tag** — Changed from `[type:pvp-warning:bd2-mirror-wars]` to `[n:pvp-warning:bd2-mirror-wars]` to reduce footer clutter
- **Removed unused config** — Deleted `CONCURRENT_DM_LIMIT` (defined but never used)

## No conflicts with existing gacha
- Gacha `reactionConfirmationService` checks for game/code embed fields
- Notification service checks for `[n:...]` footer tag
- Both register separate `messageReactionAdd` listeners with distinct guards

## Testing
- [x] `bunx tsc --noEmit` passes
- [x] 829 tests, 0 failures (full suite)
- [x] Merged with master (new season notification + CI optimization)
- [ ] Manual: react ✉️ on PVP warning → receive DM → react ❌ → unsubscribed

🤖 Generated with [Claude Code](https://claude.com/claude-code)