### PR TITLE
fix: cron jitter rolls Avalon/SR phase forward + 4h stagger for 1d/2d

### DIFF
--- a/src/services/pvpReminderService.ts
+++ b/src/services/pvpReminderService.ts
@@ -183,8 +183,15 @@ export class PvpReminderService {
     }
 
     /**
-     * Internal: next weekly Sunday season-end strictly-at-or-after `now`. Biweekly-blind.
-     * If `now` lands exactly on a season-end instant, returns that instant.
+     * Internal: next weekly Sunday season-end at-or-after `now`. Biweekly-blind.
+     *
+     * When the cron fires for a warning anticipating "this Sunday's" season end,
+     * `now` (already projected forward by minutesBefore) lands at-or-very-near the
+     * season-end instant. Cron schedulers fire with millisecond jitter, so a strict
+     * `<` comparison would treat 15:00:00.123 as "after" 15:00:00.000 and roll forward
+     * to NEXT Sunday — breaking biweekly phase calculations for any Sunday-resetting
+     * event. Use a 5-minute tolerance window to absorb jitter while still catching
+     * genuinely past season-ends.
      */
     private weeklySeasonEndAtOrAfter(event: PvpEventConfig, now: Date): Date {
         const { dayOfWeek, hour, minute } = event.seasonEnd;
@@ -199,8 +206,9 @@ export class PvpReminderService {
         const currentDay = target.getUTCDay();
         let daysUntil = dayOfWeek - currentDay;
         if (daysUntil < 0) daysUntil += 7;
-        // Strictly-less-than: at exact equality `target == now`, stay on this Sunday
-        if (daysUntil === 0 && target.getTime() < now.getTime()) daysUntil = 7;
+        // 5-min tolerance: only roll forward if target is meaningfully before now
+        const TOLERANCE_MS = 5 * 60 * 1000;
+        if (daysUntil === 0 && target.getTime() + TOLERANCE_MS < now.getTime()) daysUntil = 7;
         target.setUTCDate(target.getUTCDate() + daysUntil);
         return target;
     }

--- a/src/services/tests/pvpReminderService.test.ts
+++ b/src/services/tests/pvpReminderService.test.ts
@@ -656,6 +656,27 @@ describe('PvpReminderService', () => {
             // 05-03 is off-cycle for Avalon (anchor=05-10, so 05-03 is one week before anchor → phase=1)
             expect(service.isActiveCycle(avalon, warning2d, fri)).toBe(false);
         });
+
+        it('cron jitter regression: Avalon (not SR) fires for 1-hour warning at Sunday 14:00 UTC + ms jitter', async () => {
+            // Bug repro: cron schedulers fire with millisecond jitter. The 1-hour warning
+            // for a Sunday-resetting biweekly event should NOT roll forward to next Sunday
+            // when `now` is a few ms past the scheduled :00:00 mark.
+            const { pvpReminderServiceConfig } = await import('../../utils/data/pvpEventsConfig');
+            const avalon = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-avalon')!;
+            const sr = pvpReminderServiceConfig.events.find(e => e.id === 'lost-sword-star-reincarnation')!;
+            const service = new PvpReminderService(mockBot, pvpReminderServiceConfig);
+            const warning1h: PvpWarningConfig = { label: '1 hour', minutesBefore: 60, embedConfig: testEvent.warnings[0].embedConfig };
+
+            // Sunday 2026-05-10 14:00:00.500 UTC — cron fires with 500ms jitter
+            const sunWithJitter = new Date(Date.parse('2026-05-10T14:00:00Z') + 500);
+            expect(service.isActiveCycle(avalon, warning1h, sunWithJitter)).toBe(true);
+            expect(service.isActiveCycle(sr, warning1h, sunWithJitter)).toBe(false);
+
+            // Same exact second too — should also work
+            const sunExact = new Date('2026-05-10T14:00:00Z');
+            expect(service.isActiveCycle(avalon, warning1h, sunExact)).toBe(true);
+            expect(service.isActiveCycle(sr, warning1h, sunExact)).toBe(false);
+        });
     });
 
     describe('cyclePhase: isActiveCycle', () => {

--- a/src/utils/data/pvpEventsConfig.ts
+++ b/src/utils/data/pvpEventsConfig.ts
@@ -156,7 +156,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
     warnings: [
         {
             label: '2 days',
-            minutesBefore: (2 * 24 * 60) + 60,  // Friday 14:00 UTC (1h before daily reset to avoid notification collision)
+            minutesBefore: (2 * 24 * 60) + 240,  // Friday 11:00 UTC (4h before daily reset to avoid the 1h reset warning collision)
             embedConfig: {
                 title: '🏰 Avalon Ends in 2 Days — Hit Both Castles!',
                 description: (ts) =>
@@ -201,7 +201,7 @@ const lostSwordAvalonConfig: PvpEventConfig = {
         },
         {
             label: '1 day',
-            minutesBefore: (24 * 60) + 60, // Saturday 14:00 UTC (1h before daily reset to avoid notification collision)
+            minutesBefore: (24 * 60) + 240, // Saturday 11:00 UTC (4h before daily reset to avoid the 1h reset warning collision)
             embedConfig: {
                 title: '🏰 Avalon Ends Tomorrow!',
                 description: (ts) =>
@@ -303,7 +303,7 @@ const lostSwordStarReincarnationConfig: PvpEventConfig = {
     warnings: [
         {
             label: '2 days',
-            minutesBefore: (2 * 24 * 60) + 60,  // Friday 14:00 UTC (1h before daily reset to avoid notification collision)
+            minutesBefore: (2 * 24 * 60) + 240,  // Friday 11:00 UTC (4h before daily reset to avoid the 1h reset warning collision)
             embedConfig: {
                 title: '🌌 Star Reincarnation Ends in 2 Days — Plan Your Two Teams',
                 description: (ts) =>
@@ -348,7 +348,7 @@ const lostSwordStarReincarnationConfig: PvpEventConfig = {
         },
         {
             label: '1 day',
-            minutesBefore: (24 * 60) + 60, // Saturday 14:00 UTC (1h before daily reset to avoid notification collision)
+            minutesBefore: (24 * 60) + 240, // Saturday 11:00 UTC (4h before daily reset to avoid the 1h reset warning collision)
             embedConfig: {
                 title: '🌌 Star Reincarnation Ends Tomorrow!',
                 description: (ts) =>


### PR DESCRIPTION
## Bug 1: SR fired today instead of Avalon (cron jitter regression)

### Root cause
The 1-hour warning cron fires at Sunday 14:00 UTC and projects forward 60min to identify which Sunday season-end it anticipates. node-schedule fires with millisecond jitter, so:

- now = `Sun 14:00:00.500 UTC` (500ms jitter)
- projected = now + 60min = `Sun 15:00:00.500 UTC`
- target initially = `Sun 15:00:00.000 UTC` (this Sunday)
- Comparison: `target.getTime() < now.getTime()` → `15:00:00.000 < 15:00:00.500` → **TRUE**
- daysUntil = 7 → target rolls to **NEXT Sunday (May 17)**

Then phase calculation uses the wrong target Sunday:
- Avalon: weeksFromAnchor = 1 → phase = 1 → **don't fire** ❌
- SR:     weeksFromAnchor = 1 → phase = 0 → **FIRES** ❌

### Fix
Added a 5-minute tolerance window in `weeklySeasonEndAtOrAfter`. Only rolls forward if target is meaningfully before now:

\`\`\`ts
const TOLERANCE_MS = 5 * 60 * 1000;
if (daysUntil === 0 && target.getTime() + TOLERANCE_MS < now.getTime()) daysUntil = 7;
\`\`\`

### Regression test
Added test covering both jittered (\`+500ms\`) and exact firing times to prevent recurrence.

## Bug 2: 1d/2d warnings still collide with daily reset 1-hour warning

The previous PR moved 1d/2d to 1h ahead of reset (14:00 UTC), but the daily reset's own 1-hour warning also fires at 14:00 UTC — so they still collided.

### Fix
Moved 1d/2d to **4h ahead** of reset (11:00 UTC). The 1-hour event warning stays at 14:00 UTC since that IS the "1 hour before" moment.

| Warning | Old | New |
|---|---|---|
| 2-day | Friday 14:00 UTC | Friday 11:00 UTC |
| 1-day | Saturday 14:00 UTC | Saturday 11:00 UTC |
| 1-hour | Sunday 14:00 UTC | Sunday 14:00 UTC (unchanged) |

## Testing
- 928 tests pass (including new regression test)
- TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)