### PR TITLE
feat: add new season notification for Mirror Wars

### DIFF
--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -85,6 +85,19 @@ describe('PvpReminderService', () => {
                         color: 0xFF0000,
                         footer: { text: 'Urgent footer' }
                     }
+                },
+                {
+                    label: 'new season',
+                    minutesBefore: 0,
+                    embedConfig: {
+                        title: 'New Mirror Wars Season!',
+                        description: (ts: number) => `New season! Next ends <t:${ts}:F>`,
+                        color: 0x00CC66,
+                        footer: { text: 'New season footer' },
+                        fields: (ts: number) => [
+                            { name: 'Next Season Ends', value: `<t:${ts}:R>`, inline: true }
+                        ]
+                    }
                 }
             ],
             mediaConfig: {
@@ -153,6 +166,12 @@ describe('PvpReminderService', () => {
             expect(cron).toBe('0 12 * * 4'); // Thursday 12:00
         });
 
+        it('should calculate new season notification: Sunday 14:59 - 0min = Sunday 14:59', () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const cron = service.calculateWarningCron(testEvent, testEvent.warnings[2]);
+            expect(cron).toBe('59 14 * * 0'); // Sunday 14:59 — at season end
+        });
+
         it('should handle Sunday 00:00 event with 1-day warning = Saturday 00:00', () => {
             const service = new PvpReminderService(mockBot, testConfig);
             const sundayMidnightEvent: PvpEventConfig = {
@@ -176,9 +195,10 @@ describe('PvpReminderService', () => {
             service.initializeSchedules();
 
             const jobs = service.getScheduledJobs();
-            expect(jobs.size).toBe(2); // 2 warnings for Mirror Wars
+            expect(jobs.size).toBe(3); // 3 warnings for Mirror Wars
             expect(jobs.has('bd2-mirror-wars-1 day')).toBe(true);
             expect(jobs.has('bd2-mirror-wars-1 hour')).toBe(true);
+            expect(jobs.has('bd2-mirror-wars-new season')).toBe(true);
         });
 
         it('should handle multiple events', () => {
@@ -198,7 +218,7 @@ describe('PvpReminderService', () => {
             service.initializeSchedules();
 
             const jobs = service.getScheduledJobs();
-            expect(jobs.size).toBe(3); // 2 from Mirror Wars + 1 from Arena
+            expect(jobs.size).toBe(4); // 3 from Mirror Wars + 1 from Arena
         });
     });
 
@@ -207,7 +227,7 @@ describe('PvpReminderService', () => {
             const service = new PvpReminderService(mockBot, testConfig);
             service.initializeSchedules();
 
-            expect(service.getScheduledJobs().size).toBe(2);
+            expect(service.getScheduledJobs().size).toBe(3);
 
             service.cancelAllSchedules();
 
@@ -355,6 +375,19 @@ describe('PvpReminderService', () => {
             expect(embed.data.image).toBeUndefined();
         });
 
+        it('should build embed with correct title and color for new season notification', async () => {
+            const service = new PvpReminderService(mockBot, testConfig);
+            const buildWarningEmbed = (service as any).buildWarningEmbed;
+
+            const embed = await buildWarningEmbed.call(service, mockGuild, testEvent, testEvent.warnings[2]);
+
+            expect(embed.data.title).toBe('New Mirror Wars Season!');
+            expect(embed.data.color).toBe(0x00CC66);
+            expect(embed.data.description).toMatch(/New season! Next ends <t:\d+:F>/);
+            expect(embed.data.fields).toHaveLength(1);
+            expect(embed.data.fields?.[0].value).toMatch(/<t:\d+:R>/);
+        });
+
         it('should not set image when event has no mediaConfig', async () => {
             const eventWithoutMedia: PvpEventConfig = {
                 ...testEvent,
@@ -380,7 +413,7 @@ describe('PvpReminderService', () => {
             service.initializeSchedules();
 
             const jobs = service.getScheduledJobs();
-            expect(jobs.size).toBe(2);
+            expect(jobs.size).toBe(3);
 
             process.env.NODE_ENV = originalEnv;
         });
@@ -479,9 +512,10 @@ describe('PvpReminderService', () => {
             expect(mirrorWars.id).toBe('bd2-mirror-wars');
             expect(mirrorWars.channelName).toBe('brown-dust-2');
             expect(mirrorWars.seasonEnd).toEqual({ dayOfWeek: 0, hour: 14, minute: 59 });
-            expect(mirrorWars.warnings).toHaveLength(2);
+            expect(mirrorWars.warnings).toHaveLength(3);
             expect(mirrorWars.warnings[0].minutesBefore).toBe(24 * 60);
             expect(mirrorWars.warnings[1].minutesBefore).toBe(60);
+            expect(mirrorWars.warnings[2].minutesBefore).toBe(0);
         });
 
         it('should produce correct crons for actual BD2 config', async () => {
@@ -497,6 +531,10 @@ describe('PvpReminderService', () => {
             // 1-hour warning: Sunday 13:59
             const hourWarningCron = service.calculateWarningCron(mirrorWars, mirrorWars.warnings[1]);
             expect(hourWarningCron).toBe('59 13 * * 0');
+
+            // New season notification: Sunday 14:59 (at season end)
+            const newSeasonCron = service.calculateWarningCron(mirrorWars, mirrorWars.warnings[2]);
+            expect(newSeasonCron).toBe('59 14 * * 0');
         });
     });
 });

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -87,6 +87,36 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
                 ],
             },
         },
+        {
+            label: 'new season',
+            minutesBefore: 0, // Fires AT season end = new season start
+            embedConfig: {
+                title: '\uD83C\uDF1F New Mirror Wars Season Has Begun!',
+                description: (ts) =>
+                    `The mirrors have been restored, Adventurer! A new season of Mirror Wars awaits!\n\n` +
+                    `**Next season ends <t:${ts}:F> (<t:${ts}:R>).**\n\n` +
+                    `Set your defense team, plan your strategy, and begin your climb to the top!`,
+                color: 0x00CC66, // Green — celebratory / fresh start
+                footer: {
+                    text: 'A new season dawns! | May the Blood Imprint guide your path!',
+                    iconURL: RAPI_BOT_THUMBNAIL_URL,
+                },
+                thumbnail: BROWN_DUST_2_LOGO_URL,
+                author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
+                fields: (ts) => [
+                    {
+                        name: '\uD83D\uDCC5 Next Season Ends',
+                        value: `<t:${ts}:F>\n<t:${ts}:R>`,
+                        inline: true,
+                    },
+                    {
+                        name: '\u2728 New Season Tips',
+                        value: '\u2022 Update your **defense team**\n\u2022 Start battles early \u2014 don\'t wait!\n\u2022 Use all **40 daily battles**',
+                        inline: true,
+                    },
+                ],
+            },
+        },
     ],
     mediaConfig: {
         cdnPath: 'dailies/bd2/',


### PR DESCRIPTION
## Summary
- Adds a "New Season" notification that fires at Mirror Wars season end (Sunday 14:59 UTC) to announce the new season has begun
- Posts a green celebratory embed to `#brown-dust-2` with next season end timestamps and new season tips
- Config-only change — leverages existing `PvpReminderService` with `minutesBefore: 0`

## Changes
- **`src/utils/data/pvpEventsConfig.ts`** — Added 3rd warning entry with green embed, celebratory theme, and dynamic Discord timestamps
- **`src/services/tests/pvpReminderService.test.ts`** — Added new season warning to test fixture, cron calculation test, embed building test, updated job count assertions and config validation

## Technical Details
- `minutesBefore: 0` schedules the cron at exactly the season end time (`59 14 * * 0`)
- `getNextSeasonEndTimestamp()` naturally returns 7 days ahead when called at season end, so the "Next Season Ends" field shows the correct future date
- No service code or interface changes required — the system is already generic enough

## Testing
- [x] Type check passes (`bunx tsc --noEmit`)
- [x] All 31 PVP reminder tests pass (`bun run test:run -- pvpReminderService`)
- [ ] Manual verification in dev mode (3-minute interval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)