### PR TITLE
feat: add coupon alert DM notifications for new codes

### DIFF
--- a/src/bootstrap/serviceInitializer.ts
+++ b/src/bootstrap/serviceInitializer.ts
@@ -9,6 +9,7 @@ import { YouTubeNotificationScheduler } from '../services/youtubeNotificationSch
 import { PvpReminderService } from '../services/pvpReminderService.js';
 import { pvpReminderServiceConfig } from '../utils/data/pvpEventsConfig.js';
 import { getNotificationSubscriptionService } from '../services/notificationSubscriptionService.js';
+import { GACHA_GAMES } from '../utils/data/gachaGamesConfig.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -81,6 +82,17 @@ export async function initializeServices(bot: Client): Promise<void> {
                     thumbnailUrl: gameConfig.embedConfig.thumbnail,
                 });
             }
+        }
+
+        // Register coupon alert notification types for each gacha game
+        for (const game of Object.values(GACHA_GAMES)) {
+            notificationService.registerNotificationType({
+                type: `coupon-alert:${game.id}`,
+                displayName: `${game.shortName} Coupon Alerts`,
+                description: `New coupon code alerts for ${game.name}`,
+                embedColor: game.embedColor,
+                thumbnailUrl: game.logoPath,
+            });
         }
 
         notificationService.startListening(bot);

--- a/src/services/gachaCouponScheduler.ts
+++ b/src/services/gachaCouponScheduler.ts
@@ -244,9 +244,20 @@ export class GachaCouponScheduler {
 
                 if (result.success) {
                     if (result.newCodes.length > 0) {
-                        // Trigger auto-redemption for new codes with notification enabled
                         const redemptionService = getGachaRedemptionService();
-                        await redemptionService.processGameAutoRedemptions(this.bot, 'bd2', { hasNewCodes: true });
+                        const dataService = getGachaDataService();
+
+                        // Notify subscribers for each new code (DMs + coupon alerts)
+                        for (const code of result.newCodes) {
+                            try {
+                                const coupon = await dataService.getCoupon('bd2', code);
+                                if (coupon) {
+                                    await redemptionService.notifyNewCode(this.bot, coupon);
+                                }
+                            } catch (error) {
+                                logger.error`[BD2 Pulse] Failed to notify for code ${code}: ${error}`;
+                            }
+                        }
                     }
                 } else {
                     logger.error`[BD2 Pulse] Scraping failed: ${result.error}`;

--- a/src/services/gachaRedemptionService.ts
+++ b/src/services/gachaRedemptionService.ts
@@ -3,6 +3,7 @@ import pLimit from 'p-limit';
 import { getGachaDataService } from './gachaDataService.js';
 import { getReactionConfirmationService, CONFIRMATION_EMOJIS } from './reactionConfirmationService.js';
 import { getChannelMonitorService } from './channelMonitorService.js';
+import { getNotificationSubscriptionService } from './notificationSubscriptionService.js';
 import {
     RedemptionResult,
     GachaCoupon,
@@ -1135,6 +1136,34 @@ export class GachaRedemptionService {
         // Batch write redemption history
         if (historyEntries.length > 0) {
             await dataService.addBatchRedemptionHistory(historyEntries);
+        }
+
+        // Send notification to coupon-alert subscribers (separate from gacha subscriptions)
+        await this.sendCouponAlertNotification(bot, coupon, embed);
+    }
+
+    /**
+     * Send a coupon alert to subscribers of the coupon-alert notification type.
+     * This is separate from gacha subscriptions — users can get alerts without having
+     * a game account set up. Reuses the embed already built by notifyNewCode().
+     */
+    private async sendCouponAlertNotification(bot: Client, coupon: GachaCoupon, embed: EmbedBuilder): Promise<void> {
+        const notificationType = `coupon-alert:${coupon.gameId}`;
+        const notificationService = getNotificationSubscriptionService();
+
+        // Only send if this notification type is registered
+        if (!notificationService.getNotificationType(notificationType)) return;
+
+        try {
+            // Clone the embed to avoid mutating the original (sendNotification appends footer/fields)
+            const alertEmbed = EmbedBuilder.from(embed.toJSON());
+            const result = await notificationService.sendNotification(bot, notificationType, alertEmbed);
+
+            if (result.sent > 0 || result.failed > 0) {
+                logger.debug`[Gacha] Coupon alert DMs for ${coupon.gameId} code ${coupon.code}: sent=${result.sent}, failed=${result.failed}, dmDisabled=${result.dmDisabled}`;
+            }
+        } catch (error) {
+            logger.error`[Gacha] Failed to send coupon alert DMs for ${coupon.gameId}: ${error}`;
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `coupon-alert:{gameId}` notification types so users can get DM alerts when new coupon codes are added
- Fixes BD2 scraper to notify subscribers (was only triggering auto-redemption, skipping notification-only users)

## Changes
- **gachaRedemptionService.ts**: New `sendCouponAlertNotification()` method called at end of `notifyNewCode()` — sends via notification framework alongside existing gacha subscriber DMs
- **gachaCouponScheduler.ts**: BD2 scraper now calls `notifyNewCode()` for each newly scraped code (previously only called `processGameAutoRedemptions`)
- **serviceInitializer.ts**: Registers `coupon-alert:bd2` and `coupon-alert:lost-sword` notification types from gacha game configs

## How it works
1. New code added (mod, scraper, or channel monitor) → `notifyNewCode()` fires
2. Existing gacha subscribers get their usual DMs (notification-only or auto-redeem)
3. **New:** `coupon-alert:{gameId}` subscribers also get a DM via the notification framework
4. Users subscribe/unsubscribe via ✉️/❌ reactions (same UX as PVP and daily reset notifications)

## Bug fix
BD2 scraper previously only called `processGameAutoRedemptions()` when new codes were found, which skipped notification-only subscribers entirely. Now calls `notifyNewCode()` per code, which handles both subscriber types.

## Testing
- [x] 829 tests pass (30 files)
- [x] TypeScript compiles with 0 errors
- [x] Gacha redemption service tests pass (40 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)