### PR TITLE
fix: word-boundary assertions for slur matcher (Scunthorpe problem)

### DIFF
--- a/src/services/slurModerationService.ts
+++ b/src/services/slurModerationService.ts
@@ -264,8 +264,14 @@ export class SlurModerationService {
             .map(s => s.trim().toLowerCase())
             .filter(s => s.length > 0);
 
+        // Word-boundary assertions (`|...|`) prevent the Scunthorpe problem:
+        // `spic` no longer matches inside `spicy`, `coon` doesn't match `tycoon`,
+        // `paki` doesn't match `Pakistan`, `fag` doesn't match `flag`, etc.
+        // `|` is a literal in obscenity's pattern syntax used only at term
+        // boundaries — strip any embedded pipes from the input as a safety guard
+        // since slur terms shouldn't contain pipes anyway.
         const blacklistedTerms = assignIncrementingIds(
-            normalized.map(s => parseRawPattern(s))
+            normalized.map(s => parseRawPattern(`|${s.replace(/\|/g, '')}|`))
         );
 
         this.termIdToWord = new Map(

--- a/src/services/tests/slurModerationService.test.ts
+++ b/src/services/tests/slurModerationService.test.ts
@@ -238,6 +238,37 @@ describe('SlurModerationService', () => {
         expect(t4).not.toHaveBeenCalled();
     });
 
+    it('does not trigger on substring matches (Scunthorpe problem)', async () => {
+        // Use a list where the placeholders are themselves substrings of common words
+        // to verify word-boundary assertions are doing their job.
+        service.clearCache();
+        const substringProneList = {
+            schemaVersion: 1,
+            lastUpdated: new Date().toISOString(),
+            slurs: ['foo', 'bar'],
+        };
+        mockS3SuccessFor(substringProneList);
+
+        // 'foo' should NOT match in 'foobar', 'fool', 'food', 'foofy'
+        const { timeoutFn: t1 } = await runWith('foobar is a meta term');
+        const { timeoutFn: t2 } = await runWith('don\'t be a fool');
+        const { timeoutFn: t3 } = await runWith('I love food');
+        // 'bar' should NOT match in 'barricade', 'barbecue', 'bartender'
+        const { timeoutFn: t4 } = await runWith('built a barricade');
+        const { timeoutFn: t5 } = await runWith('barbecue tonight');
+        // But the standalone term DOES still match
+        const { timeoutFn: t6 } = await runWith('plain foo here');
+        const { timeoutFn: t7 } = await runWith('walk into a bar');
+
+        expect(t1).not.toHaveBeenCalled();
+        expect(t2).not.toHaveBeenCalled();
+        expect(t3).not.toHaveBeenCalled();
+        expect(t4).not.toHaveBeenCalled();
+        expect(t5).not.toHaveBeenCalled();
+        expect(t6).toHaveBeenCalled();
+        expect(t7).toHaveBeenCalled();
+    });
+
     it('detects leetspeak / case / homoglyph evasion', async () => {
         // Case variation: handled by the recommended transformers
         const { timeoutFn: t1 } = await runWith('FOOSLURBAR is bad');


### PR DESCRIPTION
## Summary
Production caught a false positive: \`i like my spicy mangas\` matched \`spic\` and timed the user out for 30 minutes. Adds word-boundary assertions to the obscenity matcher so substring matches no longer fire.

## Problem
The matcher built terms via \`parseRawPattern(s)\` with no boundary assertions. obscenity's default behavior is "match anywhere," so:
- \`spic\` matched inside \`spicy\` ❌
- \`coon\` would match \`tycoon\` / \`cocoon\` ❌
- \`paki\` would match \`Pakistan\` / \`Pakistani\` ❌
- \`fag\` would match \`flag\` / \`flagging\` ❌

Classic Scunthorpe problem.

## Fix
Wrap each slur with obscenity's \`|...|\` boundary assertions:

\`\`\`ts
normalized.map(s => parseRawPattern(\`|\${s.replace(/\|/g, '')}|\`))
\`\`\`

Verified empirically:

| Input | Before | After |
|---|---|---|
| \`spicy mangas\` | MATCH | OK |
| \`pakistan\` | MATCH | OK |
| \`tycoon\` | MATCH | OK |
| \`flag waving\` | MATCH | OK |
| \`scunthorpe\` | MATCH | OK |
| standalone \`spic\` | MATCH | MATCH |
| \`paki here\` | MATCH | MATCH |

Multi-word terms (\`carpet muncher\`, \`pole smoker\`, \`nig nog\`) still match correctly because the boundaries are at term edges, not internal word breaks.

Pipes are stripped from input as a safety guard — \`|\` is special in obscenity's pattern syntax and isn't part of any legitimate slur.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test:run\` → 900 tests pass (1 new Scunthorpe regression test using \`foo\`/\`bar\` placeholders to verify substring patterns)
- [x] Smoke-tested obscenity boundary syntax against real false positives (spicy, pakistan, tycoon, cocoon, flag, scunthorpe) — all clear
- [ ] Live: re-test the original failing message \`i like my spicy mangas\` → no timeout

## No S3 / config change required
The slur list in S3 is unchanged. This is purely a matcher-build behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)