### PR TITLE
fix: correct Avalon/Star Reincarnation cycle and stagger warnings 1h before reset

### DIFF
--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -591,7 +591,7 @@ describe('PvpReminderService', () => {
             expect(avalon!.seasonEnd).toEqual({ dayOfWeek: 0, hour: 15, minute: 0 });
             expect(avalon!.cyclePhase?.intervalWeeks).toBe(2);
             expect(avalon!.cyclePhase?.phaseOffset).toBe(0);
-            expect(avalon!.cyclePhase?.anchor).toBe('2026-05-03T15:00:00Z');
+            expect(avalon!.cyclePhase?.anchor).toBe('2026-05-10T15:00:00Z');
             expect(avalon!.warnings.map(w => w.label)).toEqual(['2 days', '1 day', '1 hour']);
         });
 
@@ -603,7 +603,7 @@ describe('PvpReminderService', () => {
             expect(sr!.seasonEnd).toEqual({ dayOfWeek: 0, hour: 15, minute: 0 });
             expect(sr!.cyclePhase?.intervalWeeks).toBe(2);
             expect(sr!.cyclePhase?.phaseOffset).toBe(1);
-            expect(sr!.cyclePhase?.anchor).toBe('2026-05-03T15:00:00Z');
+            expect(sr!.cyclePhase?.anchor).toBe('2026-05-10T15:00:00Z');
             expect(sr!.warnings.map(w => w.label)).toEqual(['2 days', '1 day', '1 hour']);
         });
 
@@ -619,31 +619,42 @@ describe('PvpReminderService', () => {
             };
             // Sweep 26 Sundays starting from the shared anchor
             for (let i = 0; i < 26; i++) {
-                const sunday = new Date(Date.parse('2026-05-03T15:00:00Z') + i * 7 * 24 * 60 * 60 * 1000);
+                const sunday = new Date(Date.parse('2026-05-10T15:00:00Z') + i * 7 * 24 * 60 * 60 * 1000);
                 const a = service.isActiveCycle(avalon, anyWarning, sunday);
                 const b = service.isActiveCycle(sr, anyWarning, sunday);
                 expect(a !== b).toBe(true);
             }
         });
 
