### PR TITLE
feat: wire asset sync scheduler into service initializer

### DIFF
--- a/src/bootstrap/serviceInitializer.ts
+++ b/src/bootstrap/serviceInitializer.ts
@@ -10,6 +10,7 @@ import { PvpReminderService } from '../services/pvpReminderService.js';
 import { pvpReminderServiceConfig } from '../utils/data/pvpEventsConfig.js';
 import { getNotificationSubscriptionService } from '../services/notificationSubscriptionService.js';
 import { GACHA_GAMES } from '../utils/data/gachaGamesConfig.js';
+import { AssetSyncScheduler } from '../services/assetSync/index.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -103,6 +104,13 @@ export async function initializeServices(bot: Client): Promise<void> {
         const pvpReminderService = new PvpReminderService(bot, pvpReminderServiceConfig);
         pvpReminderService.initializeSchedules();
         logger.info`PVP reminder service initialized`;
+
+        // Initialize asset sync scheduler (periodic character art sync from external APIs)
+        const assetSyncScheduler = new AssetSyncScheduler({
+            devSyncIntervalMinutes: 10,
+        });
+        assetSyncScheduler.initializeSchedules();
+        logger.info`Asset sync scheduler initialized`;
 
         logger.info`All services initialized successfully`;
     } catch (error) {


### PR DESCRIPTION
## Summary
Registers the `AssetSyncScheduler` at boot so periodic asset syncs run automatically.

## Changes
- **serviceInitializer.ts**: Adds `AssetSyncScheduler` initialization after PVP reminder service
- Cron: every 6h prod, every 10min dev
- Startup: logs last sync time from manifest (no blocking sync)

## First Run
After merging and deploying, run the initial sync manually:
```bash
docker exec rapibot bun run scripts/sync-assets.ts --game nikke
```

After that, the cron handles everything automatically.

## Testing
- [x] 863 tests pass (32 files)
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)