### PR TITLE
fix: Add cache busting to CDN logo/thumbnail URLs

### DIFF
--- a/src/config/assets.test.ts
+++ b/src/config/assets.test.ts
@@ -43,33 +43,33 @@ describe('assets.ts', () => {
   });
 
   describe('getAssetUrls', () => {
-    it('should construct full URLs for rapiBot assets', () => {
+    it('should construct full URLs for rapiBot assets with cache bust', () => {
       const urls = getAssetUrls();
-      expect(urls.rapiBot.thumbnail).toBe(
-        'https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg'
+      expect(urls.rapiBot.thumbnail).toMatch(
+        /^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg\?v=\d+$/
       );
-      expect(urls.rapiBot.icon).toBe(
-        'https://test-cdn.example.com/assets/rapi-bot-icon.png'
+      expect(urls.rapiBot.icon).toMatch(
+        /^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-icon\.png\?v=\d+$/
       );
     });
 
-    it('should construct full URLs for logos', () => {
+    it('should construct full URLs for logos with cache bust', () => {
       const urls = getAssetUrls();
-      expect(urls.logos.gfl2).toBe(
-        'https://test-cdn.example.com/assets/logos/gfl2-logo.png'
+      expect(urls.logos.gfl2).toMatch(
+        /^https:\/\/test-cdn\.example\.com\/assets\/logos\/gfl2-logo\.png\?v=\d+$/
       );
-      expect(urls.logos.nikke).toBe(
-        'https://test-cdn.example.com/assets/logos/nikke-logo.png'
+      expect(urls.logos.nikke).toMatch(
+        /^https:\/\/test-cdn\.example\.com\/assets\/logos\/nikke-logo\.png\?v=\d+$/
       );
-      expect(urls.logos.blueArchive).toBe(
-        'https://test-cdn.example.com/assets/logos/blue-archive-logo.png'
+      expect(urls.logos.blueArchive).toMatch(
+        /^https:\/\/test-cdn\.example\.com\/assets\/logos\/blue-archive-logo\.png\?v=\d+$/
       );
     });
 
     it('should return empty CDN domain when not set', () => {
       delete process.env.CDN_DOMAIN_URL;
       const urls = getAssetUrls();
-      expect(urls.rapiBot.thumbnail).toBe('/assets/rapi-bot-thumbnail.jpg');
+      expect(urls.rapiBot.thumbnail).toMatch(/^\/assets\/rapi-bot-thumbnail\.jpg\?v=\d+$/);
     });
   });
 

--- a/src/config/assets.ts
+++ b/src/config/assets.ts
@@ -13,6 +13,14 @@ function getCdnDomain(): string {
 }
 
 /**
+ * Cache-bust timestamp set at startup.
+ * Forces Discord to re-fetch logo/asset URLs after each bot restart/deploy,
+ * bypassing Discord's aggressive image caching. DigitalOcean Spaces CDN
+ * ignores unknown query params so the file is still served correctly.
+ */
+const CACHE_BUST = `v=${Math.floor(Date.now() / 1000)}`;
+
+/**
  * Asset path constants (relative to CDN root)
  */
 export const ASSET_PATHS = {
@@ -41,13 +49,13 @@ export function getAssetUrls() {
   const cdnDomain = getCdnDomain();
   return {
     rapiBot: {
-      thumbnail: `${cdnDomain}/${ASSET_PATHS.rapiBot.thumbnail}`,
-      icon: `${cdnDomain}/${ASSET_PATHS.rapiBot.icon}`,
+      thumbnail: `${cdnDomain}/${ASSET_PATHS.rapiBot.thumbnail}?${CACHE_BUST}`,
+      icon: `${cdnDomain}/${ASSET_PATHS.rapiBot.icon}?${CACHE_BUST}`,
     },
     logos: {
-      gfl2: `${cdnDomain}/${ASSET_PATHS.logos.gfl2}`,
-      nikke: `${cdnDomain}/${ASSET_PATHS.logos.nikke}`,
-      blueArchive: `${cdnDomain}/${ASSET_PATHS.logos.blueArchive}`,
+      gfl2: `${cdnDomain}/${ASSET_PATHS.logos.gfl2}?${CACHE_BUST}`,
+      nikke: `${cdnDomain}/${ASSET_PATHS.logos.nikke}?${CACHE_BUST}`,
+      blueArchive: `${cdnDomain}/${ASSET_PATHS.logos.blueArchive}?${CACHE_BUST}`,
     }
   };
 }
@@ -78,6 +86,14 @@ export function getCdnUrl(path: string): string {
   // Remove leading slash if present
   const cleanPath = path.startsWith('/') ? path.slice(1) : path;
   return `${cdnDomain}/${cleanPath}`;
+}
+
+/**
+ * Append cache-bust query param to a CDN URL.
+ * Use on logo/thumbnail URLs to force Discord to re-fetch after deploys.
+ */
+export function cacheBust(url: string): string {
+  return `${url}?${CACHE_BUST}`;
 }
 
 /**

--- a/src/utils/data/gachaGamesConfig.ts
+++ b/src/utils/data/gachaGamesConfig.ts
@@ -1,4 +1,5 @@
 import { GachaGameConfig, GachaGameId } from '../interfaces/GachaCoupon.interface';
+import { cacheBust } from '../../config/assets.js';
 
 const cdnDomainUrl = process.env.CDN_DOMAIN_URL || '';
 
@@ -22,7 +23,7 @@ export const GACHA_GAMES: Record<GachaGameId, GachaGameConfig> = {
         },
         manualRedeemUrl: 'https://redeem.bd2.pmang.cloud/bd2/index.html?lang=en-US',
         supportsAutoRedeem: true,
-        logoPath: `${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`,
+        logoPath: cacheBust(`${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`),
         embedColor: 0x8B4513,
         maxNicknameLength: 24,
         maxCodeLength: 30,
@@ -36,7 +37,7 @@ export const GACHA_GAMES: Record<GachaGameId, GachaGameConfig> = {
         // Lost Sword uses in-game redemption only (Settings > Account > Redeem Coupon)
         manualRedeemUrl: undefined,
         supportsAutoRedeem: false,
-        logoPath: `${cdnDomainUrl}/assets/logos/lost-sword-logo.png`,
+        logoPath: cacheBust(`${cdnDomainUrl}/assets/logos/lost-sword-logo.png`),
         embedColor: 0x8B4513, // Brown/sword color
         maxNicknameLength: 20,
         maxCodeLength: 20,
@@ -62,7 +63,7 @@ export const GACHA_GAMES: Record<GachaGameId, GachaGameConfig> = {
     //     // NIKKE uses in-game redemption only (no web API)
     //     manualRedeemUrl: undefined,
     //     supportsAutoRedeem: false,
-    //     logoPath: `${cdnDomainUrl}/assets/logos/nikke-logo.png`,
+    //     logoPath: cacheBust(`${cdnDomainUrl}/assets/logos/nikke-logo.png`),
     //     embedColor: 0x3498DB,
     //     maxNicknameLength: 20,
     //     maxCodeLength: 30,
@@ -76,7 +77,7 @@ export const GACHA_GAMES: Record<GachaGameId, GachaGameConfig> = {
     //     // Blue Archive uses in-game redemption only
     //     manualRedeemUrl: undefined,
     //     supportsAutoRedeem: false,
-    //     logoPath: `${cdnDomainUrl}/assets/logos/blue-archive-logo.png`,
+    //     logoPath: cacheBust(`${cdnDomainUrl}/assets/logos/blue-archive-logo.png`),
     //     embedColor: 0x00BFFF,
     //     maxNicknameLength: 20,
     //     maxCodeLength: 30,

--- a/src/utils/data/gamesResetConfig.ts
+++ b/src/utils/data/gamesResetConfig.ts
@@ -3,15 +3,17 @@ import { DailyResetConfig, DailyResetServiceConfig, EmbedField } from '../interf
 import { getBosses, getTribeTowerRotation, cdnDomainUrl } from '../util';
 import { getRandomCdnMediaUrl } from '../cdn/mediaManager';
 import { logError } from '../util';
+import { cacheBust } from '../../config/assets.js';
 
 // Asset URLs (shared across configurations)
-const RAPI_BOT_THUMBNAIL_URL = `${cdnDomainUrl}/assets/rapi-bot-thumbnail.jpg`;
-const NIKKE_LOGO_URL = `${cdnDomainUrl}/assets/logos/nikke-logo.png`;
-const BLUE_ARCHIVE_LOGO_URL = `${cdnDomainUrl}/assets/logos/blue-archive-logo.png`;
-const TRICKCAL_LOGO_URL = `${cdnDomainUrl}/assets/logos/trickcal-logo.png`;
-const CHAOS_ZERO_NIGHTMARE_LOGO_URL = `${cdnDomainUrl}/assets/logos/chaos-zero-nightmare-logo.png`;
-const LOST_SWORD_LOGO_URL = `${cdnDomainUrl}/assets/logos/lost-sword-logo.webp`;
-const BROWN_DUST_2_LOGO_URL = `${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`;
+// cacheBust() appends ?v={startup_timestamp} to bypass Discord's image caching after deploys
+const RAPI_BOT_THUMBNAIL_URL = cacheBust(`${cdnDomainUrl}/assets/rapi-bot-thumbnail.jpg`);
+const NIKKE_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/nikke-logo.png`);
+const BLUE_ARCHIVE_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/blue-archive-logo.png`);
+const TRICKCAL_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/trickcal-logo.png`);
+const CHAOS_ZERO_NIGHTMARE_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/chaos-zero-nightmare-logo.png`);
+const LOST_SWORD_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/lost-sword-logo.webp`);
+const BROWN_DUST_2_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`);
 
 // Default extensions
 const DEFAULT_IMAGE_EXTENSIONS = ['.gif', '.png', '.jpg', '.webp'] as const;

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -1,9 +1,10 @@
 import { PvpEventConfig, PvpReminderServiceConfig } from '../interfaces/PvpEventConfig.interface.js';
 import { cdnDomainUrl } from '../util.js';
+import { cacheBust } from '../../config/assets.js';
 
 // Asset URLs (shared with gamesResetConfig.ts)
-const RAPI_BOT_THUMBNAIL_URL = `${cdnDomainUrl}/assets/rapi-bot-thumbnail.jpg`;
-const BROWN_DUST_2_LOGO_URL = `${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`;
+const RAPI_BOT_THUMBNAIL_URL = cacheBust(`${cdnDomainUrl}/assets/rapi-bot-thumbnail.jpg`);
+const BROWN_DUST_2_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`);
 
 const DEFAULT_IMAGE_EXTENSIONS = ['.gif', '.png', '.jpg', '.webp'];
 

--- a/src/utils/embedTemplates.test.ts
+++ b/src/utils/embedTemplates.test.ts
@@ -42,7 +42,7 @@ describe('embedTemplates.ts', () => {
 
       expect(embed.data.title).toBe('Success Title');
       expect(embed.data.color).toBe(EmbedColors.SUCCESS);
-      expect(embed.data.thumbnail?.url).toBe('https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg');
+      expect(embed.data.thumbnail?.url).toMatch(/^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/);
       expect(embed.data.timestamp).toBeDefined();
       expect(embed.data.description).toBeUndefined();
     });
@@ -62,7 +62,7 @@ describe('embedTemplates.ts', () => {
 
       expect(embed.data.title).toBe('Error Title');
       expect(embed.data.color).toBe(EmbedColors.ERROR);
-      expect(embed.data.thumbnail?.url).toBe('https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg');
+      expect(embed.data.thumbnail?.url).toMatch(/^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/);
       expect(embed.data.timestamp).toBeDefined();
     });
 
@@ -81,7 +81,7 @@ describe('embedTemplates.ts', () => {
 
       expect(embed.data.title).toBe('Info Title');
       expect(embed.data.color).toBe(EmbedColors.INFO);
-      expect(embed.data.thumbnail?.url).toBe('https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg');
+      expect(embed.data.thumbnail?.url).toMatch(/^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/);
       expect(embed.data.timestamp).toBeDefined();
     });
 
@@ -99,7 +99,7 @@ describe('embedTemplates.ts', () => {
 
       expect(embed.data.title).toBe('Warning Title');
       expect(embed.data.color).toBe(EmbedColors.WARNING);
-      expect(embed.data.thumbnail?.url).toBe('https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg');
+      expect(embed.data.thumbnail?.url).toMatch(/^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/);
     });
 
     it('should create warning embed with title and description', () => {
@@ -116,8 +116,8 @@ describe('embedTemplates.ts', () => {
       expect(embed.data.title).toBe('Gacha Title');
       expect(embed.data.color).toBe(EmbedColors.GACHA);
       expect(embed.data.footer?.text).toBe('Gacha Coupon System');
-      expect(embed.data.footer?.icon_url).toBe('https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg');
-      expect(embed.data.thumbnail?.url).toBe('https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg');
+      expect(embed.data.footer?.icon_url).toMatch(/^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/);
+      expect(embed.data.thumbnail?.url).toMatch(/^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/);
       expect(embed.data.timestamp).toBeDefined();
     });
 
@@ -186,7 +186,7 @@ describe('embedTemplates.ts', () => {
 
       expect(embed.data.title).toBe('Custom Title');
       expect(embed.data.color).toBe(customColor);
-      expect(embed.data.thumbnail?.url).toBe('https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg');
+      expect(embed.data.thumbnail?.url).toMatch(/^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/);
       expect(embed.data.timestamp).toBeDefined();
     });
 
@@ -246,12 +246,12 @@ describe('embedTemplates.ts', () => {
     });
 
     it('all embeds should have thumbnail', () => {
-      const thumbnailUrl = 'https://test-cdn.example.com/assets/rapi-bot-thumbnail.jpg';
-      expect(successEmbed('Test').data.thumbnail?.url).toBe(thumbnailUrl);
-      expect(errorEmbed('Test').data.thumbnail?.url).toBe(thumbnailUrl);
-      expect(infoEmbed('Test').data.thumbnail?.url).toBe(thumbnailUrl);
-      expect(warningEmbed('Test').data.thumbnail?.url).toBe(thumbnailUrl);
-      expect(gachaEmbed('Test').data.thumbnail?.url).toBe(thumbnailUrl);
+      const thumbnailPattern = /^https:\/\/test-cdn\.example\.com\/assets\/rapi-bot-thumbnail\.jpg(\?v=\d+)?$/;
+      expect(successEmbed('Test').data.thumbnail?.url).toMatch(thumbnailPattern);
+      expect(errorEmbed('Test').data.thumbnail?.url).toMatch(thumbnailPattern);
+      expect(infoEmbed('Test').data.thumbnail?.url).toMatch(thumbnailPattern);
+      expect(warningEmbed('Test').data.thumbnail?.url).toMatch(thumbnailPattern);
+      expect(gachaEmbed('Test').data.thumbnail?.url).toMatch(thumbnailPattern);
     });
   });
 


### PR DESCRIPTION
## Summary
Appends `?v={startup_timestamp}` to all logo and thumbnail CDN URLs to bypass Discord's aggressive image caching after deploys.

## Changes
- **`cacheBust()` helper** in `src/config/assets.ts` — appends `?v={unix_timestamp}` set once at bot startup
- Applied to all logo/thumbnail URLs in `gamesResetConfig.ts`, `pvpEventsConfig.ts`, `gachaGamesConfig.ts`, and `getAssetUrls()`
- DigitalOcean Spaces CDN ignores unknown query params so files still serve correctly
- Images stay cached within a session, refresh on each deploy/restart

## Testing
- [x] `bunx tsc --noEmit` passes
- [x] Full suite: 780 tests, 0 failures
- [x] Updated asset and embed template tests to accept cache-bust query param

🤖 Generated with [Claude Code](https://claude.com/claude-code)