-        it('Avalon active cycle ends on 2026-05-03 (the anchor Sunday)', async () => {
+        it('Avalon active cycle ends on 2026-05-10 (the anchor Sunday)', async () => {
             const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
             const avalon = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-avalon')!;
             const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
-            // Friday 2026-05-01 (2 days before 05-03) — 2-day warning's projected target = 05-03
-            const fri = new Date('2026-05-01T15:00:00Z');
+            // Friday 2026-05-08 (2 days before 05-10) — 2-day warning's projected target = 05-10
+            const fri = new Date('2026-05-08T15:00:00Z');
             const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
             expect(service.isActiveCycle(avalon, warning2d, fri)).toBe(true);
         });
 
-        it('Star Reincarnation first active end is 2026-05-10 (one week after Avalon ends)', async () => {
+        it('Star Reincarnation first active end is 2026-05-17 (one week after Avalon ends)', async () => {
             const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
             const sr = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-star-reincarnation')!;
             const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
-            // Friday 2026-05-08 — 2-day warning's projected target = 05-10 (SR's first end)
-            const fri = new Date('2026-05-08T15:00:00Z');
+            // Friday 2026-05-15 — 2-day warning's projected target = 05-17 (SR's first end)
+            const fri = new Date('2026-05-15T15:00:00Z');
             const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
             expect(service.isActiveCycle(sr, warning2d, fri)).toBe(true);
+        });
+
+        it('Avalon should NOT fire for the 2026-05-03 reset (Avalon BEGINS that Sunday, doesn\'t end)', async () => {
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const avalon = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-avalon')!;
+            const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
+            // Friday 2026-05-01 (2 days before 05-03 — but 05-03 is Avalon START, not END)
+            const fri = new Date('2026-05-01T15:00:00Z');
+            const warning2d: PvpWarningConfig = { label: '2 days', minutesBefore: 2 * 24 * 60, embedConfig: testEvent.warnings[0].embedConfig };
+            // 05-03 is off-cycle for Avalon (anchor=05-10, so 05-03 is one week before anchor → phase=1)
+            expect(service.isActiveCycle(avalon, warning2d, fri)).toBe(false);
         });
     });
 

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -156,7 +156,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
     warnings: [
         {
             label: '2 days',
-            minutesBefore: 2 * 24 * 60,  // Friday 15:00 UTC
+            minutesBefore: (2 * 24 * 60) + 60,  // Friday 14:00 UTC (1h before daily reset to avoid notification collision)
             embedConfig: {
                 title: '🏰 Avalon Ends in 2 Days — Hit Both Castles!',
                 description: (ts) =>
@@ -201,7 +201,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
         },
         {
             label: '1 day',
-            minutesBefore: 24 * 60, // Saturday 15:00 UTC
+            minutesBefore: (24 * 60) + 60, // Saturday 14:00 UTC (1h before daily reset to avoid notification collision)
             embedConfig: {
                 title: '🏰 Avalon Ends Tomorrow!',
                 description: (ts) =>
@@ -303,7 +303,7 @@ const lostSwordStarReincarnationConfig: PvpEventConfig = {
     warnings: [
         {
             label: '2 days',
-            minutesBefore: 2 * 24 * 60,
+            minutesBefore: (2 * 24 * 60) + 60,  // Friday 14:00 UTC (1h before daily reset to avoid notification collision)
             embedConfig: {
                 title: '🌌 Star Reincarnation Ends in 2 Days — Plan Your Two Teams',
                 description: (ts) =>
@@ -348,7 +348,7 @@ const lostSwordStarReincarnationConfig: PvpEventConfig = {
         },
         {
             label: '1 day',
-            minutesBefore: 24 * 60,
+            minutesBefore: (24 * 60) + 60, // Saturday 14:00 UTC (1h before daily reset to avoid notification collision)
             embedConfig: {
                 title: '🌌 Star Reincarnation Ends Tomorrow!',
                 description: (ts) =>

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -134,8 +134,8 @@ const bd2MirrorWarsConfig: PvpEventConfig = {
  * This server's guild attacks BOTH Camelot AND Mercia — 3 attempts each
  * (6 attempts total, split 3/3).
  *
- * Schedule: ends every other Sunday at 15:00 UTC. Anchor 2026-05-03 is the
- * end of the current active cycle (Avalon active 2026-04-26 → 2026-05-03).
+ * Schedule: ends every other Sunday at 15:00 UTC. Anchor 2026-05-10 is the
+ * end of the current active cycle (Avalon active 2026-05-03 → 2026-05-10).
  * The alternating weeks run Star Reincarnation (phaseOffset=1, see below).
  */
 const lostSwordAvalonConfig: PvpEventConfig = {
@@ -149,7 +149,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
         minute: 0,
     },
     cyclePhase: {
-        anchor: '2026-05-03T15:00:00Z',  // first season-end of active cycle
+        anchor: '2026-05-10T15:00:00Z',  // first season-end of active cycle
         intervalWeeks: 2,
         phaseOffset: 0,                  // Avalon is phase A; Star Reincarnation = phase B (offset 1)
     },
@@ -283,7 +283,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
  * demand varied team compositions.
  *
  * Schedule: ends every other Sunday at 15:00 UTC, on the alternating week from
- * Avalon (shared anchor 2026-05-03 + phaseOffset=1 → SR ends 2026-05-10, 05-24, ...).
+ * Avalon (shared anchor 2026-05-10 + phaseOffset=1 → SR ends 2026-05-17, 05-31, ...).
  */
 const lostSwordStarReincarnationConfig: PvpEventConfig = {
     id: 'lost-sword-star-reincarnation',
@@ -296,7 +296,7 @@ const lostSwordStarReincarnationConfig: PvpEventConfig = {
         minute: 0,
     },
     cyclePhase: {
-        anchor: '2026-05-03T15:00:00Z',  // shared anchor with Avalon
+        anchor: '2026-05-10T15:00:00Z',  // shared anchor with Avalon
         intervalWeeks: 2,
         phaseOffset: 1,                  // phase B (Avalon = phase A, offset 0)
     },


### PR DESCRIPTION
## Problem 1: Cycle is reversed in production
Production (master) has anchor \`2026-05-03\`, which makes the system fire **Star Reincarnation** warnings for the 2026-05-10 cycle. In reality, **Avalon** is the active event ending 2026-05-10.

With the old anchor 2026-05-03 + Avalon phaseOffset=0:
- Avalon ends: 05-03, 05-17, 05-31 ❌ (off by one cycle)
- SR ends: 05-10, 05-24, 06-07 ❌

With corrected anchor 2026-05-10:
- Avalon ends: 05-10, 05-24, 06-07 ✅
- SR ends: 05-17, 05-31, 06-14 ✅

## Problem 2: Warning collision with daily reset
The 1-day and 2-day warnings previously fired at Friday/Saturday 15:00 UTC — the **exact same moment** as the Lost Sword daily reset notification. Users saw two separate embeds drop at once.

## Fix
- **Anchor**: \`2026-05-03\` → \`2026-05-10\` (corrects cycle)
- **2-day warning**: \`2 * 24 * 60\` → \`(2 * 24 * 60) + 60\` (Friday 14:00 UTC)
- **1-day warning**: \`24 * 60\` → \`(24 * 60) + 60\` (Saturday 14:00 UTC)
- **1-hour warning**: unchanged (Sunday 14:00 UTC)

Now warnings fire 1h before the daily reset, then the daily reset notification follows an hour later.

## Testing
- [x] 927 tests pass
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)