### PR TITLE
fix: Correct Lost Sword logo extension from .webp to .png

### DIFF
--- a/src/utils/data/gamesResetConfig.ts
+++ b/src/utils/data/gamesResetConfig.ts
@@ -12,7 +12,7 @@ const NIKKE_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/nikke-logo.png`);
 const BLUE_ARCHIVE_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/blue-archive-logo.png`);
 const TRICKCAL_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/trickcal-logo.png`);
 const CHAOS_ZERO_NIGHTMARE_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/chaos-zero-nightmare-logo.png`);
-const LOST_SWORD_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/lost-sword-logo.webp`);
+const LOST_SWORD_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/lost-sword-logo.png`);
 const BROWN_DUST_2_LOGO_URL = cacheBust(`${cdnDomainUrl}/assets/logos/brown-dust-2-logo.png`);
 
 // Default extensions


### PR DESCRIPTION
## Summary
Fixes Lost Sword logo not displaying in daily reset embeds due to mismatched file extension.

## Changes
- `gamesResetConfig.ts`: Changed `lost-sword-logo.webp` to `lost-sword-logo.png`
- Now consistent with `gachaGamesConfig.ts` which already used `.png`

## Testing
- [x] `bunx tsc --noEmit` passes
- [x] Full suite: 780 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)