### PR TITLE
fix: correct Avalon/SR anchor to 2026-05-10 (Avalon ends Sun, doesn't begin)

### DIFF
--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -591,7 +591,7 @@ describe('PvpReminderService', () => {
             expect(avalon!.seasonEnd).toEqual({ dayOfWeek: 0, hour: 15, minute: 0 });
             expect(avalon!.cyclePhase?.intervalWeeks).toBe(2);
             expect(avalon!.cyclePhase?.phaseOffset).toBe(0);
-            expect(avalon!.cyclePhase?.anchor).toBe('2026-05-03T15:00:00Z');
+            expect(avalon!.cyclePhase?.anchor).toBe('2026-05-10T15:00:00Z');
             expect(avalon!.warnings.map(w => w.label)).toEqual(['2 days', '1 day', '1 hour']);
         });
 
@@ -603,7 +603,7 @@ describe('PvpReminderService', () => {
             expect(sr!.seasonEnd).toEqual({ dayOfWeek: 0, hour: 15, minute: 0 });
             expect(sr!.cyclePhase?.intervalWeeks).toBe(2);
             expect(sr!.cyclePhase?.phaseOffset).toBe(1);
-            expect(sr!.cyclePhase?.anchor).toBe('2026-05-03T15:00:00Z');
+            expect(sr!.cyclePhase?.anchor).toBe('2026-05-10T15:00:00Z');
             expect(sr!.warnings.map(w => w.label)).toEqual(['2 days', '1 day', '1 hour']);
         });
 
@@ -619,31 +619,42 @@ describe('PvpReminderService', () => {
             };
             // Sweep 26 Sundays starting from the shared anchor
             for (let i = 0; i < 26; i++) {
-                const sunday = new Date(Date.parse('2026-05-03T15:00:00Z') + i * 7 * 24 * 60 * 60 * 1000);
+                const sunday = new Date(Date.parse('2026-05-10T15:00:00Z') + i * 7 * 24 * 60 * 60 * 1000);
                 const a = service.isActiveCycle(avalon, anyWarning, sunday);
                 const b = service.isActiveCycle(sr, anyWarning, sunday);
                 expect(a !== b).toBe(true);
             }
         });
 
