### PR TITLE
fix: exclude collab characters from gacha pull pool

### DIFF
--- a/src/commands/utils/gachaPuller.ts
+++ b/src/commands/utils/gachaPuller.ts
@@ -1,11 +1,17 @@
-import { ListObjectsV2Command } from "@aws-sdk/client-s3";
-import { s3Client } from '../../utils/cdn';
+import { GetObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import { s3Client, S3_BUCKET } from '../../utils/cdn/config.js';
 import { CONSTANTS } from './gachaConstants';
 import { GachaGameConfig, PullResult } from './gachaTypes';
 import { NikkeUtil } from './nikkeUtil.js';
+import { GameManifest } from '../../services/assetSync/types.js';
+import { logger } from '../../utils/logger.js';
 
 const RARITY_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
 const rarityCache = new Map<string, { files: string[]; expiry: number }>();
+
+// Manifest cache (collab exclusion list)
+const MANIFEST_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+let manifestCache: { collabSlugs: Set<string>; expiry: number } | null = null;
 
 export class GachaPuller {
     static async pull(pullType: string, gameConfig: GachaGameConfig): Promise<PullResult[]> {
@@ -33,6 +39,41 @@ export class GachaPuller {
         return Object.keys(rates)[0];
     }
 
+    /**
+     * Load collab slugs from the manifest to exclude from the gacha pool.
+     */
+    private static async getCollabSlugs(game: string): Promise<Set<string>> {
+        if (manifestCache && Date.now() < manifestCache.expiry) {
+            return manifestCache.collabSlugs;
+        }
+
+        const collabSlugs = new Set<string>();
+
+        try {
+            const response = await s3Client.send(new GetObjectCommand({
+                Bucket: S3_BUCKET,
+                Key: `assets/gacha/${game}/manifest.json`,
+            }));
+
+            const body = await response.Body?.transformToString();
+            if (body) {
+                const manifest: GameManifest = JSON.parse(body);
+                for (const entry of manifest.characters) {
+                    if (entry.collab) {
+                        // Match the filename as it appears in S3 (slug.webp or slug.png)
+                        collabSlugs.add(`${entry.slug}.webp`);
+                        collabSlugs.add(`${entry.slug}.png`);
+                    }
+                }
+            }
+        } catch {
+            // No manifest or read error — don't exclude anything
+        }
+
+        manifestCache = { collabSlugs, expiry: Date.now() + MANIFEST_CACHE_TTL };
+        return collabSlugs;
+    }
+
     private static async getRarityFiles(game: string, rarity: string): Promise<string[]> {
         const cacheKey = `${game}/${rarity.toLowerCase()}`;
         const cached = rarityCache.get(cacheKey);
@@ -41,9 +82,9 @@ export class GachaPuller {
             return cached.files;
         }
 
-        const prefix = `gacha/${game}/rarities/${rarity.toLowerCase()}`;
+        const prefix = `assets/gacha/${game}/rarities/${rarity.toLowerCase()}`;
         const response = await s3Client.send(new ListObjectsV2Command({
-            Bucket: process.env.S3BUCKET,
+            Bucket: S3_BUCKET,
             Prefix: prefix,
         }));
 
@@ -51,9 +92,18 @@ export class GachaPuller {
             throw new Error(`No characters found for ${rarity}`);
         }
 
+        // Get collab exclusion list
+        const collabSlugs = await this.getCollabSlugs(game);
+
         const validFiles = response.Contents
             .map(obj => obj.Key?.split('/').pop())
-            .filter((name): name is string => name?.endsWith('.webp') ?? false);
+            .filter((name): name is string => {
+                if (!name) return false;
+                if (!name.endsWith('.webp') && !name.endsWith('.png')) return false;
+                // Exclude collab characters from the pool
+                if (collabSlugs.has(name)) return false;
+                return true;
+            });
 
         if (!validFiles.length) {
             throw new Error(`No valid character files found for ${rarity}`);
@@ -67,7 +117,7 @@ export class GachaPuller {
         game: string,
         rarity: string
     ): Promise<PullResult> {
-        const prefix = `gacha/${game}/rarities/${rarity.toLowerCase()}`;
+        const prefix = `assets/gacha/${game}/rarities/${rarity.toLowerCase()}`;
         const validFiles = await this.getRarityFiles(game, rarity);
         const randomFile = validFiles[Math.floor(Math.random() * validFiles.length)];
 
@@ -77,4 +127,4 @@ export class GachaPuller {
             imageUrl: `${CONSTANTS.cdnDomainUrl}/${prefix}/${randomFile}`
         };
     }
-} 
+}

--- a/src/commands/utils/nikkeUtil.ts
+++ b/src/commands/utils/nikkeUtil.ts
@@ -1,6 +1,6 @@
 export const NikkeUtil = {
     fileToCharacterName(fileName: string): string {
-        const baseName = fileName.replace(/\.webp$/, '');
+        const baseName = fileName.replace(/\.(webp|png)$/, '');
         return baseName
             .split('-')
             .map((part, i) => this.capitalizeWord(part))

--- a/src/services/assetSync/assetSyncService.ts
+++ b/src/services/assetSync/assetSyncService.ts
@@ -125,6 +125,11 @@ export class AssetSyncService {
                 if (mode === 'incremental') {
                     const existing = manifestMap.get(character.code);
                     if (existing) {
+                        // Update collab flag even when skipping (in case it changed)
+                        if (character.collab !== undefined && existing.collab !== character.collab) {
+                            existing.collab = character.collab || undefined;
+                        }
+
                         // Check if image has changed via HEAD request (Content-Length comparison)
                         // If HEAD fails or Content-Length unavailable, trust manifest and skip
                         try {
@@ -198,6 +203,7 @@ export class AssetSyncService {
                         imageSize: imageBuffer.length,
                         s3Key,
                         syncedAt: new Date().toISOString(),
+                        ...(character.collab ? { collab: true } : {}),
                     };
 
                     manifestMap.set(character.code, entry);

--- a/src/services/assetSync/providers/nikkeAssetProvider.ts
+++ b/src/services/assetSync/providers/nikkeAssetProvider.ts
@@ -160,6 +160,7 @@ export class NikkeAssetProvider implements GameAssetProvider {
                 code,
                 sourceRarity: char.rarity,
                 imageUrl: `${NIKKE_IMAGE_BASE}/${code}_00.webp`,
+                collab: char.manufacturer === 'Abnormal',
                 metadata: {
                     manufacturer: char.manufacturer,
                 },

--- a/src/services/assetSync/types.ts
+++ b/src/services/assetSync/types.ts
@@ -10,6 +10,8 @@ export interface CharacterAsset {
     sourceRarity: string;
     /** Full URL to download the image */
     imageUrl: string;
+    /** Whether this is a collab unit (excluded from gacha pool but still synced) */
+    collab?: boolean;
     /** Extra metadata from the provider (e.g. manufacturer for Pilgrim detection) */
     metadata?: Record<string, unknown>;
 }
@@ -69,6 +71,8 @@ export interface ManifestEntry {
     s3Key: string;
     /** ISO timestamp of when this character was last synced */
     syncedAt: string;
+    /** Whether this character is a collab unit (excluded from gacha pool) */
+    collab?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
Excludes collaboration characters from the gacha pull pool while keeping their images synced to S3.

## Problem
Collab characters (NieR, Evangelion, Lycoris Recoil, Chainsaw Man, Re:Zero, Resident Evil, Stellar Blade) were being included in the gacha pull pool. These limited-time crossover units shouldn't appear in standard pulls.

## Solution
- **Manifest-driven exclusion**: NIKKE provider flags `manufacturer === "Abnormal"` as `collab: true`
- **GachaPuller reads manifest**: Loads collab slugs and filters them from the pool (10min cache)
- **Incremental-safe**: Re-running sync updates the collab flag on already-synced characters

## Changes
- **types.ts**: Added `collab?: boolean` to `CharacterAsset` and `ManifestEntry`
- **nikkeAssetProvider.ts**: Flags Abnormal manufacturer as collab
- **assetSyncService.ts**: Persists collab flag, updates on incremental skip
- **gachaPuller.ts**: Reads from `assets/gacha/` path, excludes collabs via manifest, accepts PNG
- **nikkeUtil.ts**: Handles `.png` extension

## After deploy
Re-run sync to update manifest with collab flags:
```bash
docker exec rapibot bun run scripts/sync-assets.ts --game nikke
```

## Testing
- [x] 863 tests pass (32 files)
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)