### PR TITLE
feat: DM offender + delete message on slur detection

### DIFF
--- a/src/services/slurModerationService.ts
+++ b/src/services/slurModerationService.ts
@@ -58,6 +58,8 @@ interface SlurOffenseStore {
     guilds: Record<string, GuildOffenseRecord>;
 }
 
+type ActionResult = { success: true } | { success: false; reason: string };
+
 /* ==========================================================================
  *  Helpers
  * ========================================================================== */
@@ -140,8 +142,15 @@ export class SlurModerationService {
 
             const matchedTerms = this.extractMatchedTerms(matches);
 
-            // Step 8: three independent operations
+            // Step 8: independent action steps — each wrapped so a failure in one
+            // doesn't unwind the others. Order: timeout → DM the offender →
+            // delete the offending message → record offense → post mod-log.
+            // DM is sent BEFORE the message is deleted so the user can see what
+            // they posted that triggered the action (Discord doesn't preserve
+            // message content after deletion in DMs).
             const timeoutResult = await this.applyTimeout(message.member);
+            const dmResult = await this.dmOffender(message, snapshot, matchedTerms);
+            const deleteResult = await this.deleteOffendingMessage(message);
             const offenses = await this.recordOffense(
                 message.guild.id,
                 message.author.id,
@@ -150,7 +159,15 @@ export class SlurModerationService {
                 message.channel.id,
                 message.id
             );
-            await this.postModLog(message, snapshot, matchedTerms, offenses, timeoutResult);
+            await this.postModLog(
+                message,
+                snapshot,
+                matchedTerms,
+                offenses,
+                timeoutResult,
+                dmResult,
+                deleteResult
+            );
         } catch (error) {
             logger.error`[slur-mod] checkMessage failed: ${error}`;
         }
@@ -306,7 +323,7 @@ export class SlurModerationService {
 
     private async applyTimeout(
         member: GuildMember
-    ): Promise<{ success: true } | { success: false; reason: string }> {
+    ): Promise<ActionResult> {
         try {
             await member.timeout(
                 SLUR_MOD_CONFIG.TIMEOUT_DURATION_MS,
@@ -326,6 +343,94 @@ export class SlurModerationService {
                 reason = error?.message || String(error);
             }
             logger.warn`[slur-mod] timeout failed for ${member.user.tag}: ${reason}`;
+            return { success: false, reason };
+        }
+    }
+
+    /* --------------------------------------------------------------------
+     * DM the offender + delete the offending message
+     * -------------------------------------------------------------------- */
+
+    private async dmOffender(
+        message: Message,
+        snapshot: string,
+        matchedTerms: string[]
+    ): Promise<ActionResult> {
+        try {
+            const guildName = message.guild?.name ?? 'the server';
+            const channelMention = `<#${message.channel.id}>`;
+            const previewLength = SLUR_MOD_CONFIG.MESSAGE_PREVIEW_LENGTH;
+            const truncated =
+                snapshot.length > previewLength
+                    ? `${snapshot.slice(0, previewLength)}…`
+                    : snapshot;
+            // Defang inner spoiler markers so the outer ||...|| wrap renders correctly
+            const safeContent = truncated.replace(/\|\|/g, '|​|');
+
+            const embed = EmbedTemplates.warning('⚠️ Auto-Moderation Notice')
+                .setColor(EmbedColors.WARNING)
+                .setDescription(
+                    `Your message in **${guildName}** has been removed for violating community rules ` +
+                        `and you have been timed out for **30 minutes**.`
+                )
+                .addFields(
+                    {
+                        name: 'Channel',
+                        value: channelMention,
+                        inline: true,
+                    },
+                    {
+                        name: 'Matched Term(s)',
+                        value: matchedTerms.map(t => `||${t}||`).join(', ') || 'unknown',
+                        inline: true,
+                    },
+                    {
+                        name: 'Your Message',
+                        value: `||${safeContent}||`,
+                        inline: false,
+                    },
+                    {
+                        name: 'If you think this is a mistake',
+                        value:
+                            'Please reach out to any moderator for further assistance. ' +
+                            'This violation has been reported to the moderation team.',
+                        inline: false,
+                    }
+                )
+                .setFooter({ text: 'Auto-moderation' });
+
+            await message.author.send({ embeds: [embed] });
+            return { success: true };
+        } catch (error: any) {
+            const code = error?.code;
+            let reason: string;
+            if (code === 50007) {
+                reason = 'Cannot send DMs to this user (DMs disabled or blocked)';
+            } else {
+                reason = error?.message || String(error);
+            }
+            logger.warn`[slur-mod] DM offender failed for ${message.author.tag}: ${reason}`;
+            return { success: false, reason };
+        }
+    }
+
+    private async deleteOffendingMessage(
+        message: Message
+    ): Promise<ActionResult> {
+        try {
+            await message.delete();
+            return { success: true };
+        } catch (error: any) {
+            const code = error?.code;
+            let reason: string;
+            if (code === 10008) {
+                reason = 'Message already deleted';
+            } else if (code === 50013) {
+                reason = 'Bot lacks Manage Messages permission';
+            } else {
+                reason = error?.message || String(error);
+            }
+            logger.warn`[slur-mod] delete message failed (${message.id}): ${reason}`;
             return { success: false, reason };
         }
     }
@@ -491,7 +596,9 @@ export class SlurModerationService {
         snapshot: string,
         matchedTerms: string[],
         offenses: UserOffenses,
-        timeoutResult: { success: true } | { success: false; reason: string }
+        timeoutResult: ActionResult,
+        dmResult: ActionResult,
+        deleteResult: ActionResult
     ): Promise<void> {
         try {
             const channel = this.findModLogChannel(message.guild!);
@@ -516,6 +623,8 @@ export class SlurModerationService {
                 matchedTerms,
                 offenses,
                 timeoutResult,
+                dmResult,
+                deleteResult,
                 suppressed
             );
             await channel.send({ embeds: [embed] });
@@ -529,7 +638,9 @@ export class SlurModerationService {
         snapshot: string,
         matchedTerms: string[],
         offenses: UserOffenses,
-        timeoutResult: { success: true } | { success: false; reason: string },
+        timeoutResult: ActionResult,
+        dmResult: ActionResult,
+        deleteResult: ActionResult,
         suppressed: number
     ): EmbedBuilder {
         const member = message.member!;
@@ -610,10 +721,20 @@ export class SlurModerationService {
                     inline: false,
                 },
                 {
-                    name: 'Action',
-                    value: timeoutResult.success
-                        ? `Timed out for 30 min`
-                        : `Timeout failed: ${timeoutResult.reason} — manual action needed`,
+                    name: 'Actions',
+                    value: capFieldValue(
+                        [
+                            timeoutResult.success
+                                ? '✅ Timed out for 30 min'
+                                : `❌ Timeout failed: ${timeoutResult.reason}`,
+                            deleteResult.success
+                                ? '✅ Message deleted'
+                                : `❌ Delete failed: ${deleteResult.reason}`,
+                            dmResult.success
+                                ? '✅ DM sent to user'
+                                : `⚠️ DM not delivered: ${dmResult.reason}`,
+                        ].join('\n')
+                    ),
                     inline: false,
                 }
             )

--- a/src/services/tests/slurModerationService.test.ts
+++ b/src/services/tests/slurModerationService.test.ts
@@ -125,9 +125,21 @@ interface FakeMemberOpts {
     userId?: string;
 }
 
-function makeMessage(content: string, opts: FakeMemberOpts = {}, guildOpts: FakeGuildOpts = {}) {
+interface MessageBehaviorOpts {
+    deleteSucceeds?: boolean;
+    deleteErrorCode?: number;
+    dmSucceeds?: boolean;
+    dmErrorCode?: number;
+}
+
+function makeMessage(
+    content: string,
+    opts: FakeMemberOpts & MessageBehaviorOpts = {},
+    guildOpts: FakeGuildOpts = {}
+) {
     const userId = opts.userId ?? 'user-1';
     const { guild, modLogChannel } = makeGuild(guildOpts);
+    guild.name = 'Test Guild';
 
     const timeoutFn = vi.fn().mockImplementation(async () => {
         if (opts.timeoutSucceeds === false) {
@@ -136,6 +148,24 @@ function makeMessage(content: string, opts: FakeMemberOpts = {}, guildOpts: Fake
             throw err;
         }
         return undefined;
+    });
+
+    const deleteFn = vi.fn().mockImplementation(async () => {
+        if (opts.deleteSucceeds === false) {
+            const err: any = new Error('delete failed');
+            if (opts.deleteErrorCode) err.code = opts.deleteErrorCode;
+            throw err;
+        }
+        return undefined;
+    });
+
+    const dmSendFn = vi.fn().mockImplementation(async () => {
+        if (opts.dmSucceeds === false) {
+            const err: any = new Error('dm failed');
+            if (opts.dmErrorCode) err.code = opts.dmErrorCode;
+            throw err;
+        }
+        return { id: 'dm-msg' };
     });
 
     const roles = new Map<string, any>();
@@ -187,12 +217,14 @@ function makeMessage(content: string, opts: FakeMemberOpts = {}, guildOpts: Fake
             ...member.user,
             bot: !!opts.isBot,
             createdTimestamp: 1500000000000,
+            send: dmSendFn,
         },
         channel,
         url: 'https://discord.com/channels/guild-1/chan-general/msg-1',
+        delete: deleteFn,
     };
 
-    return { message, member, guild, modLogChannel, timeoutFn };
+    return { message, member, guild, modLogChannel, timeoutFn, deleteFn, dmSendFn };
 }
 
 /* ==========================================================================
@@ -343,7 +375,7 @@ describe('SlurModerationService', () => {
         expect(data.title).toContain('Slur Detected');
         const fieldNames = (data.fields ?? []).map((f: any) => f.name);
         expect(fieldNames).toEqual(
-            expect.arrayContaining(['User', 'Account Created', 'Channel', 'Action', 'Total Offenses'])
+            expect.arrayContaining(['User', 'Account Created', 'Channel', 'Actions', 'Total Offenses'])
         );
     });
 
@@ -368,7 +400,73 @@ describe('SlurModerationService', () => {
         expect(sentEmbeds).toHaveLength(1);
     });
 
-    it('still posts mod-log when timeout fails (with failure note in Action field)', async () => {
+    it('deletes the offending message and DMs the offender on detection', async () => {
+        const { message, deleteFn, dmSendFn } = makeMessage('fooslurbar');
+        await service.checkMessage(message);
+        expect(deleteFn).toHaveBeenCalledTimes(1);
+        expect(dmSendFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('DM payload includes server name, channel mention, matched terms, and recourse instructions', async () => {
+        const { message, dmSendFn } = makeMessage('fooslurbar');
+        await service.checkMessage(message);
+
+        const dmCall = dmSendFn.mock.calls[0][0];
+        const embed = dmCall.embeds[0];
+        const data = embed.data ?? embed.toJSON();
+
+        expect(data.title).toContain('Auto-Moderation');
+        expect(data.description).toContain('Test Guild');
+        expect(data.description).toContain('30 minutes');
+
+        const fieldNames = (data.fields ?? []).map((f: any) => f.name);
+        expect(fieldNames).toEqual(
+            expect.arrayContaining(['Channel', 'Matched Term(s)', 'Your Message', 'If you think this is a mistake'])
+        );
+
+        const recourse = (data.fields ?? []).find((f: any) => f.name === 'If you think this is a mistake');
+        expect(recourse.value).toContain('moderator');
+    });
+
+    it('handles DM failure (user has DMs disabled) without aborting other actions', async () => {
+        const sentEmbeds: any[] = [];
+        const { message, deleteFn } = makeMessage(
+            'fooslurbar',
+            { dmSucceeds: false, dmErrorCode: 50007 },
+            { modLogSentEmbeds: sentEmbeds }
+        );
+        await service.checkMessage(message);
+
+        // Delete still happens
+        expect(deleteFn).toHaveBeenCalledTimes(1);
+        // Mod-log still posted
+        expect(sentEmbeds).toHaveLength(1);
+        // Mod-log Actions field reflects DM failure
+        const data = sentEmbeds[0].data ?? sentEmbeds[0].toJSON();
+        const actions = (data.fields ?? []).find((f: any) => f.name === 'Actions');
+        expect(actions.value).toContain('DM not delivered');
+        expect(actions.value).toContain('DMs disabled');
+    });
+
+    it('handles delete failure (already deleted / lacking permission) without aborting other actions', async () => {
+        const sentEmbeds: any[] = [];
+        const { message, dmSendFn } = makeMessage(
+            'fooslurbar',
+            { deleteSucceeds: false, deleteErrorCode: 10008 },
+            { modLogSentEmbeds: sentEmbeds }
+        );
+        await service.checkMessage(message);
+
+        // DM still sent
+        expect(dmSendFn).toHaveBeenCalledTimes(1);
+        // Mod-log still posted
+        expect(sentEmbeds).toHaveLength(1);
+        const data = sentEmbeds[0].data ?? sentEmbeds[0].toJSON();
+        const actions = (data.fields ?? []).find((f: any) => f.name === 'Actions');
+        expect(actions.value).toContain('Delete failed');
+    });
+
+    it('still posts mod-log when timeout fails (with failure note in Actions field)', async () => {
         const sentEmbeds: any[] = [];
         const { message } = makeMessage(
             'qwertytest',
@@ -378,7 +476,7 @@ describe('SlurModerationService', () => {
         await service.checkMessage(message);
         expect(sentEmbeds).toHaveLength(1);
         const data = sentEmbeds[0].data ?? sentEmbeds[0].toJSON();
-        const action = (data.fields ?? []).find((f: any) => f.name === 'Action');
+        const action = (data.fields ?? []).find((f: any) => f.name === 'Actions');
         expect(action.value).toContain('Timeout failed');
     });
 


### PR DESCRIPTION
## Summary
On slur detection the bot now (in addition to the 30-min timeout):
1. **DMs the offender** with an embed explaining what happened, what they posted, and how to appeal
2. **Deletes the offending message** so it doesn't linger
3. Mod-log embed surfaces all three action outcomes in a single \`Actions\` field

## Why
Mod request: users should know *why* they got timed out (so it doesn't look like a random bot bug), the offending message shouldn't sit visible in chat, and there should be a clear appeal path if the auto-mod was wrong.

## DM payload
Uses \`EmbedTemplates.warning()\` for visual consistency with the mod-log embed. Fields:

| Field | Content |
|---|---|
| Title | \`⚠️ Auto-Moderation Notice\` |
| Description | \`Your message in **<server name>** has been removed for violating community rules and you have been timed out for **30 minutes**.\` |
| Channel | \`<#channel-id>\` mention |
| Matched Term(s) | spoilered |
| Your Message | spoilered, 200-char preview (so the user can see what they wrote that triggered it — Discord doesn't preserve message content after deletion in the chat history) |
| If you think this is a mistake | \`Please reach out to any moderator for further assistance. This violation has been reported to the moderation team.\` |
| Footer | \`Auto-moderation\` |

The DM is sent **before** the message is deleted so Discord embeds the original message contents in the user's notification. (No true \"ephemeral\" message exists outside of slash command interactions; a DM is the closest equivalent — only the offender sees it.)

## Mod-log embed change
Renamed the \`Action\` field to \`Actions\` (plural) and surfaces all three outcomes:
- \`✅ Timed out for 30 min\` / \`❌ Timeout failed: <reason>\`
- \`✅ Message deleted\` / \`❌ Delete failed: <reason>\`
- \`✅ DM sent to user\` / \`⚠️ DM not delivered: <reason>\`

Specific Discord error codes are translated to plain English (\`50007 → DMs disabled\`, \`50013 → Manage Messages permission missing\`, \`10008 → Message already deleted\`).

## Independent failure handling
Each of the four steps (timeout / DM / delete / mod-log) has its own try/catch. A user with DMs disabled doesn't block the message-delete; a missing Manage Messages permission doesn't block the timeout; etc.

## Bot permissions required (in addition to existing)
- \`MODERATE_MEMBERS\` — for timeout (existing)
- \`MANAGE_MESSAGES\` — **NEW**, for deletion. Without it the mod-log will show \`❌ Delete failed: Bot lacks Manage Messages permission\` and a mod can manually delete.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test:run\` → 904 tests pass (4 new: delete+dm fire on detection, DM payload shape, DM disabled doesn't abort delete, delete failure doesn't abort DM)
- [ ] Live: post a slur from alt → DM received with embed, message deleted, mod-log shows all three ✅
- [ ] Live: post slur from an alt that has DMs disabled → message still deleted, mod-log shows DM ⚠️ + reason

## Files changed
- \`src/services/slurModerationService.ts\` — added \`dmOffender\` + \`deleteOffendingMessage\`, threaded results through \`postModLog\` + \`buildModLogEmbed\`, added shared \`ActionResult\` type
- \`src/services/tests/slurModerationService.test.ts\` — 4 new tests + extended message mock with \`delete\` + \`author.send\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)