### PR TITLE
feat: restrict chat commands to #rapi-bot channel

### DIFF
--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -89,6 +89,9 @@ export async function handleMessage(msg: Message, bot: CustomClient): Promise<vo
         return;
     }
 
+    // ccp commands (ccp leadership, ccp rules, ccp #1) are allowed everywhere
+    const isCcpCommand = chatCommand.name.toLowerCase().startsWith('ccp ');
+
     try {
         const ignoredRole = findRoleByName(msg.guild, 'Grounded');
         const contentCreatorRole = findRoleByName(msg.guild, 'Content Creator');
@@ -96,7 +99,30 @@ export async function handleMessage(msg: Message, bot: CustomClient): Promise<vo
         const hasIgnoredRole = ignoredRole && msg.member.roles.cache.has(ignoredRole.id);
         const hasContentCreatorRole = contentCreatorRole && msg.member.roles.cache.has(contentCreatorRole.id);
 
-        // Rate limit all chat commands (except in rapi-bot channel)
+        // Block non-ccp chat commands outside #rapi-bot
+        if (isChatCommand && !isCcpCommand && !isRapiBotChannel) {
+            const rapiBotChannelId = msg.guild.channels.cache.find(
+                channel => channel.type === ChannelType.GuildText && channel.name === 'rapi-bot'
+            )?.id;
+
+            const channelMention = rapiBotChannelId ? `<#${rapiBotChannelId}>` : '#rapi-bot';
+
+            const warningMsg = await msg.reply({
+                content: `Commander ${msg.author}, this command is only available in ${channelMention}.`
+            });
+
+            setTimeout(async () => {
+                try {
+                    await warningMsg.delete();
+                } catch {
+                    // Message likely already deleted
+                }
+            }, 5000);
+
+            return;
+        }
+
+        // Rate limit ccp chat commands (only path that reaches here outside rapi-bot)
         if (isChatCommand && !isRapiBotChannel) {
             const guildId = msg.guild.id;
             const userId = msg.author.id;


### PR DESCRIPTION
## Summary
Most chat commands now only fire inside the `#rapi-bot` channel. Users invoking them elsewhere get an auto-deleting redirect message.

## Behavior

**Restricted to #rapi-bot only:**
All chat commands except those listed below — `booba?`, `whale levels`, `read nikke`, `good girl`, `dammit rapi`, etc.

**Allowed everywhere (exceptions):**
- All \`ccp *\` chat commands: \`ccp leadership\`, \`ccp rules\`, \`ccp #1\`
- All slash commands (including \`/lucky\` and \`/rapiball\`)

**System features unaffected** — slur moderation, sensitive terms, embed fix (Twitter/Pixiv), scarrow detection still run on every message.

## UX
When a user posts a restricted chat command outside `#rapi-bot`:
> Commander @user, this command is only available in #rapi-bot.

Auto-deletes after 5 seconds.

## Implementation
Single change to `messageHandler.ts`:
1. Detect ccp commands by `chatCommand.name.startsWith('ccp ')`
2. Block non-ccp chat commands outside `#rapi-bot` with redirect
3. Existing rate limiter continues to apply to ccp commands outside `#rapi-bot`

## Testing
- [x] 927 tests pass
- [x] TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)