### PR TITLE
fix: replace raw notification type slugs with display names in footers

### DIFF
--- a/src/services/notificationSubscriptionService.ts
+++ b/src/services/notificationSubscriptionService.ts
@@ -142,13 +142,12 @@ export class NotificationSubscriptionService {
 
         if (subscribers.length === 0) return result;
 
-        // Append footer tag for unsubscribe parsing, ensure Rapi thumbnail icon
+        // Set branded footer with display name (used for unsubscribe type lookup)
         const ASSET_URLS = getAssetUrls();
-        const footerText = embed.data.footer?.text || 'Rapi BOT Notifications';
-        const taggedFooter = `${footerText} | [n:${notificationType}]`;
+        const displayName = typeConfig?.displayName || notificationType;
         const footerIcon = embed.data.footer?.icon_url || ASSET_URLS.rapiBot.thumbnail;
         embed.setFooter({
-            text: taggedFooter,
+            text: `Rapi BOT Notifications • ${displayName}`,
             ...(footerIcon?.startsWith('http') ? { iconURL: footerIcon } : {}),
         });
 
@@ -308,7 +307,7 @@ export class NotificationSubscriptionService {
                 .setDescription(result.message)
                 .setColor(result.success ? 0x00FF00 : 0xFFA500)
                 .setFooter({
-                    text: `Rapi BOT Notifications | [n:${notificationType}]`,
+                    text: `Rapi BOT Notifications • ${typeConfig?.displayName || notificationType}`,
                     ...(confirmFooterIcon?.startsWith('http') ? { iconURL: confirmFooterIcon } : {}),
                 })
                 .setTimestamp();
@@ -384,18 +383,33 @@ export class NotificationSubscriptionService {
     }
 
     /**
-     * Parse notification type from message embed footer tag [type:...]
+     * Parse notification type from message embed footer.
+     * Matches the display name after "Rapi BOT Notifications • " against the type registry.
+     * Falls back to legacy [n:type] tag parsing for older DMs.
      */
     private parseNotificationTypeFromEmbed(message: Message): NotificationType | undefined {
         const embed = message.embeds[0];
         if (!embed?.footer?.text) return undefined;
 
-        const match = embed.footer.text.match(NOTIFICATION_TYPE_FOOTER_REGEX);
-        if (!match) return undefined;
+        const footerText = embed.footer.text;
 
-        const type = match[1];
-        // Only handle types we know about
-        return this.typeRegistry.has(type) ? type : undefined;
+        // Try display name lookup: "Rapi BOT Notifications • Display Name"
+        const displayNameMatch = footerText.match(/Rapi BOT Notifications\s*[•·|]\s*(.+)/);
+        if (displayNameMatch) {
+            const displayName = displayNameMatch[1].trim();
+            for (const [type, config] of this.typeRegistry) {
+                if (config.displayName === displayName) return type;
+            }
+        }
+
+        // Legacy fallback: parse [n:type] tag for older DMs
+        const legacyMatch = footerText.match(NOTIFICATION_TYPE_FOOTER_REGEX);
+        if (legacyMatch) {
+            const type = legacyMatch[1];
+            return this.typeRegistry.has(type) ? type : undefined;
+        }
+
+        return undefined;
     }
 }
 

--- a/src/services/tests/notificationSubscriptionService.test.ts
+++ b/src/services/tests/notificationSubscriptionService.test.ts
@@ -170,7 +170,7 @@ describe('NotificationSubscriptionService', () => {
             expect(sendDMSafe).not.toHaveBeenCalled();
         });
 
-        it('should append footer tag with notification type', async () => {
+        it('should set branded footer with display name', async () => {
             vi.mocked(mockDataService.getSubscribers).mockResolvedValueOnce([
                 { discordId: 'user1', guildId: 'g1', notificationType: 'pvp-warning:bd2-mirror-wars', subscribedAt: '' },
             ]);
@@ -187,11 +187,11 @@ describe('NotificationSubscriptionService', () => {
 
             await service.sendNotification(mockBot, 'pvp-warning:bd2-mirror-wars', embed);
 
-            // Check the embed passed to sendDMSafe has the footer tag
+            // Check the embed passed to sendDMSafe has branded footer with display name
             const call = vi.mocked(sendDMSafe).mock.calls[0];
             const sentEmbed = call[1].embeds[0];
-            expect(sentEmbed.data.footer?.text).toContain('[n:pvp-warning:bd2-mirror-wars]');
-            expect(sentEmbed.data.footer?.text).toContain('Original footer');
+            expect(sentEmbed.data.footer?.text).toContain('Rapi BOT Notifications');
+            expect(sentEmbed.data.footer?.text).toContain('BD2 Mirror Wars PVP');
         });
 
         it('should count failures when sendDMSafe returns null', async () => {
@@ -239,7 +239,19 @@ describe('NotificationSubscriptionService', () => {
     });
 
     describe('Footer Tag Parsing', () => {
-        it('should parse notification type from embed footer', () => {
+        it('should parse notification type from display name in footer', () => {
+            const parseMethod = (service as any).parseNotificationTypeFromEmbed.bind(service);
+
+            const message = {
+                embeds: [{
+                    footer: { text: 'Rapi BOT Notifications • BD2 Mirror Wars PVP' },
+                }],
+            } as any;
+
+            expect(parseMethod(message)).toBe('pvp-warning:bd2-mirror-wars');
+        });
+
+        it('should parse notification type from legacy [n:type] footer tag', () => {
             const parseMethod = (service as any).parseNotificationTypeFromEmbed.bind(service);
 
             const message = {


### PR DESCRIPTION
## Summary
Replaces ugly raw slugs like `[n:daily-reset:chaos-zero-nightmare]` with clean display names in notification DM footers.

## Before
```
[n:daily-reset:chaos-zero-nightmare] • Today at 1:32 PM
```

## After
```
🔸 Rapi BOT Notifications • Chaos Zero Nightmare Daily Reset • Today at 1:32 PM
```

## Changes
- **notificationSubscriptionService.ts**:
  - `sendNotification()` — footer now uses `Rapi BOT Notifications • {displayName}` format
  - `handleSubscribeReaction()` — confirmation DMs use same format
  - `parseNotificationTypeFromEmbed()` — reverse-lookups display name → type from registry, with legacy `[n:]` tag fallback for older DMs still in users' inboxes

## Backward compatibility
Older DMs that still have the `[n:type]` footer tag will continue to work — the parser tries display name lookup first, then falls back to legacy tag parsing.

## Testing
- [x] 839 tests pass (30 files, +1 new test for display name parsing)
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)