-        it('Avalon active cycle ends on 2026-05-03 (the anchor Sunday)', async () => {
+        it('Avalon active cycle ends on 2026-05-10 (the anchor Sunday)', async () => {
             const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
             const avalon = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-avalon')!;
             const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
-            // Friday 2026-05-01 (2 days before 05-03) — 2-day warning's projected target = 05-03
-            const fri = new Date('2026-05-01T15:00:00Z');
+            // Friday 2026-05-08 (2 days before 05-10) — 2-day warning's projected target = 05-10
+            const fri = new Date('2026-05-08T15:00:00Z');
             const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
             expect(service.isActiveCycle(avalon, warning2d, fri)).toBe(true);
         });
 
-        it('Star Reincarnation first active end is 2026-05-10 (one week after Avalon ends)', async () => {
+        it('Star Reincarnation first active end is 2026-05-17 (one week after Avalon ends)', async () => {
             const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
             const sr = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-star-reincarnation')!;
             const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
-            // Friday 2026-05-08 — 2-day warning's projected target = 05-10 (SR's first end)
-            const fri = new Date('2026-05-08T15:00:00Z');
+            // Friday 2026-05-15 — 2-day warning's projected target = 05-17 (SR's first end)
+            const fri = new Date('2026-05-15T15:00:00Z');
             const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
             expect(service.isActiveCycle(sr, warning2d, fri)).toBe(true);
+        });
+
+        it('Avalon should NOT fire for the 2026-05-03 reset (Avalon BEGINS that Sunday, doesn\'t end)', async () => {
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const avalon = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-avalon')!;
+            const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
+            // Friday 2026-05-01 (2 days before 05-03 — but 05-03 is Avalon START, not END)
+            const fri = new Date('2026-05-01T15:00:00Z');
+            const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
+            // 05-03 is off-cycle for Avalon (anchor=05-10, so 05-03 is one week before anchor → phase=1)
+            expect(service.isActiveCycle(avalon, warning2d, fri)).toBe(false);
         });
     });
 

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -134,8 +134,8 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
  * This server's guild attacks BOTH Camelot AND Mercia — 3 attempts each
  * (6 attempts total, split 3/3).
  *
- * Schedule: ends every other Sunday at 15:00 UTC. Anchor 2026-05-03 is the
- * end of the current active cycle (Avalon active 2026-04-26 → 2026-05-03).
+ * Schedule: ends every other Sunday at 15:00 UTC. Anchor 2026-05-10 is the
+ * end of the current active cycle (Avalon active 2026-05-03 → 2026-05-10).
  * The alternating weeks run Star Reincarnation (phaseOffset=1, see below).
  */
 const lostSwordAvalonConfig: PvpEventConfig = {
@@ -149,7 +149,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
         minute: 0,
     },
     cyclePhase: {
-        anchor: '2026-05-03T15:00:00Z',  // first season-end of active cycle
+        anchor: '2026-05-10T15:00:00Z',  // first season-end of active cycle
         intervalWeeks: 2,
         phaseOffset: 0,                  // Avalon is phase A; Star Reincarnation = phase B (offset 1)
     },
@@ -283,7 +283,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
  * demand varied team compositions.
  *
  * Schedule: ends every other Sunday at 15:00 UTC, on the alternating week from
- * Avalon (shared anchor 2026-05-03 + phaseOffset=1 → SR ends 2026-05-10, 05-24, ...).
+ * Avalon (shared anchor 2026-05-10 + phaseOffset=1 → SR ends 2026-05-17, 05-31, ...).
  */
 const lostSwordStarReincarnationConfig: PvpEventConfig = {
     id: 'lost-sword-star-reincarnation',
@@ -296,7 +296,7 @@ const lostSwordStarReincarnationConfig: PvpEventConfig = {
         minute: 0,
     },
     cyclePhase: {
-        anchor: '2026-05-03T15:00:00Z',  // shared anchor with Avalon
+        anchor: '2026-05-10T15:00:00Z',  // shared anchor with Avalon
         intervalWeeks: 2,
         phaseOffset: 1,                  // phase B (Avalon = phase A, offset 0)
     },


### PR DESCRIPTION
## Summary
Fixes the Lost Sword Avalon + Star Reincarnation cycle anchor. The previous value (`2026-05-03T15:00:00Z`) was the Sunday Avalon **began**, not the Sunday it **ends**. With that wrong anchor the bot would have fired the 2-day warning on Friday 2026-05-01 announcing \"Avalon ends in 2 days\" *before Avalon had even started*, and would have been silent during Avalon's actual 2026-05-10 reset.

## Verified actual current date
Ran `date -u` to confirm: today is **2026-05-07 01:17 UTC** (Wednesday 5/06 in user TZ). Avalon active period is **2026-05-03 → 2026-05-10**. The first end-of-active-cycle Sunday is **2026-05-10**.

## Cycle calendar after this fix

| Sunday | Active event |
|---|---|
| 2026-05-03 | (Avalon begins; nothing to alert) |
| **2026-05-10** | 🏰 Avalon ends (warnings Fri 05-08, Sat 05-09, Sun 05-10 14:00) |
| **2026-05-17** | 🌌 Star Reincarnation ends (warnings Fri 05-15, Sat 05-16, Sun 05-17 14:00) |
| **2026-05-24** | 🏰 Avalon ends |
| **2026-05-31** | 🌌 Star Reincarnation ends |

## Tests
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test:run` → 927 tests pass
- [x] **New regression test**: Avalon's 2-day warning fired Friday 2026-05-01 must be **silent** for the 05-03 Sunday (since that's Avalon's start, not end)
- [x] Anchor + 14-day, 28-day, 42-day projections verified across the 26-week mutual-exclusion sweep
- [ ] **Live smoke**: Friday 2026-05-08 ~15:00 UTC — Avalon 2-day warning fires in `#lost-sword`. Confirm 1d follows Saturday 05-09, 1h Sunday 05-10 14:00 (with DM blast).

## Process note
Saved a `feedback_check_current_date.md` memory: when the actual current date matters (anchors, scheduling math, deadline-sensitive work), shell out to `date` instead of trusting system-reminder timestamps which can be stale. This bug shipped twice because I trusted a system-reminder claiming \"today is 2026-04-26.\"

## Files changed
- `src/utils/data/pvpEventsConfig.ts` — anchor `2026-05-03T15:00:00Z` → `2026-05-10T15:00:00Z` (both events), docstrings updated
- `src/services/tests/pvpReminderService.test.ts` — anchor refs updated, +1 regression test for the start-vs-end semantic

🤖 Generated with [Claude Code](https://claude.com/claude-code)