### PR TITLE
feat: Lost Sword Star Reincarnation alerts + Avalon anchor fix

### DIFF
--- a/src/bootstrap/serviceInitializer.ts
+++ b/src/bootstrap/serviceInitializer.ts
@@ -80,6 +80,13 @@ export async function initializeServices(bot: Client): Promise<void> {
             embedColor: 0xFFD700,
         });
 
+        notificationService.registerNotificationType({
+            type: 'pvp-warning:lost-sword-star-reincarnation',
+            displayName: 'Lost Sword Star Reincarnation',
+            description: 'Biweekly Star Reincarnation endgame raid reset reminders for Lost Sword',
+            embedColor: 0x9B59B6,
+        });
+
         // Register daily reset notification types for each game
         for (const gameConfig of dailyResetServiceConfig.games) {
             if (gameConfig.notificationType) {

--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -591,8 +591,59 @@ describe('PvpReminderService', () => {
             expect(avalon!.seasonEnd).toEqual({ dayOfWeek: 0, hour: 15, minute: 0 });
             expect(avalon!.cyclePhase?.intervalWeeks).toBe(2);
             expect(avalon!.cyclePhase?.phaseOffset).toBe(0);
-            expect(avalon!.cyclePhase?.anchor).toBe('2026-04-26T15:00:00Z');
+            expect(avalon!.cyclePhase?.anchor).toBe('2026-05-03T15:00:00Z');
             expect(avalon!.warnings.map(w => w.label)).toEqual(['2 days', '1 day', '1 hour']);
+        });
+
+        it('should include Lost Sword Star Reincarnation biweekly config', async () => {
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const sr = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-star-reincarnation');
+            expect(sr).toBeDefined();
+            expect(sr!.channelName).toBe('lost-sword');
+            expect(sr!.seasonEnd).toEqual({ dayOfWeek: 0, hour: 15, minute: 0 });
+            expect(sr!.cyclePhase?.intervalWeeks).toBe(2);
+            expect(sr!.cyclePhase?.phaseOffset).toBe(1);
+            expect(sr!.cyclePhase?.anchor).toBe('2026-05-03T15:00:00Z');
+            expect(sr!.warnings.map(w => w.label)).toEqual(['2 days', '1 day', '1 hour']);
+        });
+
+        it('Avalon and Star Reincarnation should never both fire on the same Sunday', async () => {
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const avalon = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-avalon')!;
+            const sr = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-star-reincarnation')!;
+            const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
+            const anyWarning: PvpWarningConfig = {
+                label: 'test',
+                minutesBefore: 0,
+                embedConfig: testEvent.warnings[0].embedConfig,
+            };
+            // Sweep 26 Sundays starting from the shared anchor
+            for (let i = 0; i < 26; i++) {
+                const sunday = new Date(Date.parse('2026-05-03T15:00:00Z') + i * 7 * 24 * 60 * 60 * 1000);
+                const a = service.isActiveCycle(avalon, anyWarning, sunday);
+                const b = service.isActiveCycle(sr, anyWarning, sunday);
+                expect(a !== b).toBe(true);
+            }
+        });
+
+        it('Avalon active cycle ends on 2026-05-03 (the anchor Sunday)', async () => {
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const avalon = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-avalon')!;
+            const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
+            // Friday 2026-05-01 (2 days before 05-03) — 2-day warning's projected target = 05-03
+            const fri = new Date('2026-05-01T15:00:00Z');
+            const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
+            expect(service.isActiveCycle(avalon, warning2d, fri)).toBe(true);
+        });
+
+        it('Star Reincarnation first active end is 2026-05-10 (one week after Avalon ends)', async () => {
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const sr = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-star-reincarnation')!;
+            const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
+            // Friday 2026-05-08 — 2-day warning's projected target = 05-10 (SR's first end)
+            const fri = new Date('2026-05-08T15:00:00Z');
+            const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
+            expect(service.isActiveCycle(sr, warning2d, fri)).toBe(true);
         });
     });
 

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -130,13 +130,13 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
 /**
  * Lost Sword — Avalon (Biweekly Guild Raid)
  *
- * Avalon is a biweekly event where guilds attack one of 6 castles for points.
- * This server's guild attacks Camelot or Mercia.
- * Each member gets 6 attempts; first 2 give 100 Diamonds, 3rd gives 150 💎.
- * Guild rewards = highest single-castle score, so focus efforts on ONE castle.
+ * Avalon is a biweekly event where guilds attack castles for points.
+ * This server's guild attacks BOTH Camelot AND Mercia — 3 attempts each
+ * (6 attempts total, split 3/3).
  *
- * Schedule: ends every other Sunday at 15:00 UTC. Anchor 2026-04-26 confirms
- * the active week. The off-week runs Star Reincarnation (separate config — TBD).
+ * Schedule: ends every other Sunday at 15:00 UTC. Anchor 2026-05-03 is the
+ * end of the current active cycle (Avalon active 2026-04-26 → 2026-05-03).
+ * The alternating weeks run Star Reincarnation (phaseOffset=1, see below).
  */
 const lostSwordAvalonConfig: PvpEventConfig = {
     id: 'lost-sword-avalon',
@@ -149,20 +149,20 @@ const lostSwordAvalonConfig: PvpEventConfig = {
         minute: 0,
     },
     cyclePhase: {
-        anchor: '2026-04-26T15:00:00Z',  // user-confirmed active Sunday
+        anchor: '2026-05-03T15:00:00Z',  // first season-end of active cycle
         intervalWeeks: 2,
-        phaseOffset: 0,                  // Avalon is phase A; future Star Reincarnation = phase 1
+        phaseOffset: 0,                  // Avalon is phase A; Star Reincarnation = phase B (offset 1)
     },
     warnings: [
         {
             label: '2 days',
             minutesBefore: 2 * 24 * 60,  // Friday 15:00 UTC
             embedConfig: {
-                title: '🏰 Avalon Ends in 2 Days — Lock Your Castle Target',
+                title: '🏰 Avalon Ends in 2 Days — Hit Both Castles!',
                 description: (ts) =>
                     `Swordbringers, the Round Table calls! Avalon's reset approaches.\n\n` +
                     `**Avalon ends <t:${ts}:F> (<t:${ts}:R>).**\n\n` +
-                    `Coordinate with your guild — focus efforts on **ONE castle** for the best leaderboard score.`,
+                    `Spend your **6 attempts: 3 on Camelot, 3 on Mercia.**`,
                 color: 0xFFD700, // Gold — Lost Sword brand color
                 footer: {
                     text: 'May Excalibur guide your path, Swordbringers!',
@@ -177,18 +177,18 @@ const lostSwordAvalonConfig: PvpEventConfig = {
                         inline: true,
                     },
                     {
-                        name: '🎯 This Server Attacks',
-                        value: '**Camelot** or **Mercia** — coordinate with guild',
+                        name: '🎯 Castles to Attack',
+                        value: '**Camelot** AND **Mercia**\n(3 attempts each)',
                         inline: true,
                     },
                     {
                         name: '⚔️ Attempts',
-                        value: '6 per member\n• 1st & 2nd: **100 💎** each\n• 3rd: **150 💎**',
+                        value: '**6 attempts total** — 3 on Camelot, 3 on Mercia',
                         inline: false,
                     },
                     {
                         name: '📜 Strategy',
-                        value: 'Guild rewards = highest single-castle score. **Focus on ONE castle** for max leaderboard impact.',
+                        value: 'Split your **6 attempts evenly** across both castles. Coordinate in guild chat to align with team picks.',
                         inline: false,
                     },
                     {
@@ -207,7 +207,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
                 description: (ts) =>
                     `Swordbringers, the castle siege closes tomorrow!\n\n` +
                     `**Avalon ends <t:${ts}:F> (<t:${ts}:R>).**\n\n` +
-                    `Spend your remaining attempts and push your guild's chosen castle to the leaderboard.`,
+                    `Spend remaining attempts on **both Camelot AND Mercia** — 3 each.`,
                 color: 0xFFA500, // Orange — urgency rising
                 footer: {
                     text: 'The Round Table awaits, Swordbringer!',
@@ -222,13 +222,13 @@ const lostSwordAvalonConfig: PvpEventConfig = {
                         inline: true,
                     },
                     {
-                        name: '🎯 Castle Targets',
-                        value: '**Camelot** or **Mercia**',
+                        name: '🎯 Castles',
+                        value: '**Camelot** AND **Mercia** (3 each)',
                         inline: true,
                     },
                     {
                         name: '🔥 What to Do',
-                        value: '• Burn remaining **6 attempts**\n• Stack on guild\'s chosen castle\n• Coordinate in guild chat',
+                        value: '• Burn remaining attempts\n• 3 on Camelot, 3 on Mercia\n• Coordinate team picks in guild chat',
                         inline: false,
                     },
                 ],
@@ -243,7 +243,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
                 description: (ts) =>
                     `Final hour, Swordbringers! Avalon's reset is imminent.\n\n` +
                     `**Avalon ends <t:${ts}:R> (<t:${ts}:t>).**\n\n` +
-                    `**Last chance** to spend attempts — rewards lock at reset.`,
+                    `**Last chance** to spend remaining attempts on Camelot AND Mercia — rewards lock at reset.`,
                 color: 0xFF0000, // Red — urgent
                 footer: {
                     text: 'The siege closes! | May Excalibur guide your path!',
@@ -259,7 +259,154 @@ const lostSwordAvalonConfig: PvpEventConfig = {
                     },
                     {
                         name: '🚨 Last Call',
-                        value: '• Spend **all 6 attempts NOW**\n• Final castle pushes\n• Rewards lock at reset',
+                        value: '• Spend **all 6 attempts NOW**\n• 3 on Camelot, 3 on Mercia\n• Rewards lock at reset',
+                        inline: true,
+                    },
+                ],
+            },
+        },
+    ],
+    mediaConfig: {
+        cdnPath: 'dailies/lost-sword/',
+        extensions: [...DEFAULT_IMAGE_EXTENSIONS],
+        trackLast: 10,
+    },
+};
+
+/**
+ * Lost Sword — Star Reincarnation (Biweekly Endgame Raid)
+ *
+ * Alternates with Avalon: when Avalon is dormant, Star Reincarnation is active.
+ * Players fight 6 bosses with 2 different teams (10 chars + 6 pets total) for
+ * Goddess Stones and Galaxy Essence. Damage thresholds reward Diamonds + Goddess
+ * Stones at 10M / 100M / 300M. Each cycle features unique bosses and buffs that
+ * demand varied team compositions.
+ *
+ * Schedule: ends every other Sunday at 15:00 UTC, on the alternating week from
+ * Avalon (shared anchor 2026-05-03 + phaseOffset=1 → SR ends 2026-05-10, 05-24, ...).
+ */
+const lostSwordStarReincarnationConfig: PvpEventConfig = {
+    id: 'lost-sword-star-reincarnation',
+    game: 'Lost Sword',
+    eventName: 'Star Reincarnation',
+    channelName: 'lost-sword',
+    seasonEnd: {
+        dayOfWeek: 0,
+        hour: 15,
+        minute: 0,
+    },
+    cyclePhase: {
+        anchor: '2026-05-03T15:00:00Z',  // shared anchor with Avalon
+        intervalWeeks: 2,
+        phaseOffset: 1,                  // phase B (Avalon = phase A, offset 0)
+    },
+    warnings: [
+        {
+            label: '2 days',
+            minutesBefore: 2 * 24 * 60,
+            embedConfig: {
+                title: '🌌 Star Reincarnation Ends in 2 Days — Plan Your Two Teams',
+                description: (ts) =>
+                    `Swordbringers, the cosmos calls! Star Reincarnation's reset approaches.\n\n` +
+                    `**Star Reincarnation ends <t:${ts}:F> (<t:${ts}:R>).**\n\n` +
+                    `Build **two distinct teams** (5 characters + 3 pets each) and start chipping away at the 6 bosses for Goddess Stones.`,
+                color: 0x9B59B6, // Purple — cosmic/Star theme
+                footer: {
+                    text: 'May the stars align for you, Swordbringer!',
+                    iconURL: RAPI_BOT_THUMBNAIL_URL,
+                },
+                thumbnail: LOST_SWORD_LOGO_URL,
+                author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
+                fields: (ts) => [
+                    {
+                        name: '⏰ Reset',
+                        value: `<t:${ts}:F>\n<t:${ts}:R>`,
+                        inline: true,
+                    },
+                    {
+                        name: '⚔️ Format',
+                        value: '**6 bosses** × **2 teams**\n10 characters + 6 pets total',
+                        inline: true,
+                    },
+                    {
+                        name: '💎 Damage Thresholds',
+                        value: '• **10M** damage\n• **100M** damage\n• **300M** damage\nEach tier unlocks Diamonds + Goddess Stones',
+                        inline: false,
+                    },
+                    {
+                        name: '🌠 Strategy',
+                        value: 'Each cycle features unique bosses and buffs — review boss kits and adjust your team comps. Roster depth matters here.',
+                        inline: false,
+                    },
+                    {
+                        name: '📖 Guides',
+                        value: '[Star Reincarnation Guide](https://lootandwaifus.com/guides/reincarnation-of-stars-lost-sword/)',
+                        inline: false,
+                    },
+                ],
+            },
+        },
+        {
+            label: '1 day',
+            minutesBefore: 24 * 60,
+            embedConfig: {
+                title: '🌌 Star Reincarnation Ends Tomorrow!',
+                description: (ts) =>
+                    `Swordbringers, the cosmic raid closes tomorrow!\n\n` +
+                    `**Star Reincarnation ends <t:${ts}:F> (<t:${ts}:R>).**\n\n` +
+                    `Push damage on remaining bosses and lock in your highest tier rewards before reset.`,
+                color: 0xFFA500, // Orange — urgency rising
+                footer: {
+                    text: 'The stars wait for no one, Swordbringer!',
+                    iconURL: RAPI_BOT_THUMBNAIL_URL,
+                },
+                thumbnail: LOST_SWORD_LOGO_URL,
+                author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
+                fields: (ts) => [
+                    {
+                        name: '⏰ Reset',
+                        value: `<t:${ts}:F>\n<t:${ts}:R>`,
+                        inline: true,
+                    },
+                    {
+                        name: '🎯 Reward Tiers',
+                        value: '**10M / 100M / 300M** damage',
+                        inline: true,
+                    },
+                    {
+                        name: '🔥 What to Do',
+                        value: '• Finish remaining bosses\n• Push for next damage tier\n• Swap team comps if stuck',
+                        inline: false,
+                    },
+                ],
+            },
+        },
+        {
+            label: '1 hour',
+            minutesBefore: 60,
+            sendDM: true,
+            embedConfig: {
+                title: '🚨 Star Reincarnation Reset in 1 Hour!',
+                description: (ts) =>
+                    `Final hour, Swordbringers! Star Reincarnation closes soon.\n\n` +
+                    `**Star Reincarnation ends <t:${ts}:R> (<t:${ts}:t>).**\n\n` +
+                    `**Last chance** to push damage tiers — Goddess Stones lock at reset.`,
+                color: 0xFF0000, // Red — urgent
+                footer: {
+                    text: 'The stars dim! | May the cosmos guide your path!',
+                    iconURL: RAPI_BOT_THUMBNAIL_URL,
+                },
+                thumbnail: LOST_SWORD_LOGO_URL,
+                author: { name: 'Rapi BOT', iconURL: RAPI_BOT_THUMBNAIL_URL },
+                fields: (ts) => [
+                    {
+                        name: '⏰ Reset',
+                        value: `<t:${ts}:t> (<t:${ts}:R>)`,
+                        inline: true,
+                    },
+                    {
+                        name: '🚨 Last Call',
+                        value: '• Finish damage pushes\n• Final boss attempts\n• Rewards lock at reset',
                         inline: true,
                     },
                 ],
@@ -274,6 +421,6 @@ const lostSwordAvalonConfig: PvpEventConfig = {
 };
 
 export const pvpReminderServiceConfig: PvpReminderServiceConfig = {
-    events: [bd2MirrorWarsConfig, lostSwordAvalonConfig],
+    events: [bd2MirrorWarsConfig, lostSwordAvalonConfig, lostSwordStarReincarnationConfig],
     devModeInterval: 3,
 };


### PR DESCRIPTION
## Summary
Adds biweekly Star Reincarnation alerts to `#lost-sword` on the alternating weeks from Avalon, completing full Sunday coverage of the Lost Sword endgame raid cycle. Uses the existing `cyclePhase` abstraction with a shared anchor + `phaseOffset: 1`.

Also fixes a subtle Avalon anchor bug surfaced while wiring SR. The prior anchor `2026-04-26` was the Sunday Avalon **started**, not **ended**. The bot would have skipped this Sunday's actual 2026-05-03 reset and fired one week late on the Star Reincarnation Sunday. Anchor is now `2026-05-03T15:00:00Z` (the first end-of-active-cycle Sunday).

## Cycle calendar (active ends, with shared anchor 2026-05-03)
| Sunday | Avalon (offset 0) | Star Reincarnation (offset 1) |
|---|---|---|
| 2026-05-03 | ✅ ENDS (anchor) | dormant |
| 2026-05-10 | dormant | ✅ ENDS |
| 2026-05-17 | ✅ ENDS | dormant |
| 2026-05-24 | dormant | ✅ ENDS |

Mutual exclusion enforced by the cyclePhase invariant in the service.

## Avalon embed corrections (per mod direction)
- **Strategy now correct**: hit **BOTH Camelot AND Mercia** with 3 attempts each (was: focus single castle)
- **Removed unconfirmed gem amounts** from the per-attempt rewards (was: 100/100/150 💎 breakdown). Now just says \"6 attempts total — 3 on Camelot, 3 on Mercia.\"
- Title updated: \"Avalon Ends in 2 Days — Hit Both Castles!\"

## Star Reincarnation embed
- **Title (2d)**: \"🌌 Star Reincarnation Ends in 2 Days — Plan Your Two Teams\"
- Color: purple (`0x9B59B6`) for cosmic theming, distinct from Avalon's gold
- Fields: reset timestamp, format (6 bosses × 2 teams; 10 chars + 6 pets), damage tiers (10M / 100M / 300M), strategy reminder (unique bosses + buffs each cycle), single guide link to Loot and Waifus
- 1d (orange) and 1h (red) follow the urgency-color escalation pattern. Only 1h DM-blasts subscribers.

## Tests
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test:run` → 926 tests pass (4 new for SR + cross-event mutual exclusion + anchor fix)
- [x] **Active cycle math**: Avalon active on 05-03, dormant on 05-10; SR dormant on 05-03, active on 05-10
- [x] **26-week mutual exclusion**: across 26 simulated Sundays starting from anchor, exactly one of {Avalon, SR} fires on each Sunday — never both, never neither
- [x] **Real-config sweep**: uses the production configs (not synthetic test data) to validate alternation
- [ ] **Live smoke**: on Friday 2026-05-08 the SR 2-day warning fires; the following Friday 2026-05-15 should be silent (Avalon's pre-fire week is the *next* one, 2026-05-22)
- [ ] **Live verify Avalon**: on Friday 2026-05-01 the Avalon 2-day warning fires for the 2026-05-03 reset

## Files changed
- `src/utils/data/pvpEventsConfig.ts` — SR config block, Avalon anchor fix, Avalon embed copy updates
- `src/bootstrap/serviceInitializer.ts` — register `pvp-warning:lost-sword-star-reincarnation` notification type
- `src/services/tests/pvpReminderService.test.ts` — 4 new tests

## Out of scope (still deferred)
Tech-debt phases 1-6. User wants those next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)