### PR TITLE
fix: Add Node 22 to release workflow and chain deploy after release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,20 @@
 name: Build, Push and Deploy Docker Image
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [master]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4.1.1
+        with:
+          ref: master
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
@@ -39,17 +43,17 @@ jobs:
           script: |
             echo "Pulling the latest Docker image..."
             docker pull ${{ secrets.DOCKER_USERNAME }}/rapi-bot:latest
-            
+
             echo "Checking if the container is already running..."
             if [ "$(docker ps -q -f name=rapibot)" ]; then
                 echo "Container is running. Stopping and removing..."
                 docker stop rapibot
                 docker rm rapibot
             fi
-            
+
             echo "Removing all unused images..."
             docker image prune -a -f
-            
+
             echo "Creating environment file..."
             cat << EOF > .env
             WAIFUPORT=${{ secrets.WAIFU_PORT }}
@@ -64,6 +68,6 @@ jobs:
             TWITCH_CLIENT_SECRET=${{ secrets.TWITCH_CLIENT_SECRET }}
             YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }}
             EOF
-            
+
             echo "Running the new container..."
             docker run -d --restart unless-stopped --name rapibot --env-file .env ${{ secrets.DOCKER_USERNAME }}/rapi-bot:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           ref: master
 
+      - name: Get version from package.json
+        id: version
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -28,7 +32,9 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/rapi-bot:latest
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/rapi-bot:latest
+            ${{ secrets.DOCKER_USERNAME }}/rapi-bot:v${{ steps.version.outputs.VERSION }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           persist-credentials: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:


### PR DESCRIPTION
## Summary
Fixes the failed release workflow and reorders the CI/CD pipeline so deploys happen after the version bump.

## Changes
- **`release.yml`**: Added `actions/setup-node@v4` with Node 22 — semantic-release requires Node >= 22.14.0 but the runner defaulted to Node 20
- **`deploy.yml`**: Changed trigger from `on: push` to `on: workflow_run` after Release workflow completes — ensures Docker builds include the version-bumped `package.json`

## New pipeline order
```
Push to master → CI (tests) → Release (version bump + tag + GitHub Release) → Deploy (Docker build + DigitalOcean)
```

## Testing
- [x] Root cause confirmed: `node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.1`
- [ ] Release workflow passes after merge
- [ ] Deploy triggers after successful release

🤖 Generated with [Claude Code](https://claude.com/claude-code)