### PR TITLE
fix: exclude IncorrectUser errors from circuit breaker

### DIFF
--- a/src/services/gachaRedemptionService.ts
+++ b/src/services/gachaRedemptionService.ts
@@ -206,7 +206,9 @@ class BD2RedemptionHandler implements GameRedemptionHandler {
                 const errorCode = data.error || 'Unknown';
                 const errorMessage = ERROR_MESSAGES[errorCode as CommonRedemptionError] || `Redemption failed: ${errorCode}`;
                 // Don't count business logic errors as circuit breaker failures
-                if (errorCode !== 'InvalidCode' && errorCode !== 'AlreadyUsed' && errorCode !== 'ExpiredCode') {
+                // These are user/data issues, not API outages
+                const nonCircuitErrors = ['InvalidCode', 'AlreadyUsed', 'ExpiredCode', 'IncorrectUser', 'ValidationFailed'];
+                if (!nonCircuitErrors.includes(errorCode)) {
                     circuitBreaker.recordFailure(this.gameId);
                 }
                 return this.createResult(code, false, errorMessage, errorCode);


### PR DESCRIPTION
## Problem
Three users with bad BD2 account IDs (`ThrainX7`, `10001369`, `16724340`) return `IncorrectUser` on every auto-redemption attempt. These errors were counting toward the circuit breaker threshold (5 failures), tripping it every 6 hours and **blocking redemption for all users**.

## Fix
Added `IncorrectUser` and `ValidationFailed` to the list of business logic errors excluded from the circuit breaker. Only actual API outages (HTTP errors, timeouts, rate limits) should trip it.

## Before
```
InvalidCode, AlreadyUsed, ExpiredCode → excluded
IncorrectUser → counted as failure → trips breaker
```

## After
```
InvalidCode, AlreadyUsed, ExpiredCode, IncorrectUser, ValidationFailed → excluded
```

## Testing
- [x] 863 tests pass
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)