### PR TITLE
fix: reset unbounded command usage stats on cleanup interval

### DIFF
--- a/src/utils/chatCommandRateLimiter.ts
+++ b/src/utils/chatCommandRateLimiter.ts
@@ -148,5 +148,10 @@ export class ChatCommandRateLimiter {
             if (Object.keys(this.usage[guildId]).length === 0) delete this.usage[guildId];
             if (this.violators[guildId] && Object.keys(this.violators[guildId]).length === 0) delete this.violators[guildId];
         });
+
+        // Reset command usage stats (these are display-only and grow without bounds)
+        this.commandUsage = {};
+        this.guildCommandCount = {};
+        this.globalCommandCount = 0;
     }
 } 


### PR DESCRIPTION
## Summary
Fixes unbounded memory growth in `ChatCommandRateLimiter` — three data structures grew indefinitely without cleanup.

## Changes
- **chatCommandRateLimiter.ts**: Resets `commandUsage`, `guildCommandCount`, and `globalCommandCount` every 2 hours alongside existing usage/violator cleanup

## Context
Audit found that `messageTypeMap` in NotificationSubscriptionService already has max-size cleanup (evicts oldest half at 500 entries). The only truly unbounded structures were in the rate limiter — these are display-only stats used by `/spam stats` and don't need to persist across cleanup windows.

## Testing
- [x] 838 tests pass (30 files)
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)