### PR TITLE
feat: add Fandom wiki fallback for missing DotGG character art

### DIFF
--- a/src/services/assetSync/assetSyncService.ts
+++ b/src/services/assetSync/assetSyncService.ts
@@ -145,10 +145,19 @@ export class AssetSyncService {
                 }
 
                 try {
-                    // Download image
-                    const imageResponse = await fetch(character.imageUrl);
+                    // Download image — try primary URL, then fallback on 404
+                    let imageResponse = await fetch(character.imageUrl);
+
+                    if (!imageResponse.ok && imageResponse.status === 404 && provider.getFallbackImageUrl) {
+                        const fallbackUrl = await provider.getFallbackImageUrl(character);
+                        if (fallbackUrl) {
+                            logger.debug`[AssetSync] ${gameName}: primary 404 for ${character.name}, trying fallback`;
+                            imageResponse = await fetch(fallbackUrl);
+                        }
+                    }
+
                     if (!imageResponse.ok) {
-                        throw new Error(`HTTP ${imageResponse.status} downloading ${character.imageUrl}`);
+                        throw new Error(`HTTP ${imageResponse.status} downloading ${character.name}`);
                     }
 
                     const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
@@ -158,19 +167,25 @@ export class AssetSyncService {
                         throw new Error(`Image too large: ${imageBuffer.length} bytes (max ${MAX_IMAGE_SIZE_BYTES})`);
                     }
 
-                    // Validate WebP magic bytes: RIFF header + WEBP marker
-                    if (imageBuffer.length < 12 ||
-                        imageBuffer.toString('ascii', 0, 4) !== 'RIFF' ||
-                        imageBuffer.toString('ascii', 8, 12) !== 'WEBP') {
-                        throw new Error('Downloaded file is not a valid WebP image');
+                    // Validate image format (WebP or PNG)
+                    const isWebP = imageBuffer.length >= 12 &&
+                        imageBuffer.toString('ascii', 0, 4) === 'RIFF' &&
+                        imageBuffer.toString('ascii', 8, 12) === 'WEBP';
+                    const isPNG = imageBuffer.length >= 4 &&
+                        imageBuffer[0] === 0x89 && imageBuffer[1] === 0x50 &&
+                        imageBuffer[2] === 0x4E && imageBuffer[3] === 0x47;
+
+                    if (!isWebP && !isPNG) {
+                        throw new Error('Downloaded file is not a valid image (expected WebP or PNG)');
                     }
 
                     // Upload to S3
+                    const contentType = isPNG ? 'image/png' : 'image/webp';
                     await s3Client.send(new PutObjectCommand({
                         Bucket: S3_BUCKET,
                         Key: s3Key,
                         Body: imageBuffer,
-                        ContentType: 'image/webp',
+                        ContentType: contentType,
                         ACL: 'public-read',
                     }));
 

--- a/src/services/assetSync/providers/nikkeAssetProvider.ts
+++ b/src/services/assetSync/providers/nikkeAssetProvider.ts
@@ -4,6 +4,7 @@ import { logger } from '../../../utils/logger.js';
 
 const NIKKE_API_URL = 'https://api.dotgg.gg/nikke/characters/';
 const NIKKE_IMAGE_BASE = 'https://static.dotgg.gg/nikke/characters';
+const FANDOM_API_BASE = 'https://nikke-goddess-of-victory-international.fandom.com/api.php';
 
 interface DotGGCharacter {
     name: string;
@@ -51,6 +52,77 @@ export class NikkeAssetProvider implements GameAssetProvider {
 
     slugifyName(name: string): string {
         return slugify(name);
+    }
+
+    /**
+     * Fallback: search the Fandom wiki for full-body art (_FB.png) when DotGG 404s.
+     * Uses the MediaWiki allimages API to search by character name prefix.
+     */
+    async getFallbackImageUrl(character: CharacterAsset): Promise<string | null> {
+        try {
+            const baseName = character.name.split(':')[0].trim().replace(/ /g, '_');
+
+            const params = new URLSearchParams({
+                action: 'query',
+                list: 'allimages',
+                aiprefix: baseName,
+                ailimit: '50',
+                format: 'json',
+            });
+
+            const response = await fetch(`${FANDOM_API_BASE}?${params}`, {
+                headers: { 'User-Agent': 'RapiBot/1.0 (Discord Bot)' },
+            });
+
+            if (!response.ok) return null;
+
+            const data = await response.json() as {
+                query?: { allimages?: Array<{ name: string }> };
+            };
+
+            const allImages = data.query?.allimages || [];
+            const fbImages = allImages
+                .filter(img => img.name.endsWith('_FB.png'))
+                .map(img => img.name);
+
+            if (fbImages.length === 0) return null;
+
+            // Best match: exact base name, otherwise first FB image found
+            const exactMatch = fbImages.find(f => f === `${baseName}_FB.png`);
+            const bestMatch = exactMatch || fbImages[0];
+
+            // Resolve actual URL via imageinfo API
+            const infoParams = new URLSearchParams({
+                action: 'query',
+                titles: `File:${bestMatch}`,
+                prop: 'imageinfo',
+                iiprop: 'url',
+                format: 'json',
+            });
+
+            const infoResponse = await fetch(`${FANDOM_API_BASE}?${infoParams}`, {
+                headers: { 'User-Agent': 'RapiBot/1.0 (Discord Bot)' },
+            });
+
+            if (!infoResponse.ok) return null;
+
+            const infoData = await infoResponse.json() as {
+                query?: { pages?: Record<string, { imageinfo?: Array<{ url: string }> }> };
+            };
+
+            const pages = infoData.query?.pages || {};
+            for (const page of Object.values(pages)) {
+                const url = page.imageinfo?.[0]?.url;
+                if (url) {
+                    logger.debug`[AssetSync:NIKKE] Fandom fallback for ${character.name}: ${bestMatch}`;
+                    return url;
+                }
+            }
+        } catch (error) {
+            logger.warn`[AssetSync:NIKKE] Fandom fallback failed for ${character.name}: ${error}`;
+        }
+
+        return null;
     }
 
     async fetchCharacterList(): Promise<CharacterAsset[]> {

--- a/src/services/assetSync/types.ts
+++ b/src/services/assetSync/types.ts
@@ -43,6 +43,12 @@ export interface GameAssetProvider {
      * Convert a character display name to a slugified filename (without extension).
      */
     slugifyName(name: string): string;
+
+    /**
+     * Optional: resolve a fallback image URL when the primary imageUrl returns 404.
+     * Return null if no fallback is available.
+     */
+    getFallbackImageUrl?(character: CharacterAsset): Promise<string | null>;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds the Fandom wiki as a fallback image source when DotGG returns 404 for character art. Resolves 26 missing characters from the initial sync.

## How it works
1. Primary: try `static.dotgg.gg/nikke/characters/c{code}_00.webp`
2. On 404: search Fandom wiki MediaWiki API for `{CharacterName}_FB.png` full-body art
3. Fandom API resolves the hash-based CDN URL automatically
4. Accepts both WebP (DotGG) and PNG (Fandom) formats

## Changes
- **types.ts**: Added optional `getFallbackImageUrl()` to `GameAssetProvider` interface
- **nikkeAssetProvider.ts**: Implements Fandom wiki search via `allimages` + `imageinfo` MediaWiki APIs
- **assetSyncService.ts**: Tries fallback on 404, validates WebP and PNG formats, sets correct ContentType

## Testing
- [x] 863 tests pass (32 files)
- [x] TypeScript compiles with 0 errors

After merge, re-run sync to pick up the 26 missing characters:
```bash
docker exec rapibot bun run scripts/sync-assets.ts --game nikke
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)