### PR TITLE
perf: cache S3 ListObjectsV2 calls on hot paths

### DIFF
--- a/src/commands/utils/gachaPuller.ts
+++ b/src/commands/utils/gachaPuller.ts
@@ -4,6 +4,9 @@ import { CONSTANTS } from './gachaConstants';
 import { GachaGameConfig, PullResult } from './gachaTypes';
 import { NikkeUtil } from './nikkeUtil.js';
 
+const RARITY_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+const rarityCache = new Map<string, { files: string[]; expiry: number }>();
+
 export class GachaPuller {
     static async pull(pullType: string, gameConfig: GachaGameConfig): Promise<PullResult[]> {
         const pulls = pullType === 'multi' ? 10 : 1;
@@ -30,12 +33,15 @@ export class GachaPuller {
         return Object.keys(rates)[0];
     }
 
-    private static async getRandomCharacter(
-        game: string,
-        rarity: string
-    ): Promise<PullResult> {
+    private static async getRarityFiles(game: string, rarity: string): Promise<string[]> {
+        const cacheKey = `${game}/${rarity.toLowerCase()}`;
+        const cached = rarityCache.get(cacheKey);
+
+        if (cached && Date.now() < cached.expiry) {
+            return cached.files;
+        }
+
         const prefix = `gacha/${game}/rarities/${rarity.toLowerCase()}`;
-        
         const response = await s3Client.send(new ListObjectsV2Command({
             Bucket: process.env.S3BUCKET,
             Prefix: prefix,
@@ -53,8 +59,18 @@ export class GachaPuller {
             throw new Error(`No valid character files found for ${rarity}`);
         }
 
+        rarityCache.set(cacheKey, { files: validFiles, expiry: Date.now() + RARITY_CACHE_TTL });
+        return validFiles;
+    }
+
+    private static async getRandomCharacter(
+        game: string,
+        rarity: string
+    ): Promise<PullResult> {
+        const prefix = `gacha/${game}/rarities/${rarity.toLowerCase()}`;
+        const validFiles = await this.getRarityFiles(game, rarity);
         const randomFile = validFiles[Math.floor(Math.random() * validFiles.length)];
-        
+
         return {
             rarity,
             name: NikkeUtil.fileToCharacterName(randomFile),

--- a/src/utils/cdn/mediaManager.ts
+++ b/src/utils/cdn/mediaManager.ts
@@ -5,6 +5,10 @@ import { logger } from "../logger.js";
 // Track recently sent media keys per guild and prefix
 const recentlySentMediaKeys: Map<string, Map<string, string[]>> = new Map();
 
+// Cache S3 ListObjectsV2 results per prefix (1-hour TTL — media files change rarely)
+const MEDIA_LIST_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+const mediaListCache = new Map<string, { keys: string[]; expiry: number }>();
+
 /**
  * Retrieves and filters media from the CDN based on specified criteria, with guild-based tracking 
  * to prevent recent repeats within each server.
@@ -52,6 +56,14 @@ async function fetchAndFilterMediaKeys(
     maxSizeMB: number,
     extensions: string[]
 ): Promise<string[]> {
+    // Build cache key from all filter params
+    const cacheKey = `${prefix}|${maxSizeMB}|${extensions.join(',')}`;
+    const cached = mediaListCache.get(cacheKey);
+
+    if (cached && Date.now() < cached.expiry) {
+        return cached.keys;
+    }
+
     const response = await s3Client.send(new ListObjectsV2Command({
         Bucket: S3_BUCKET,
         Prefix: prefix,
@@ -67,7 +79,7 @@ async function fetchAndFilterMediaKeys(
             return sizeInMB <= maxSizeMB;
         })
         .map(obj => obj.Key)
-        .filter(key => key && (extensions.length === 0 || extensions.some(ext => 
+        .filter(key => key && (extensions.length === 0 || extensions.some(ext =>
             key.toLowerCase().endsWith(ext)
         )));
 
@@ -75,7 +87,9 @@ async function fetchAndFilterMediaKeys(
         throw new Error(`No valid media files found under ${maxSizeMB}MB with extensions: ${extensions.join(', ')}`);
     }
 
-    return mediaKeys.filter(key => key !== undefined) as string[];
+    const result = mediaKeys.filter(key => key !== undefined) as string[];
+    mediaListCache.set(cacheKey, { keys: result, expiry: Date.now() + MEDIA_LIST_CACHE_TTL });
+    return result;
 }
 
 async function getRandomUniqueKey(


### PR DESCRIPTION
## Summary
- Adds in-memory TTL caching for S3 ListObjectsV2 calls on two hot-path services that previously had zero caching

## Changes
- **GachaPuller**: 10-minute TTL cache for rarity file lists — `/gacha multi` drops from 10 S3 calls to 1 per cache window
- **MediaManager**: 1-hour TTL cache for media file lists — eliminates redundant S3 LIST calls for CDN media fetches (scarrow mentions, daily reset images, etc.)

## Impact
- ~90% reduction in S3 LIST operations for gacha commands
- Eliminates all redundant media LIST calls within 1-hour windows
- No data freshness risk: character lists and media files change infrequently

## Testing
- [x] 838 tests pass (30 files)
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)